### PR TITLE
CLOUD-543 hide vendor changes in PRs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+vendor/** linguist-generated=true


### PR DESCRIPTION
[![CLOUD-543](https://badgen.net/badge/JIRA/CLOUD-543/green)](https://jira.percona.com/browse/CLOUD-543)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

according to https://help.github.com/en/github/administering-a-repository/customizing-how-changed-files-appear-on-github