### PR TITLE
K8SPSMDB-354 fix quotes in the password change command

### DIFF
--- a/source/users.rst
+++ b/source/users.rst
@@ -147,7 +147,7 @@ with the following command:
 
 .. code:: bash
 
-   kubectl patch secret/my-cluster-name-secrets -p '{"data":{"PMM_SERVER_PASSWORD": '$(echo -n new_password | base64)'}}'
+   kubectl patch secret/my-cluster-name-secrets -p '{"data":{"PMM_SERVER_PASSWORD": "'$(echo -n new_password | base64)'"}}'
 
 .. note:: The operator creates and updates an additional Secrets object named
    based on the cluster name, like ``internal-my-cluster-name-users``. It is


### PR DESCRIPTION
[![K8SPSMDB-354](https://badgen.net/badge/JIRA/K8SPSMDB-354/green)](https://jira.percona.com/browse/K8SPSMDB-354) [&#10088;?&#10089;](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

