### PR TITLE
Fix filtering PBM logs in wait_backup_agent e2e function

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -106,7 +106,7 @@ wait_backup_agent() {
     set +o xtrace
     retry=0
     echo -n $agent_pod
-    until [ "$(kubectl_bin logs $agent_pod -c backup-agent | egrep -v "\[ERROR\] pitr: check if on:|node:|starting PITR routine" | cut -d' ' -f3- | tail -n 1)" == "listening for the commands" ]; do
+    until [ "$(kubectl_bin logs $agent_pod -c backup-agent | egrep -v "\[ERROR\] pitr: check if on:|node:|starting PITR routine|\[agentCheckup\]" | cut -d' ' -f3- | tail -n 1)" == "listening for the commands" ]; do
         sleep 5
         echo -n .
         let retry+=1


### PR DESCRIPTION
Latest logs in main branch look like:
```
2020-12-18T16:53:20.000+0000 I node: rs0/some-name-rs0-0.some-name-rs0.demand-backup-18921.svc.cluster.local:27017
2020-12-18T16:53:20.000+0000 I listening for the commands
2020-12-18T16:53:20.000+0000 I starting PITR routine
2020-12-18T16:53:25.000+0000 E [agentCheckup] check storage connecion: unable to get storage: get config: get: mongo: no documents in result
```
So wait_backup_agent just waits forever because it's not filtering the last message - although we need to check if this is really something we want to filter.