### PR TITLE
create rbac objects for backup job

### DIFF
--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -1,4 +1,4 @@
-kind: Role
+kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: percona-server-mongodb-operator
@@ -26,6 +26,7 @@ rules:
   - services
   - persistentvolumeclaims
   - secrets
+  - serviceaccounts
   verbs:
   - get
   - list
@@ -86,6 +87,23 @@ rules:
   - patch
   - delete
   - deletecollection
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resourceNames:
+  -  percona-server-mongodb-operator
+  resources:
+  - clusterroles
+  verbs:
+  - bind
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -100,6 +118,6 @@ subjects:
 - kind: ServiceAccount
   name: percona-server-mongodb-operator
 roleRef:
-  kind: Role
+  kind: ClusterRole
   name: percona-server-mongodb-operator
   apiGroup: rbac.authorization.k8s.io

--- a/pkg/controller/perconaservermongodb/backup.go
+++ b/pkg/controller/perconaservermongodb/backup.go
@@ -4,13 +4,21 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	batchv1b "k8s.io/api/batch/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
 	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb/backup"
+)
+
+const (
+	roleBindingName = "mongodb-operator"
 )
 
 func (r *ReconcilePerconaServerMongoDB) reconcileBackupTasks(cr *api.PerconaServerMongoDB) error {
@@ -58,6 +66,82 @@ func (r *ReconcilePerconaServerMongoDB) reconcileBackupTasks(cr *api.PerconaServ
 			err := r.client.Delete(context.TODO(), &t)
 			if err != nil && !errors.IsNotFound(err) {
 				return fmt.Errorf("delete backup task %s: %v", t.Name, err)
+			}
+		}
+	}
+
+	// no ns set, ignore it because we cannot run without it
+	ns, err := k8sutil.GetWatchNamespace()
+	if err != nil {
+		return err
+	}
+	if cr.Namespace != ns {
+		var sa corev1.ServiceAccount
+		if err := r.client.Get(context.TODO(), client.ObjectKey{
+			Namespace: cr.Namespace,
+			Name:      cr.Spec.Backup.ServiceAccountName,
+		}, &sa); err != nil {
+			if !errors.IsNotFound(err) {
+				return fmt.Errorf("get service account %s: %v", cr.Spec.Backup.ServiceAccountName, err)
+			}
+
+			sa = corev1.ServiceAccount{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "ServiceAccount",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      cr.Spec.Backup.ServiceAccountName,
+					Namespace: cr.Namespace,
+				},
+			}
+
+			if err := setControllerReference(cr, &sa, r.scheme); err != nil {
+				return fmt.Errorf("set owner reference for service account %s: %v", cr.Spec.Backup.ServiceAccountName, err)
+			}
+
+			if err := r.client.Create(context.TODO(), &sa); err != nil {
+				return fmt.Errorf("create service account %s: %v", cr.Spec.Backup.ServiceAccountName, err)
+			}
+		}
+
+		var rb rbacv1.RoleBinding
+		if err := r.client.Get(context.TODO(), client.ObjectKey{
+			Namespace: cr.Namespace,
+			Name:      roleBindingName,
+		}, &rb); err != nil {
+			if !errors.IsNotFound(err) {
+				return fmt.Errorf("get role binding %s: %v", roleBindingName, err)
+			}
+
+			rb = rbacv1.RoleBinding{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "rbac.authorization.k8s.io/v1",
+					Kind:       "RoleBinding",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      roleBindingName,
+					Namespace: cr.Namespace,
+				},
+				RoleRef: rbacv1.RoleRef{
+					APIGroup: "rbac.authorization.k8s.io",
+					Kind:     "ClusterRole",
+					Name:     "mongodb-operator",
+				},
+				Subjects: []rbacv1.Subject{
+					{
+						Kind: "ServiceAccount",
+						Name: cr.Spec.Backup.ServiceAccountName,
+					},
+				},
+			}
+
+			if err := setControllerReference(cr, &rb, r.scheme); err != nil {
+				return fmt.Errorf("set owner reference for role binding %s: %v", roleBindingName, err)
+			}
+
+			if err := r.client.Create(context.TODO(), &rb); err != nil {
+				return fmt.Errorf("create role binding %s: %v", roleBindingName, err)
 			}
 		}
 	}

--- a/pkg/controller/perconaservermongodb/backup.go
+++ b/pkg/controller/perconaservermongodb/backup.go
@@ -126,7 +126,7 @@ func (r *ReconcilePerconaServerMongoDB) reconcileBackupTasks(cr *api.PerconaServ
 				RoleRef: rbacv1.RoleRef{
 					APIGroup: "rbac.authorization.k8s.io",
 					Kind:     "ClusterRole",
-					Name:     "mongodb-operator",
+					Name:     "percona-server-mongodb-operator",
 				},
 				Subjects: []rbacv1.Subject{
 					{

--- a/pkg/controller/perconaservermongodb/backup.go
+++ b/pkg/controller/perconaservermongodb/backup.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	roleBindingName = "mongodb-operator"
+	roleBindingName = "percona-server-mongodb-operator"
 )
 
 func (r *ReconcilePerconaServerMongoDB) reconcileBackupTasks(cr *api.PerconaServerMongoDB) error {


### PR DESCRIPTION
if the operator is running in cluster-wide mode, the backup cronjob fails because it lacks rights to create the backup cr. this pr deployes a service account and a role binding if the env var WATCH_NAMESPACE is empty. this requires the operator role deployed as a cluster role