### PR TITLE
CLOUD-220 Unsafe MongoDB startup

### DIFF
--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -180,7 +180,7 @@ spec:
 #        type: s3
 #        s3:
 #          bucket: MINIO-BACKUP-BUCKET-NAME-HERE
-#          region: us-west-1
+#          region: us-east-1
 #          credentialsSecret: my-cluster-name-backup-minio
 #          endpointUrl: http://minio.psmdb.svc.cluster.local:9000/minio/
     tasks:

--- a/pkg/psmdb/container.go
+++ b/pkg/psmdb/container.go
@@ -129,6 +129,7 @@ func containerArgs(m *api.PerconaServerMongoDB, replset *api.ReplsetSpec, resour
 	if m.Spec.UnsafeConf {
 		args = append(args,
 			"--clusterAuthMode=keyFile",
+			"--sslMode=disabled",
 			"--keyFile="+mongodSecretsDir+"/mongodb-key",
 		)
 	} else {


### PR DESCRIPTION
If ssl argument is present in command line for mongod, the latter won't start without sslMode specified explicitly