### PR TITLE
K8SPSMDB-197 - added more sans to certificate

### DIFF
--- a/pkg/controller/perconaservermongodb/ssl.go
+++ b/pkg/controller/perconaservermongodb/ssl.go
@@ -44,14 +44,7 @@ func (r *ReconcilePerconaServerMongoDB) createSSLByCertManager(cr *api.PerconaSe
 	certificateDNSNames := []string{"localhost"}
 
 	for _, replset := range cr.Spec.Replsets {
-		certificateDNSNames = append(certificateDNSNames,
-			cr.Name+"-"+replset.Name,
-			cr.Name+"-"+replset.Name+"."+cr.Namespace,
-			cr.Name+"-"+replset.Name+"."+cr.Namespace+"."+cr.Spec.ClusterServiceDNSSuffix,
-			"*."+cr.Name+"-"+replset.Name,
-			"*."+cr.Name+"-"+replset.Name+"."+cr.Namespace,
-			"*."+cr.Name+"-"+replset.Name+"."+cr.Namespace+"."+cr.Spec.ClusterServiceDNSSuffix,
-		)
+		certificateDNSNames = append(certificateDNSNames, getCertificateSans(cr, replset)...)
 	}
 	owner, err := OwnerRef(cr, r.scheme)
 	if err != nil {
@@ -125,10 +118,7 @@ func (r *ReconcilePerconaServerMongoDB) createSSLManualy(cr *api.PerconaServerMo
 	data := make(map[string][]byte)
 	certificateDNSNames := []string{"localhost"}
 	for _, replset := range cr.Spec.Replsets {
-		certificateDNSNames = append(certificateDNSNames,
-			cr.Name+"-"+replset.Name,
-			"*."+cr.Name+"-"+replset.Name,
-		)
+		certificateDNSNames = append(certificateDNSNames, getCertificateSans(cr, replset)...)
 	}
 	caCert, tlsCert, key, err := tls.Issue(certificateDNSNames)
 	if err != nil {
@@ -179,4 +169,15 @@ func (r *ReconcilePerconaServerMongoDB) createSSLManualy(cr *api.PerconaServerMo
 		return fmt.Errorf("create TLS internal secret: %v", err)
 	}
 	return nil
+}
+
+func getCertificateSans(cr *api.PerconaServerMongoDB, replset *api.ReplsetSpec) []string {
+	return []string{
+		cr.Name + "-" + replset.Name,
+		cr.Name + "-" + replset.Name + "." + cr.Namespace,
+		cr.Name + "-" + replset.Name + "." + cr.Namespace + "." + cr.Spec.ClusterServiceDNSSuffix,
+		"*." + cr.Name + "-" + replset.Name,
+		"*." + cr.Name + "-" + replset.Name + "." + cr.Namespace,
+		"*." + cr.Name + "-" + replset.Name + "." + cr.Namespace + "." + cr.Spec.ClusterServiceDNSSuffix,
+	}
 }

--- a/pkg/controller/perconaservermongodb/ssl.go
+++ b/pkg/controller/perconaservermongodb/ssl.go
@@ -46,7 +46,11 @@ func (r *ReconcilePerconaServerMongoDB) createSSLByCertManager(cr *api.PerconaSe
 	for _, replset := range cr.Spec.Replsets {
 		certificateDNSNames = append(certificateDNSNames,
 			cr.Name+"-"+replset.Name,
+			cr.Name+"-"+replset.Name+"."+cr.Namespace,
+			cr.Name+"-"+replset.Name+"."+cr.Namespace+"."+cr.Spec.ClusterServiceDNSSuffix,
 			"*."+cr.Name+"-"+replset.Name,
+			"*."+cr.Name+"-"+replset.Name+"."+cr.Namespace,
+			"*."+cr.Name+"-"+replset.Name+"."+cr.Namespace+"."+cr.Spec.ClusterServiceDNSSuffix,
 		)
 	}
 	owner, err := OwnerRef(cr, r.scheme)


### PR DESCRIPTION
some libraries perform a reverse lookup of the dns entry and then report an untrusted certificate because the certificate does not contain the fqdn. this pr adds more sans to cover those cases.