### PR TITLE
Fix wait_backup_agent func in e2e-tests for PBM 1.3.x

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -102,7 +102,7 @@ wait_backup_agent() {
     set +o xtrace
     retry=0
     echo -n $agent_pod
-    until [ "$(kubectl_bin logs $agent_pod -c backup-agent | tail -n 1)" == "pbm agent is listening for the commands" ]; do
+    until [ "$(kubectl_bin logs $agent_pod -c backup-agent | egrep -v "\[ERROR\] pitr: check if on:|node:" | cut -d' ' -f3- | tail -n 1)" == "listening for the commands" ]; do
         sleep 5
         echo -n .
         let retry+=1


### PR DESCRIPTION
In PBM 1.3.x log messages have changed so our function to check if agent is listening is not working any more.
Here's how the log looks now:
```
2020/09/04 06:36:46 starting pitr routine
2020/09/04 06:36:46 listening for the commands
2020/09/04 06:36:46 node: rs0/some-name-rs0-0.some-name-rs0.demand-backup-31889.svc.cluster.local:27017
2020/09/04 06:37:01 [ERROR] pitr: check if on: get config: get: mongo: no documents in result
2020/09/04 06:37:16 [ERROR] pitr: check if on: get config: get: mongo: no documents in result
2020/09/04 06:37:31 [ERROR] pitr: check if on: get config: get: mongo: no documents in result
2020/09/04 06:37:46 [ERROR] pitr: check if on: get config: get: mongo: no documents in result
```
date and time was added and some additional lines