### PR TITLE
Update for 1.6.0 release

### DIFF
--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -14,7 +14,7 @@ spec:
   scope: Namespaced
   versions:
     - name: v1
-      storage: true
+      storage: false
       served: true
     - name: v1-1-0
       storage: false
@@ -31,10 +31,16 @@ spec:
     - name: v1-5-0
       storage: false
       served: true
+    - name: v1-6-0
+      storage: true
+      served: true
     - name: v1alpha1
       storage: false
       served: true
   additionalPrinterColumns:
+    - name: ENDPOINT
+      type: string
+      JSONPath: .status.host
     - name: Status
       type: string
       JSONPath: .status.state
@@ -199,6 +205,7 @@ rules:
   - delete
 - apiGroups:
   - certmanager.k8s.io
+  - cert-manager.io
   resources:
   - issuers
   - certificates
@@ -246,7 +253,7 @@ spec:
       serviceAccountName: percona-server-mongodb-operator
       containers:
         - name: percona-server-mongodb-operator
-          image: percona/percona-server-mongodb-operator:1.5.0
+          image: percona/percona-server-mongodb-operator:1.6.0
           ports:
           - containerPort: 60000
             name: metrics

--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -7,7 +7,7 @@ spec:
 #  clusterServiceDNSSuffix: svc.cluster.local
 #  pause: true
   crVersion: 1.6.0
-  image: percona/percona-server-mongodb:4.2.8-8
+  image: percona/percona-server-mongodb:4.4.2-4
   imagePullPolicy: Always
 #  imagePullSecrets:
 #    - name: private-registry-credentials
@@ -278,7 +278,7 @@ spec:
   backup:
     enabled: true
     restartOnFailure: true
-    image: percona/percona-server-mongodb-operator:1.5.0-backup
+    image: percona/percona-server-mongodb-operator:1.6.0-backup
     serviceAccountName: percona-server-mongodb-operator
 #    resources:
 #      limits:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: percona-server-mongodb-operator
       containers:
         - name: percona-server-mongodb-operator
-          image: percona/percona-server-mongodb-operator:1.5.0
+          image: percona/percona-server-mongodb-operator:1.6.0
           ports:
           - containerPort: 60000
             name: metrics


### PR DESCRIPTION
Check which PSMDB version should be default in cr.yaml 4.2 or 4.4?
Also notice this is merge to release-1.6.0 branch, not sure if it should go into release branch and only after release to master.