### PR TITLE
Rename psmdb-recovery to psmdb-restore in e2e-tests functions

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -529,7 +529,7 @@ destroy() {
 
     kubectl_bin delete psmdb --all
     kubectl_bin delete psmdb-backup --all || :
-    kubectl_bin delete psmdb-recovery --all || :
+    kubectl_bin delete psmdb-restore --all || :
 
     kubectl_bin delete -f https://github.com/jetstack/cert-manager/releases/download/v0.15.1/cert-manager.yaml 2>/dev/null || :
     if [ "$OPENSHIFT" == 1 ]; then


### PR DESCRIPTION
Seems this was a typo or some leftover from before (if it was renamed).