### PR TITLE
Remove unused pending state

### DIFF
--- a/pkg/apis/psmdb/v1/psmdb_types.go
+++ b/pkg/apis/psmdb/v1/psmdb_types.go
@@ -103,10 +103,9 @@ type ReplsetStatus struct {
 type AppState string
 
 const (
-	AppStatePending AppState = "pending"
-	AppStateInit    AppState = "initializing"
-	AppStateReady   AppState = "ready"
-	AppStateError   AppState = "error"
+	AppStateInit  AppState = "initializing"
+	AppStateReady AppState = "ready"
+	AppStateError AppState = "error"
 )
 
 type UpgradeStrategy string


### PR DESCRIPTION
~Also, convert all state constants from untyped strings to AppState.
Staticcheck linter (a part of gopls and golangci-lint) can catch this
bug, and it is present in many other places across operators code
bases.~

That was already done in `master`.