### PR TITLE
K8SPSMDB-341 - Increment versions after 1.6.0 release

### DIFF
--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -32,6 +32,9 @@ spec:
       storage: false
       served: true
     - name: v1-6-0
+      storage: false
+      served: true
+    - name: v1-7-0
       storage: true
       served: true
     - name: v1alpha1

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -5,7 +5,7 @@ BASH_XTRACEFD="5"
 
 GIT_COMMIT=$(git rev-parse HEAD)
 GIT_BRANCH=${VERSION:-$(git rev-parse --abbrev-ref HEAD | sed -e 's^/^-^g; s^[.]^-^g;' | sed -e 's/_/-/g' | tr '[:upper:]' '[:lower:]')}
-API="psmdb.percona.com/v1-6-0"
+API="psmdb.percona.com/v1-7-0"
 IMAGE=${IMAGE:-"perconalab/percona-server-mongodb-operator:${GIT_BRANCH}"}
 IMAGE_PMM=${IMAGE_PMM:-"perconalab/pmm-client:dev-latest"}
 IMAGE_MONGOD=${IMAGE_MONGOD:-"perconalab/percona-server-mongodb-operator:master-mongod4.2"}

--- a/e2e-tests/upgrade-consistency/compare/service_some-name-rs0-170.yml
+++ b/e2e-tests/upgrade-consistency/compare/service_some-name-rs0-170.yml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: some-name-rs0
+  ownerReferences:
+    - controller: true
+      kind: PerconaServerMongoDB
+      name: some-name
+spec:
+  ports:
+    - name: mongodb
+      port: 27017
+      protocol: TCP
+      targetPort: 27017
+  selector:
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/managed-by: percona-server-mongodb-operator
+    app.kubernetes.io/name: percona-server-mongodb
+    app.kubernetes.io/part-of: percona-server-mongodb
+    app.kubernetes.io/replset: rs0
+  sessionAffinity: None
+  type: ClusterIP

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-170-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-170-oc.yml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  generation: 6
+  generation: 7
   labels:
     app.kubernetes.io/component: mongod
     app.kubernetes.io/instance: some-name

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-170-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-170-oc.yml
@@ -1,0 +1,194 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  generation: 6
+  labels:
+    app.kubernetes.io/component: mongod
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/managed-by: percona-server-mongodb-operator
+    app.kubernetes.io/name: percona-server-mongodb
+    app.kubernetes.io/part-of: percona-server-mongodb
+    app.kubernetes.io/replset: rs0
+  name: some-name-rs0
+  ownerReferences:
+    - controller: true
+      kind: PerconaServerMongoDB
+      name: some-name
+spec:
+  podManagementPolicy: OrderedReady
+  replicas: 3
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: mongod
+      app.kubernetes.io/instance: some-name
+      app.kubernetes.io/managed-by: percona-server-mongodb-operator
+      app.kubernetes.io/name: percona-server-mongodb
+      app.kubernetes.io/part-of: percona-server-mongodb
+      app.kubernetes.io/replset: rs0
+  serviceName: some-name-rs0
+  template:
+    metadata:
+      annotations: {}
+      labels:
+        app.kubernetes.io/component: mongod
+        app.kubernetes.io/instance: some-name
+        app.kubernetes.io/managed-by: percona-server-mongodb-operator
+        app.kubernetes.io/name: percona-server-mongodb
+        app.kubernetes.io/part-of: percona-server-mongodb
+        app.kubernetes.io/replset: rs0
+    spec:
+      containers:
+        - args:
+            - --bind_ip_all
+            - --auth
+            - --dbpath=/data/db
+            - --port=27017
+            - --replSet=rs0
+            - --storageEngine=wiredTiger
+            - --relaxPermChecks
+            - --sslAllowInvalidCertificates
+            - --sslMode=preferSSL
+            - --clusterAuthMode=x509
+            - --slowms=100
+            - --profile=1
+            - --rateLimit=1
+            - --enableEncryption
+            - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
+            - --wiredTigerCacheSizeGB=0.25
+            - --wiredTigerCollectionBlockCompressor=snappy
+            - --wiredTigerJournalCompressor=snappy
+            - --wiredTigerIndexPrefixCompression=true
+            - --setParameter
+            - ttlMonitorSleepSecs=60
+            - --setParameter
+            - wiredTigerConcurrentReadTransactions=128
+            - --setParameter
+            - wiredTigerConcurrentWriteTransactions=128
+          command:
+            - /data/db/ps-entry.sh
+          env:
+            - name: SERVICE_NAME
+              value: some-name
+            - name: MONGODB_PORT
+              value: "27017"
+            - name: MONGODB_REPLSET
+              value: rs0
+          envFrom:
+            - secretRef:
+                name: internal-some-name-users
+                optional: false
+          imagePullPolicy: Always
+          livenessProbe:
+            exec:
+              command:
+                - /data/db/mongodb-healthcheck
+                - k8s
+                - liveness
+                - --startupDelaySeconds
+                - "7200"
+            failureThreshold: 4
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 5
+          name: mongod
+          ports:
+            - containerPort: 27017
+              name: mongodb
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 8
+            initialDelaySeconds: 10
+            periodSeconds: 3
+            successThreshold: 1
+            tcpSocket:
+              port: 27017
+            timeoutSeconds: 2
+          resources:
+            limits:
+              cpu: 500m
+              memory: 500M
+            requests:
+              cpu: 100m
+              memory: 100M
+          securityContext:
+            runAsNonRoot: true
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /data/db
+              name: mongod-data
+            - mountPath: /etc/mongodb-secrets
+              name: some-name-mongodb-keyfile
+              readOnly: true
+            - mountPath: /etc/mongodb-ssl
+              name: ssl
+              readOnly: true
+            - mountPath: /etc/mongodb-ssl-internal
+              name: ssl-internal
+              readOnly: true
+            - mountPath: /etc/mongodb-encryption
+              name: some-name-mongodb-encryption-key
+              readOnly: true
+          workingDir: /data/db
+      dnsPolicy: ClusterFirst
+      initContainers:
+        - command:
+            - /init-entrypoint.sh
+          imagePullPolicy: Always
+          name: mongo-init
+          resources:
+            limits:
+              cpu: 500m
+              memory: 500M
+            requests:
+              cpu: 100m
+              memory: 100M
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /data/db
+              name: mongod-data
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: default
+      serviceAccountName: default
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: some-name-mongodb-keyfile
+          secret:
+            defaultMode: 288
+            optional: false
+            secretName: some-name-mongodb-keyfile
+        - name: some-name-mongodb-encryption-key
+          secret:
+            defaultMode: 288
+            optional: false
+            secretName: some-name-mongodb-encryption-key
+        - name: ssl
+          secret:
+            defaultMode: 288
+            optional: false
+            secretName: some-name-ssl
+        - name: ssl-internal
+          secret:
+            defaultMode: 288
+            optional: true
+            secretName: some-name-ssl-internal
+  updateStrategy:
+    rollingUpdate:
+      partition: 0
+    type: RollingUpdate
+  volumeClaimTemplates:
+    - metadata:
+        name: mongod-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+      status:
+        phase: Pending

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-170.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-170.yml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  generation: 6
+  generation: 7
   labels:
     app.kubernetes.io/component: mongod
     app.kubernetes.io/instance: some-name

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-170.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-170.yml
@@ -1,0 +1,196 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  generation: 6
+  labels:
+    app.kubernetes.io/component: mongod
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/managed-by: percona-server-mongodb-operator
+    app.kubernetes.io/name: percona-server-mongodb
+    app.kubernetes.io/part-of: percona-server-mongodb
+    app.kubernetes.io/replset: rs0
+  name: some-name-rs0
+  ownerReferences:
+    - controller: true
+      kind: PerconaServerMongoDB
+      name: some-name
+spec:
+  podManagementPolicy: OrderedReady
+  replicas: 3
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: mongod
+      app.kubernetes.io/instance: some-name
+      app.kubernetes.io/managed-by: percona-server-mongodb-operator
+      app.kubernetes.io/name: percona-server-mongodb
+      app.kubernetes.io/part-of: percona-server-mongodb
+      app.kubernetes.io/replset: rs0
+  serviceName: some-name-rs0
+  template:
+    metadata:
+      annotations: {}
+      labels:
+        app.kubernetes.io/component: mongod
+        app.kubernetes.io/instance: some-name
+        app.kubernetes.io/managed-by: percona-server-mongodb-operator
+        app.kubernetes.io/name: percona-server-mongodb
+        app.kubernetes.io/part-of: percona-server-mongodb
+        app.kubernetes.io/replset: rs0
+    spec:
+      containers:
+        - args:
+            - --bind_ip_all
+            - --auth
+            - --dbpath=/data/db
+            - --port=27017
+            - --replSet=rs0
+            - --storageEngine=wiredTiger
+            - --relaxPermChecks
+            - --sslAllowInvalidCertificates
+            - --sslMode=preferSSL
+            - --clusterAuthMode=x509
+            - --slowms=100
+            - --profile=1
+            - --rateLimit=1
+            - --enableEncryption
+            - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
+            - --wiredTigerCacheSizeGB=0.25
+            - --wiredTigerCollectionBlockCompressor=snappy
+            - --wiredTigerJournalCompressor=snappy
+            - --wiredTigerIndexPrefixCompression=true
+            - --setParameter
+            - ttlMonitorSleepSecs=60
+            - --setParameter
+            - wiredTigerConcurrentReadTransactions=128
+            - --setParameter
+            - wiredTigerConcurrentWriteTransactions=128
+          command:
+            - /data/db/ps-entry.sh
+          env:
+            - name: SERVICE_NAME
+              value: some-name
+            - name: MONGODB_PORT
+              value: "27017"
+            - name: MONGODB_REPLSET
+              value: rs0
+          envFrom:
+            - secretRef:
+                name: internal-some-name-users
+                optional: false
+          imagePullPolicy: Always
+          livenessProbe:
+            exec:
+              command:
+                - /data/db/mongodb-healthcheck
+                - k8s
+                - liveness
+                - --startupDelaySeconds
+                - "7200"
+            failureThreshold: 4
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 5
+          name: mongod
+          ports:
+            - containerPort: 27017
+              name: mongodb
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 8
+            initialDelaySeconds: 10
+            periodSeconds: 3
+            successThreshold: 1
+            tcpSocket:
+              port: 27017
+            timeoutSeconds: 2
+          resources:
+            limits:
+              cpu: 500m
+              memory: 500M
+            requests:
+              cpu: 100m
+              memory: 100M
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /data/db
+              name: mongod-data
+            - mountPath: /etc/mongodb-secrets
+              name: some-name-mongodb-keyfile
+              readOnly: true
+            - mountPath: /etc/mongodb-ssl
+              name: ssl
+              readOnly: true
+            - mountPath: /etc/mongodb-ssl-internal
+              name: ssl-internal
+              readOnly: true
+            - mountPath: /etc/mongodb-encryption
+              name: some-name-mongodb-encryption-key
+              readOnly: true
+          workingDir: /data/db
+      dnsPolicy: ClusterFirst
+      initContainers:
+        - command:
+            - /init-entrypoint.sh
+          imagePullPolicy: Always
+          name: mongo-init
+          resources:
+            limits:
+              cpu: 500m
+              memory: 500M
+            requests:
+              cpu: 100m
+              memory: 100M
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /data/db
+              name: mongod-data
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext:
+        fsGroup: 1001
+      serviceAccount: default
+      serviceAccountName: default
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: some-name-mongodb-keyfile
+          secret:
+            defaultMode: 288
+            optional: false
+            secretName: some-name-mongodb-keyfile
+        - name: some-name-mongodb-encryption-key
+          secret:
+            defaultMode: 288
+            optional: false
+            secretName: some-name-mongodb-encryption-key
+        - name: ssl
+          secret:
+            defaultMode: 288
+            optional: false
+            secretName: some-name-ssl
+        - name: ssl-internal
+          secret:
+            defaultMode: 288
+            optional: true
+            secretName: some-name-ssl-internal
+  updateStrategy:
+    rollingUpdate:
+      partition: 0
+    type: RollingUpdate
+  volumeClaimTemplates:
+    - metadata:
+        name: mongod-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+      status:
+        phase: Pending

--- a/e2e-tests/upgrade-consistency/run
+++ b/e2e-tests/upgrade-consistency/run
@@ -80,8 +80,14 @@ main() {
     }'
     wait_for_running "${CLUSTER}-rs0" "1" "false"
 
-    compare_kubectl service/${CLUSTER}-rs0 "-160"
-    compare_kubectl statefulset/${CLUSTER}-rs0 "-160"
+    # test 1.7.0
+    API="psmdb.percona.com/v1-7-0"
+    kubectl_bin patch psmdb "${CLUSTER}" --type=merge --patch '{
+        "spec": {"crVersion":"1.7.0"}
+    }'
+    wait_for_running "${CLUSTER}-rs0" "1" "false"
+    compare_kubectl service/${CLUSTER}-rs0 "-170"
+    compare_kubectl statefulset/${CLUSTER}-rs0 "-170"
 
     destroy $namespace
 }

--- a/e2e-tests/upgrade-consistency/run
+++ b/e2e-tests/upgrade-consistency/run
@@ -80,12 +80,16 @@ main() {
     }'
     wait_for_running "${CLUSTER}-rs0" "1" "false"
 
+    compare_kubectl service/${CLUSTER}-rs0 "-160"
+    compare_kubectl statefulset/${CLUSTER}-rs0 "-160"
+
     # test 1.7.0
     API="psmdb.percona.com/v1-7-0"
     kubectl_bin patch psmdb "${CLUSTER}" --type=merge --patch '{
         "spec": {"crVersion":"1.7.0"}
     }'
     wait_for_running "${CLUSTER}-rs0" "1" "false"
+
     compare_kubectl service/${CLUSTER}-rs0 "-170"
     compare_kubectl statefulset/${CLUSTER}-rs0 "-170"
 

--- a/e2e-tests/upgrade-sharded/run
+++ b/e2e-tests/upgrade-sharded/run
@@ -26,15 +26,11 @@ INIT_OPERATOR_VER=$(curl -s https://check.percona.com/versions/v1/psmdb-operator
 if [[ "${INIT_OPERATOR_VER}" == "${TARGET_OPERATOR_VER}" ]]; then
     INIT_OPERATOR_VER=$(curl -s https://check.percona.com/versions/v1/psmdb-operator | jq -r '.versions[].operator' | sort -V | tail -n2 | head -n1)
 fi
-# TODO: REMOVE NEXT LINE AND UNCOMMENT ONE BELOW IT AFTER 1.6.0 RELEASE !!!
-GIT_TAG="master"
-#GIT_TAG="v${INIT_OPERATOR_VER}"
+GIT_TAG="v${INIT_OPERATOR_VER}"
 INIT_OPERATOR_IMAGES=$(curl -s "https://check.percona.com/versions/v1/psmdb-operator/${INIT_OPERATOR_VER}/latest?databaseVersion=${MONGO_VER}")
 OPERATOR_NAME='percona-server-mongodb-operator'
 API="psmdb.percona.com/v${INIT_OPERATOR_VER//./-}"
-# TODO: REMOVE NEXT LINE AND UNCOMMENT ONE BELOW IT AFTER 1.6.0 RELEASE !!!
-IMAGE="${TARGET_IMAGE}"
-#IMAGE=$(echo "${INIT_OPERATOR_IMAGES}" | jq -r '.versions[].matrix.operator[].imagePath')
+IMAGE=$(echo "${INIT_OPERATOR_IMAGES}" | jq -r '.versions[].matrix.operator[].imagePath')
 # we use the starting image from the same repo so we don't need to use initImage option
 if [[ "$(echo ${TARGET_IMAGE}|cut -d'/' -f1)" == "perconalab" ]]; then
     IMAGE="${IMAGE/percona\//perconalab\/}"

--- a/e2e-tests/version-service/conf/crd.yaml
+++ b/e2e-tests/version-service/conf/crd.yaml
@@ -32,6 +32,9 @@ spec:
       storage: false
       served: true
     - name: v1-6-0
+      storage: false
+      served: true
+    - name: v1-7-0
       storage: true
       served: true
     - name: v9-9-9

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "1.6.0"
+	Version = "1.7.0"
 )


### PR DESCRIPTION
[![K8SPSMDB-341](https://badgen.net/badge/JIRA/K8SPSMDB-341/green)](https://jira.percona.com/browse/K8SPSMDB-341)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Two backup tests are failing because of: https://github.com/percona/percona-server-mongodb-operator/pull/515
`upgrade-consistency` is fixed in the second commit