### PR TITLE
K8PSMDB-341 CRD version settings breaks test execution on 3.11

### DIFF
--- a/e2e-tests/version-service/conf/crd.yaml
+++ b/e2e-tests/version-service/conf/crd.yaml
@@ -14,7 +14,7 @@ spec:
   scope: Namespaced
   versions:
     - name: v1
-      storage: true
+      storage: false
       served: true
     - name: v1-1-0
       storage: false
@@ -32,7 +32,7 @@ spec:
       storage: false
       served: true
     - name: v1-6-0
-      storage: false
+      storage: true
       served: true
     - name: v9-9-9
       storage: false


### PR DESCRIPTION
[![K8SPSMDB-341](https://badgen.net/badge/JIRA/K8SPSMDB-341/green)](https://jira.percona.com/browse/K8SPSMDB-341)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

