### PR TITLE
Fix compare mongos deployment on GKE 1.15

### DIFF
--- a/e2e-tests/demand-backup-sharded/run
+++ b/e2e-tests/demand-backup-sharded/run
@@ -22,6 +22,7 @@ kubectl_bin apply \
 apply_cluster "$test_dir/conf/$cluster-rs0.yml"
 desc 'check if all 3 Pods started'
 wait_for_running $cluster-rs0 3
+wait_for_running $cluster-cfg 3 "false"
 
 desc 'check if service and statefulset created with expected config'
 compare_kubectl statefulset/$cluster-rs0

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -365,7 +365,7 @@ compare_kubectl() {
         | yq d - 'spec.volumeClaimTemplates.*.apiVersion' \
         | yq d - 'spec.volumeClaimTemplates.*.kind' \
         | $sed "s/${namespace}/NAME_SPACE/g" \
-        | if [[ "${resource}" == *"deployment"* ]]; then $sed 's#^apiVersion: extensions/v1beta1#^apiVersion: apps/v1#g'; fi \
+        | $sed "s#^apiVersion: extensions/v1beta1#apiVersion: apps/v1#" \
         > ${new_result}
 
     diff -u "$expected_result" "$new_result"

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -365,6 +365,7 @@ compare_kubectl() {
         | yq d - 'spec.volumeClaimTemplates.*.apiVersion' \
         | yq d - 'spec.volumeClaimTemplates.*.kind' \
         | $sed "s/${namespace}/NAME_SPACE/g" \
+        | if [[ "${resource}" == *"deployment"* ]]; then $sed 's#^apiVersion: extensions/v1beta1#^apiVersion: apps/v1#g'; fi \
         > ${new_result}
 
     diff -u "$expected_result" "$new_result"


### PR DESCRIPTION
This fixes `monitoring-2-0` and `demand-backup-sharded` tests which were failing on GKE 1.15 with something like:
Here's the test run with GKE 1.15: https://cloud.cd.percona.com/job/psmdb-operator-gke-version/248/
```
+ diff -u /mnt/jenkins/workspace/psmdb-operator-gke-version/source/e2e-tests/monitoring-2-0/compare/deployment_monitoring-mongos.yml /tmp/tmp.FeZx9y4Xr5/deployment_monitoring-mongos.yml
--- /mnt/jenkins/workspace/psmdb-operator-gke-version/source/e2e-tests/monitoring-2-0/compare/deployment_monitoring-mongos.yml	2020-12-13 16:31:40.000000000 +0000
+++ /tmp/tmp.FeZx9y4Xr5/deployment_monitoring-mongos.yml	2020-12-13 16:48:19.851401485 +0000
@@ -1,4 +1,4 @@
-apiVersion: apps/v1
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   annotations:
```