### PR TITLE
Fix connections leak

### DIFF
--- a/pkg/controller/perconaservermongodb/mgo.go
+++ b/pkg/controller/perconaservermongodb/mgo.go
@@ -60,7 +60,12 @@ func (r *ReconcilePerconaServerMongoDB) reconcileCluster(cr *api.PerconaServerMo
 		}
 	}
 
-	defer session.Disconnect(context.TODO())
+	defer func() {
+		err := session.Disconnect(context.TODO())
+		if err != nil {
+			log.Error(err, "failed to disconnect")
+		}
+	}()
 
 	cnf, err := mongo.ReadConfig(context.TODO(), session)
 	if err != nil {

--- a/pkg/controller/perconaservermongodb/mgo.go
+++ b/pkg/controller/perconaservermongodb/mgo.go
@@ -60,12 +60,7 @@ func (r *ReconcilePerconaServerMongoDB) reconcileCluster(cr *api.PerconaServerMo
 		}
 	}
 
-	defer func() {
-		err := session.Disconnect(context.TODO())
-		if err != nil {
-			log.Error(err, "failed to disconnect")
-		}
-	}()
+	defer session.Disconnect(context.TODO())
 
 	cnf, err := mongo.ReadConfig(context.TODO(), session)
 	if err != nil {

--- a/pkg/controller/perconaservermongodb/psmdb_controller.go
+++ b/pkg/controller/perconaservermongodb/psmdb_controller.go
@@ -199,7 +199,7 @@ func (r *ReconcilePerconaServerMongoDB) Reconcile(request reconcile.Request) (re
 			OpVersion: version.String(),
 		})
 		if err != nil {
-			return reconcile.Result{}, errors.Wrap(err, "failed to ensure version")
+			reqLogger.Info(fmt.Sprintf("failed to ensure version: %v; running with default", err))
 		}
 	}
 

--- a/pkg/psmdb/mongo/mongo.go
+++ b/pkg/psmdb/mongo/mongo.go
@@ -39,6 +39,12 @@ func Dial(addrs []string, replset, username, password string, useTLS bool) (*mon
 		return nil, fmt.Errorf("failed to connect to mongo rs: %v", err)
 	}
 
+	defer func() {
+		if err != nil {
+			_ = client.Disconnect(ctx)
+		}
+	}()
+
 	ctx, pingcancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer pingcancel()
 


### PR DESCRIPTION
This PR fixes issue when connection with MongoDB was established but after that Ping command was unsuccessful.
It adds logic which controls that if any error occurred in Dial function connection should be closed.