### PR TITLE
Fix compare_mongo_user for generic PSMDB docker images

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -385,10 +385,10 @@ compare_mongo_user() {
     local user=$(echo $uri | cut -d : -f 1)
     local expected_result=${test_dir}/compare/$user.json
 
-    if [[ "$IMAGE_MONGOD" =~ 4\.0$ ]] && [ -f ${test_dir}/compare/$user-40.json ]; then
+    if [[ "$IMAGE_MONGOD" =~ 4\.0 ]] && [ -f ${test_dir}/compare/$user-40.json ]; then
         expected_result=${test_dir}/compare/$user-40.json
     fi
-    if [[ "$IMAGE_MONGOD" =~ 4\.2$ ]] && [ -f ${test_dir}/compare/$user-42.json ]; then
+    if [[ "$IMAGE_MONGOD" =~ 4\.2 ]] && [ -f ${test_dir}/compare/$user-42.json ]; then
         expected_result=${test_dir}/compare/$user-42.json
     fi
 


### PR DESCRIPTION
This is needed so that the `compare_mongo_user` function can work with images like `percona/percona-server-mongodb:4.2.8-8` instead of just with `percona/percona-server-mongodb-operator:1.4.0-mongod4.2`.

`init_deploy` is the only test currently using this and it is passing for me locally.
We had the same fix for PXC.