### PR TITLE
Fix upgrade test to allow using images from percona-server-mongodb repo

### DIFF
--- a/e2e-tests/upgrade/run
+++ b/e2e-tests/upgrade/run
@@ -15,7 +15,11 @@ IMAGE_MONGOD_TO_UPDATE=${IMAGE_MONGOD}
 IMAGE_BACKUP_TO_UPDATE=${IMAGE_BACKUP}
 OPERATOR_NAME='percona-server-mongodb-operator'
 
-MONGO_VER=$(echo -n "${IMAGE_MONGOD}" | $sed -r 's/.*([0-9].[0-9])$/\1/')
+if [[ "${IMAGE_MONGOD}" == *"percona-server-mongodb-operator"* ]]; then
+    MONGO_VER=$(echo -n "${IMAGE_MONGOD}" | $sed -r 's/.*([0-9].[0-9])$/\1/')
+else
+    MONGO_VER=$(echo -n "${IMAGE_MONGOD}" | $sed -r 's/.*:([0-9]+\.[0-9]+).*$/\1/')
+fi
 API='psmdb.percona.com/v1-1-0'
 IMAGE='percona/percona-server-mongodb-operator:1.1.0'
 IMAGE_PMM='percona/percona-server-mongodb-operator:1.1.0-pmm'


### PR DESCRIPTION
This allows for the test to be run regardless if the new image is from `percona-server-mongodb-operator` or from `percona-server-mongodb` docker repository.