### PR TITLE
Fix init-deploy and data-sharded e2e-tests for Minikube

### DIFF
--- a/e2e-tests/data-sharded/conf/some-name.yml
+++ b/e2e-tests/data-sharded/conf/some-name.yml
@@ -12,6 +12,8 @@ spec:
 
     configsvrReplSet:
       size: 3
+      affinity:
+        antiAffinityTopologyKey: none
       volumeSpec:
         persistentVolumeClaim:
           resources:
@@ -20,6 +22,8 @@ spec:
 
     mongos:
       size: 3
+      affinity:
+        antiAffinityTopologyKey: none
       expose:
         enabled: false
         exposeType: ClusterIP

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -353,6 +353,7 @@ compare_kubectl() {
         | yq d - '**.creationTimestamp' \
         | yq d - '**.image' \
         | yq d - '**.clusterIP' \
+        | yq d - 'spec.clusterIPs' \
         | yq d - '**.dataSource' \
         | yq d - '**.procMount' \
         | yq d - '**.storageClassName' \


### PR DESCRIPTION
`data-sharded` already had `antiAffinityTopologyKey: none` defined for some pods, but not for all, so this sets them for all so it can run on Minikube.
`init-deploy` fails on Minikube with:
```
+ diff -u /mnt/jenkins/workspace/psmdb-operator-minikube/source/e2e-tests/init-deploy/compare/service_some-name-rs0.yml /tmp/tmp.S3v6LoJCuC/service_some-name-rs0.yml
--- /mnt/jenkins/workspace/psmdb-operator-minikube/source/e2e-tests/init-deploy/compare/service_some-name-rs0.yml	2021-02-10 16:32:17.000000000 +0000
+++ /tmp/tmp.S3v6LoJCuC/service_some-name-rs0.yml	2021-02-10 16:38:45.253306738 +0000
@@ -7,6 +7,8 @@
       kind: PerconaServerMongoDB
       name: some-name
 spec:
+  clusterIPs:
+    - None
   ports:
     - name: mongodb
       port: 27017
```