### PR TITLE
Fix one-pod test - PBM doesn't release a lock soon enough after backup

### DIFF
--- a/e2e-tests/one-pod/run
+++ b/e2e-tests/one-pod/run
@@ -68,6 +68,7 @@ main() {
     spinup_psmdb "$cluster" "$test_dir/conf/$cluster.yml" "1"
 
     run_backup         "$cluster" "backup-minio"
+    sleep 20
     run_recovery_check "$cluster" "backup-minio"
 
     destroy $namespace


### PR DESCRIPTION
Tried to play with waiting for PBM locks, but it looks like a PBM bug where no locks are listed in admin.pbmLock collection, but the agent still reports that previous operation is in progress and refuses to do restore.
So for now went with the sleep and will investigate and report PBM issue if needed.
There's a possibility that this affects only 1 node replica set.