### PR TITLE
Fix version-service test to not use psmdb_spinup

### DIFF
--- a/e2e-tests/version-service/run
+++ b/e2e-tests/version-service/run
@@ -44,7 +44,7 @@ for i in "${!cases[@]}"; do
         | $sed -e "s#image: .*-mongodb:[34].*#image: $IMAGE_MONGOD#" \
         | kubectl_bin apply -f -
     desc 'check if Pod is started'
-    wait_for_running "${cluster}-rs0" "$size"
+    wait_for_running "${cluster}-rs0" 3
     sleep 20
     compare_kubectl "statefulset/${cluster}-rs0"
     desc 'write data'

--- a/e2e-tests/version-service/run
+++ b/e2e-tests/version-service/run
@@ -34,7 +34,24 @@ for i in "${!cases[@]}"; do
     tmp_file=$(mktemp)
     sed "s%#initImage%$IMAGE%g" "$test_dir/conf/${cluster}-rs0.yml" >"$tmp_file"
 
-    spinup_psmdb ${cluster}-rs0 "$tmp_file"
+    desc 'create first PSMDB cluster'
+    cat "$tmp_file" \
+        | $sed -e "s#apiVersion: psmdb.percona.com/v.*\$#apiVersion: $API#" \
+        | $sed -e "s#image:\$#image: $IMAGE_MONGOD#" \
+        | $sed -e "s#image:.*-pmm\$#image: $IMAGE_PMM#" \
+        | $sed -e "s#image:.*-backup\$#image: $IMAGE_BACKUP#" \
+        | $sed -e "s#image: .*-mongod[34].*#image: $IMAGE_MONGOD#" \
+        | $sed -e "s#image: .*-mongodb:[34].*#image: $IMAGE_MONGOD#" \
+        | kubectl_bin apply -f -
+    desc 'check if Pod is started'
+    wait_for_running "${cluster}-rs0" "$size"
+    sleep 20
+    compare_kubectl "statefulset/${cluster}-rs0"
+    desc 'write data'
+    run_mongo 'db.createUser({user: "myApp", pwd: "myPass", roles: [{ db: "myApp", role: "readWrite" }]})' \
+              "userAdmin:userAdmin123456@${cluster}-rs0.${namespace}"
+
+    run_mongo 'use myApp\n db.test.insert({ x: 100500 })' "myApp:myPass@${cluster}-rs0.${namespace}"
     compare_kubectl "statefulset/${cluster}-rs0"
 
     pods=($(kubectl get pods -l app.kubernetes.io/name=percona-server-mongodb -o=name))


### PR DESCRIPTION
Fix version-service test to not use psmdb_spinup because it disables SmartUpdate apply option
Needed after this change: https://github.com/percona/percona-server-mongodb-operator/pull/498

This copies commands from functions `psmdb_spinup` to the test and fixes parameters, removes the sed to disable `apply` option since it is needed for this test.
I have executed the test locally and it passed.