### PR TITLE
feature: allow connectivity from outside the cluster and using existing issuers

### DIFF
--- a/build/ps-entry.sh
+++ b/build/ps-entry.sh
@@ -276,6 +276,7 @@ if [ "$originalArgOne" = 'mongod' ]; then
 		_mongod_hack_ensure_no_arg --auth "${mongodHackedArgs[@]}"
 		if [ "$MONGO_INITDB_ROOT_USERNAME" ] && [ "$MONGO_INITDB_ROOT_PASSWORD" ]; then
 			_mongod_hack_ensure_no_arg_val --replSet "${mongodHackedArgs[@]}"
+			_mongod_hack_ensure_no_arg_val --clusterAuthMode "${mongodHackedArgs[@]}"
 		fi
 
 		# "BadValue: need sslPEMKeyFile when SSL is enabled" vs "BadValue: need to enable SSL via the sslMode flag when using SSL configuration parameters"

--- a/pkg/apis/psmdb/v1/psmdb_types.go
+++ b/pkg/apis/psmdb/v1/psmdb_types.go
@@ -248,10 +248,16 @@ type ResourcesSpec struct {
 	Requests *ResourceSpecRequirements `json:"requests,omitempty"`
 }
 
+type Issuer struct {
+	Name string `json:"name,omitempty"`
+	Kind string `json:"kind,omitempty"`
+}
+
 type SecretsSpec struct {
-	Users       string `json:"users,omitempty"`
-	SSL         string `json:"ssl,omitempty"`
-	SSLInternal string `json:"sslInternal,omitempty"`
+	Users          string  `json:"users,omitempty"`
+	SSL            string  `json:"ssl,omitempty"`
+	SSLInternal    string  `json:"sslInternal,omitempty"`
+	ExistingIssuer *Issuer `json:"existingIssuer,omitempty"`
 }
 
 type MongosSpec struct {

--- a/pkg/apis/psmdb/v1/psmdb_types.go
+++ b/pkg/apis/psmdb/v1/psmdb_types.go
@@ -145,6 +145,15 @@ const (
 	ClusterError   ClusterConditionType = "Error"
 )
 
+type Mapping struct {
+	External string `json:"external"`
+	Internal string `json:"internal"`
+}
+
+type Connectivity struct {
+	Mapping []Mapping `json:"mapping"`
+}
+
 type ClusterCondition struct {
 	Status             ConditionStatus      `json:"status"`
 	Type               ClusterConditionType `json:"type"`
@@ -192,6 +201,7 @@ type ReplsetSpec struct {
 	LivenessProbe            *LivenessProbeExtended     `json:"livenessProbe,omitempty"`
 	PodSecurityContext       *corev1.PodSecurityContext `json:"podSecurityContext,omitempty"`
 	ContainerSecurityContext *corev1.SecurityContext    `json:"containerSecurityContext,omitempty"`
+	Connectivity             *Connectivity              `json:"connectivity"`
 	MultiAZ
 }
 

--- a/pkg/controller/perconaservermongodb/ssl.go
+++ b/pkg/controller/perconaservermongodb/ssl.go
@@ -210,12 +210,18 @@ func (r *ReconcilePerconaServerMongoDB) createSSLManualy(cr *api.PerconaServerMo
 }
 
 func getCertificateSans(cr *api.PerconaServerMongoDB, replset *api.ReplsetSpec) []string {
-	return []string{
+	externalHostNames := []string{}
+	if replset.Connectivity != nil {
+		for _, mapping := range replset.Connectivity.Mapping {
+			externalHostNames = append(externalHostNames, mapping.External)
+		}
+	}
+	return append([]string{
 		cr.Name + "-" + replset.Name,
 		cr.Name + "-" + replset.Name + "." + cr.Namespace,
 		cr.Name + "-" + replset.Name + "." + cr.Namespace + "." + cr.Spec.ClusterServiceDNSSuffix,
 		"*." + cr.Name + "-" + replset.Name,
 		"*." + cr.Name + "-" + replset.Name + "." + cr.Namespace,
 		"*." + cr.Name + "-" + replset.Name + "." + cr.Namespace + "." + cr.Spec.ClusterServiceDNSSuffix,
-	}
+	}, externalHostNames...)
 }

--- a/pkg/psmdb/const.go
+++ b/pkg/psmdb/const.go
@@ -9,10 +9,11 @@ const (
 	// MongodContainerDataDir is a mondo data path in container
 	MongodContainerDataDir = "/data/db"
 
-	sslDir               = "/etc/mongodb-ssl"
-	sslInternalDir       = "/etc/mongodb-ssl-internal"
-	mongodSecretsDir     = "/etc/mongodb-secrets"
-	mongodRESTencryptDir = "/etc/mongodb-encryption"
-	EncryptionKeyName    = "encryption-key"
-	mongodPortName       = "mongodb"
+	sslDir                 = "/etc/mongodb-ssl"
+	sslInternalDir         = "/etc/mongodb-ssl-internal"
+	mongodSecretsDir       = "/etc/mongodb-secrets"
+	mongodRESTencryptDir   = "/etc/mongodb-encryption"
+	EncryptionKeyName      = "encryption-key"
+	mongodPortName         = "mongodb"
+	externalHostAnnotation = "psmdbExternalHostName"
 )

--- a/pkg/psmdb/container.go
+++ b/pkg/psmdb/container.go
@@ -134,6 +134,7 @@ func containerArgs(m *api.PerconaServerMongoDB, replset *api.ReplsetSpec, resour
 		args = append(args,
 			"--sslMode=preferSSL",
 			"--clusterAuthMode=x509",
+			"--tlsAllowConnectionsWithoutCertificates",
 		)
 	}
 

--- a/pkg/psmdb/service.go
+++ b/pkg/psmdb/service.go
@@ -65,7 +65,16 @@ func ExternalService(m *api.PerconaServerMongoDB, replset *api.ReplsetSpec, podN
 			Namespace: m.Namespace,
 		},
 	}
+	var annotations = make(map[string]string)
+	if replset.Connectivity != nil {
+		for index := range replset.Connectivity.Mapping {
+			if replset.Connectivity.Mapping[index].Internal == podName {
+				annotations[externalHostAnnotation] = replset.Connectivity.Mapping[index].External
+			}
+		}
+	}
 
+	svc.Annotations = annotations
 	svc.Labels = map[string]string{
 		"app.kubernetes.io/name":       "percona-server-mongodb",
 		"app.kubernetes.io/instance":   m.Name,
@@ -85,7 +94,9 @@ func ExternalService(m *api.PerconaServerMongoDB, replset *api.ReplsetSpec, podN
 		},
 		Selector: map[string]string{"statefulset.kubernetes.io/pod-name": podName},
 	}
-
+	if replset.Connectivity != nil {
+		svc.Spec.PublishNotReadyAddresses = true
+	}
 	switch replset.Expose.ExposeType {
 	case corev1.ServiceTypeNodePort:
 		svc.Spec.Type = corev1.ServiceTypeNodePort
@@ -143,6 +154,9 @@ func GetServiceAddr(svc corev1.Service, pod corev1.Pod, cl client.Client) (*Serv
 			}
 			addr.Port = int(p.NodePort)
 		}
+	}
+	if externalHost,ok := svc.Annotations[externalHostAnnotation]; ok {
+		addr.Host = externalHost
 	}
 	return addr, nil
 }


### PR DESCRIPTION
This is possible by defing a new entry in the replsets section in the crd. Here is an example for a
cluster named "smurf" with replicaset name rs0:

    Connectivity:
      Mapping:
        External:  n0.smurf.mongodb.example.com
        Internal:  smurf-rs0-0
        External:  n1.smurf.mongodb.example.com
        Internal:  smurf-rs0-1
        External:  n2.smurf.mongodb.example.com
        Internal:  smurf-rs0-2

This will cause the following things to happen:

- SANs of generated certificates will also contain those external hostnames
- Each service will get an annotated with `psmdbExternalHostName: n0.smurf.mongodb.example.com` (depending on external hostname)
- Hostnames of the mongodb nodes will be set to the external hostname

To make this setup fully work, a DNS horizon has to be created inside the cluster, so the nodes inside the cluster connect directly to each other.
This might be for example done by configuring CoreDNS like this (it also generalizes the namespace)

    rewrite stop {
      name regex n(.*)\.(.*)\.(.*)\.example.com\.$ {2}-rs0-{1}.{3}.svc.cluster.local
      answer name (.*)-rs0-(.*)\.(.*)\.svc\.cluster\.local\.$ n{2}.{1}.{3}.example.com
    }

After this you can route tcp traffic from the outside to the cluster using an ingress controller. Here is a part of traefik ingress configuration:

    Routes:
      Match:  HostSNI(`n0.smurf.mongodb.example.com`)
      Services:
        Name: smurf-rs0-0
        Port: 27017

---

Sometimes there is already a ClusterIssuer which is responsible to generate certificates.
It can now be used by the operator by specifing it in the secrets section:

    Secrets:
      Existing Issuer:
        Kind: ClusterIssuer
        Name: myown-ca-issuer

---

Related Issues: https://jira.percona.com/browse/K8SPSMDB-279
Code also written by @ElKiwos 🥇