### PR TITLE
K8SPSMDB-340: add sleep to certmanager install

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -508,6 +508,7 @@ deploy_cert_manager() {
     kubectl_bin create namespace cert-manager || :
     kubectl_bin label namespace cert-manager certmanager.k8s.io/disable-validation=true || :
     kubectl_bin apply -f https://github.com/jetstack/cert-manager/releases/download/v0.15.1/cert-manager.yaml --validate=false || : 2>/dev/null
+    sleep 30
 }
 
 destroy() {

--- a/pkg/controller/perconaservermongodb/ssl.go
+++ b/pkg/controller/perconaservermongodb/ssl.go
@@ -95,7 +95,7 @@ func (r *ReconcilePerconaServerMongoDB) createSSLByCertManager(cr *api.PerconaSe
 		return fmt.Errorf("create certificate: %v", err)
 	}
 	if cr.Spec.Secrets.SSL == cr.Spec.Secrets.SSLInternal {
-		return nil
+		return r.waitForCerts(cr.Namespace, cr.Spec.Secrets.SSL)
 	}
 
 	err = r.client.Create(context.TODO(), &cm.Certificate{
@@ -124,7 +124,7 @@ func (r *ReconcilePerconaServerMongoDB) createSSLByCertManager(cr *api.PerconaSe
 }
 
 func (r *ReconcilePerconaServerMongoDB) waitForCerts(namespace string, secretsList ...string) error {
-	ticker := time.NewTicker(3 * time.Second)
+	ticker := time.NewTicker(1 * time.Second)
 	timeoutTimer := time.NewTimer(30 * time.Second)
 	defer timeoutTimer.Stop()
 	defer ticker.Stop()


### PR DESCRIPTION
[![K8SPSMDB-340](https://badgen.net/badge/JIRA/K8SPSMDB-340/green)](https://jira.percona.com/browse/K8SPSMDB-340)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Sometimes certmanager do not issue certificates fast enough, and we have test fail because of that.
This pr fixes this(service per pod) test