### PR TITLE
K8SPSMDB-380 Mount users secret to mongo pod

### DIFF
--- a/cmd/mongodb-healthcheck/main.go
+++ b/cmd/mongodb-healthcheck/main.go
@@ -49,11 +49,14 @@ func main() {
 	startupDelaySeconds := livenessCmd.Flag("startupDelaySeconds", "").Default("7200").Uint64()
 	component := k8sCmd.Flag("component", "").Default("mongod").String()
 
-	cnf := db.NewConfig(
+	cnf, err := db.NewConfig(
 		app,
 		pkg.EnvMongoDBClusterMonitorUser,
 		pkg.EnvMongoDBClusterMonitorPassword,
 	)
+	if err != nil {
+		log.Fatalf("new cfg: %s", err)
+	}
 
 	command, err := app.Parse(os.Args[1:])
 	if err != nil {

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -35,6 +35,9 @@ spec:
       storage: false
       served: true
     - name: v1-7-0
+      storage: false
+      served: true
+    - name: v1-8-0
       storage: true
       served: true
     - name: v1alpha1

--- a/e2e-tests/arbiter/compare/statefulset_arbiter-clusterip-rs0-arbiter-oc.yml
+++ b/e2e-tests/arbiter/compare/statefulset_arbiter-clusterip-rs0-arbiter-oc.yml
@@ -126,6 +126,8 @@ spec:
         - mountPath: /etc/mongodb-encryption
           name: arbiter-clusterip-mongodb-encryption-key
           readOnly: true
+        - mountPath: /etc/users-secret
+          name: users-secret-file
         workingDir: /data/db
       dnsPolicy: ClusterFirst
       initContainers:
@@ -166,6 +168,10 @@ spec:
           defaultMode: 288
           optional: true
           secretName: arbiter-clusterip-ssl-internal
+      - name: users-secret-file
+        secret:
+          defaultMode: 420
+          secretName: internal-arbiter-users
       - emptyDir: {}
         name: mongod-data
   updateStrategy:

--- a/e2e-tests/arbiter/compare/statefulset_arbiter-clusterip-rs0-arbiter.yml
+++ b/e2e-tests/arbiter/compare/statefulset_arbiter-clusterip-rs0-arbiter.yml
@@ -127,6 +127,8 @@ spec:
         - mountPath: /etc/mongodb-encryption
           name: arbiter-clusterip-mongodb-encryption-key
           readOnly: true
+        - mountPath: /etc/users-secret
+          name: users-secret-file
         workingDir: /data/db
       dnsPolicy: ClusterFirst
       initContainers:
@@ -168,6 +170,10 @@ spec:
           defaultMode: 288
           optional: true
           secretName: arbiter-clusterip-ssl-internal
+      - name: users-secret-file
+        secret:
+          defaultMode: 420
+          secretName: internal-arbiter-users
       - emptyDir: {}
         name: mongod-data
   updateStrategy:

--- a/e2e-tests/arbiter/compare/statefulset_arbiter-rs0-arbiter-oc.yml
+++ b/e2e-tests/arbiter/compare/statefulset_arbiter-rs0-arbiter-oc.yml
@@ -127,6 +127,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: arbiter-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
       dnsPolicy: ClusterFirst
       initContainers:
@@ -165,6 +167,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: arbiter-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-arbiter-users
         - emptyDir: {}
           name: mongod-data
   updateStrategy:

--- a/e2e-tests/arbiter/compare/statefulset_arbiter-rs0-arbiter.yml
+++ b/e2e-tests/arbiter/compare/statefulset_arbiter-rs0-arbiter.yml
@@ -134,6 +134,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: arbiter-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
       dnsPolicy: ClusterFirst
       initContainers:
@@ -173,6 +175,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: arbiter-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-arbiter-users
         - emptyDir: {}
           name: mongod-data
   updateStrategy:

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-cfg-oc.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-cfg-oc.yml
@@ -137,6 +137,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: some-name-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
         - args:
             - -c
@@ -214,6 +216,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: some-name-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-some-name-users
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-cfg.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-cfg.yml
@@ -144,6 +144,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: some-name-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
         - args:
             - -c
@@ -223,6 +225,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: some-name-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-some-name-users
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs0-oc.yml
@@ -132,6 +132,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: some-name-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
         - args:
             - -c
@@ -215,6 +217,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: some-name-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-some-name-users
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs0.yml
@@ -139,6 +139,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: some-name-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
         - env:
             - name: PBM_AGENT_MONGODB_USERNAME
@@ -214,6 +216,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: some-name-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-some-name-users
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs1.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs1.yml
@@ -139,6 +139,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: some-name-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
         - env:
             - name: PBM_AGENT_MONGODB_USERNAME
@@ -213,6 +215,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: some-name-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-some-name-users
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs2.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs2.yml
@@ -139,6 +139,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: some-name-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
         - args:
             - -c
@@ -223,6 +225,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: some-name-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-some-name-users
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/e2e-tests/demand-backup/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/demand-backup/compare/statefulset_some-name-rs0-oc.yml
@@ -131,6 +131,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: some-name-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
         - env:
             - name: PBM_AGENT_MONGODB_USERNAME
@@ -201,6 +203,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: some-name-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-some-name-users
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/e2e-tests/demand-backup/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/demand-backup/compare/statefulset_some-name-rs0.yml
@@ -138,6 +138,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: some-name-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
         - env:
             - name: PBM_AGENT_MONGODB_USERNAME
@@ -210,6 +212,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: some-name-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-some-name-users
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -5,7 +5,7 @@ BASH_XTRACEFD="5"
 
 GIT_COMMIT=$(git rev-parse HEAD)
 GIT_BRANCH=${VERSION:-$(git rev-parse --abbrev-ref HEAD | sed -e 's^/^-^g; s^[.]^-^g;' | sed -e 's/_/-/g' | tr '[:upper:]' '[:lower:]')}
-API="psmdb.percona.com/v1-7-0"
+API="psmdb.percona.com/v1-8-0"
 IMAGE=${IMAGE:-"perconalab/percona-server-mongodb-operator:${GIT_BRANCH}"}
 IMAGE_PMM=${IMAGE_PMM:-"perconalab/pmm-client:dev-latest"}
 IMAGE_MONGOD=${IMAGE_MONGOD:-"perconalab/percona-server-mongodb-operator:main-mongod4.4"}

--- a/e2e-tests/init-deploy/compare/statefulset_another-name-rs0-oc.yml
+++ b/e2e-tests/init-deploy/compare/statefulset_another-name-rs0-oc.yml
@@ -131,6 +131,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: another-name-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
         - args:
             - -c
@@ -198,6 +200,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: another-name-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-another-name-users
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/e2e-tests/init-deploy/compare/statefulset_another-name-rs0.yml
+++ b/e2e-tests/init-deploy/compare/statefulset_another-name-rs0.yml
@@ -138,6 +138,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: another-name-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
         - args:
             - -c
@@ -206,6 +208,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: another-name-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-another-name-users
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/e2e-tests/init-deploy/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/init-deploy/compare/statefulset_some-name-rs0-oc.yml
@@ -131,6 +131,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: some-name-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
       dnsPolicy: ClusterFirst
       initContainers:
@@ -177,6 +179,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: some-name-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-some-name-users
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/e2e-tests/init-deploy/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/init-deploy/compare/statefulset_some-name-rs0.yml
@@ -138,6 +138,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: some-name-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
       dnsPolicy: ClusterFirst
       initContainers:
@@ -185,6 +187,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: some-name-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-some-name-users
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/e2e-tests/limits/compare/statefulset_no-limits-rs0-increased-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-rs0-increased-oc.yml
@@ -139,6 +139,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: no-limits-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
       dnsPolicy: ClusterFirst
       initContainers:
@@ -182,6 +184,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: no-limits-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-no-limits-users
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/e2e-tests/limits/compare/statefulset_no-limits-rs0-increased.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-rs0-increased.yml
@@ -146,6 +146,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: no-limits-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
       dnsPolicy: ClusterFirst
       initContainers:
@@ -190,6 +192,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: no-limits-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-no-limits-users
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/e2e-tests/limits/compare/statefulset_no-limits-rs0-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-rs0-oc.yml
@@ -139,6 +139,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: no-limits-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
       dnsPolicy: ClusterFirst
       initContainers:
@@ -182,6 +184,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: no-limits-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-no-limits-users
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/e2e-tests/limits/compare/statefulset_no-limits-rs0.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-rs0.yml
@@ -146,6 +146,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: no-limits-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
       dnsPolicy: ClusterFirst
       initContainers:
@@ -190,6 +192,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: no-limits-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-no-limits-users
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/e2e-tests/limits/compare/statefulset_no-requests-no-limits-rs0-increased-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-no-limits-rs0-increased-oc.yml
@@ -136,6 +136,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: no-requests-no-limits-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
       dnsPolicy: ClusterFirst
       initContainers:
@@ -176,6 +178,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: no-requests-no-limits-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-no-requests-no-limits-users
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/e2e-tests/limits/compare/statefulset_no-requests-no-limits-rs0-increased.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-no-limits-rs0-increased.yml
@@ -143,6 +143,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: no-requests-no-limits-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
       dnsPolicy: ClusterFirst
       initContainers:
@@ -184,6 +186,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: no-requests-no-limits-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-no-requests-no-limits-users
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/e2e-tests/limits/compare/statefulset_no-requests-no-limits-rs0-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-no-limits-rs0-oc.yml
@@ -136,6 +136,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: no-requests-no-limits-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
       dnsPolicy: ClusterFirst
       initContainers:
@@ -176,6 +178,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: no-requests-no-limits-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-no-requests-no-limits-users
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/e2e-tests/limits/compare/statefulset_no-requests-no-limits-rs0.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-no-limits-rs0.yml
@@ -143,6 +143,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: no-requests-no-limits-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
       dnsPolicy: ClusterFirst
       initContainers:
@@ -184,6 +186,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: no-requests-no-limits-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-no-requests-no-limits-users
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/e2e-tests/limits/compare/statefulset_no-requests-rs0-increased-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-rs0-increased-oc.yml
@@ -140,6 +140,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: no-requests-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
       dnsPolicy: ClusterFirst
       initContainers:
@@ -183,6 +185,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: no-requests-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-no-requests-users
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/e2e-tests/limits/compare/statefulset_no-requests-rs0-increased.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-rs0-increased.yml
@@ -147,6 +147,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: no-requests-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
       dnsPolicy: ClusterFirst
       initContainers:
@@ -191,6 +193,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: no-requests-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-no-requests-users
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/e2e-tests/limits/compare/statefulset_no-requests-rs0-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-rs0-oc.yml
@@ -140,6 +140,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: no-requests-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
       dnsPolicy: ClusterFirst
       initContainers:
@@ -183,6 +185,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: no-requests-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-no-requests-users
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/e2e-tests/limits/compare/statefulset_no-requests-rs0.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-rs0.yml
@@ -147,6 +147,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: no-requests-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
       dnsPolicy: ClusterFirst
       initContainers:
@@ -191,6 +193,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: no-requests-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-no-requests-users
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/e2e-tests/liveness/compare/statefulset_liveness-rs0-changed-oc.yml
+++ b/e2e-tests/liveness/compare/statefulset_liveness-rs0-changed-oc.yml
@@ -131,6 +131,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: liveness-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
         - env:
             - name: PBM_AGENT_MONGODB_USERNAME
@@ -201,6 +203,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: liveness-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-liveness-users
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/e2e-tests/liveness/compare/statefulset_liveness-rs0-changed.yml
+++ b/e2e-tests/liveness/compare/statefulset_liveness-rs0-changed.yml
@@ -138,6 +138,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: liveness-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
         - env:
             - name: PBM_AGENT_MONGODB_USERNAME
@@ -210,6 +212,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: liveness-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-liveness-users
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/e2e-tests/liveness/compare/statefulset_liveness-rs0-oc.yml
+++ b/e2e-tests/liveness/compare/statefulset_liveness-rs0-oc.yml
@@ -131,6 +131,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: liveness-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
       dnsPolicy: ClusterFirst
       initContainers:
@@ -177,6 +179,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: liveness-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-liveness-users
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/e2e-tests/liveness/compare/statefulset_liveness-rs0.yml
+++ b/e2e-tests/liveness/compare/statefulset_liveness-rs0.yml
@@ -138,6 +138,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: liveness-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
       dnsPolicy: ClusterFirst
       initContainers:
@@ -185,6 +187,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: liveness-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-liveness-users
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-cfg-oc.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-cfg-oc.yml
@@ -135,6 +135,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: monitoring-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
         - env:
             - name: PMM_SERVER
@@ -300,6 +302,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: monitoring-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-monitoring-users
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-cfg.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-cfg.yml
@@ -136,6 +136,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: monitoring-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
         - env:
             - name: PMM_SERVER
@@ -302,6 +304,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: monitoring-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-monitoring-users
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0-oc.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0-oc.yml
@@ -123,6 +123,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: monitoring-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
         - env:
             - name: PMM_SERVER
@@ -288,6 +290,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: monitoring-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-monitoring-users
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0.yml
@@ -124,6 +124,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: monitoring-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
         - env:
             - name: PMM_SERVER
@@ -290,6 +292,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: monitoring-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-monitoring-users
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/e2e-tests/one-pod/compare/statefulset_one-pod-rs0-oc.yml
+++ b/e2e-tests/one-pod/compare/statefulset_one-pod-rs0-oc.yml
@@ -138,6 +138,8 @@ spec:
             - mountPath: /etc/mongodb-ssl-internal
               name: ssl-internal
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
         - env:
             - name: PBM_AGENT_MONGODB_USERNAME
@@ -203,6 +205,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: one-pod-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-one-pod-users
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/e2e-tests/one-pod/compare/statefulset_one-pod-rs0.yml
+++ b/e2e-tests/one-pod/compare/statefulset_one-pod-rs0.yml
@@ -145,6 +145,8 @@ spec:
             - mountPath: /etc/mongodb-ssl-internal
               name: ssl-internal
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
         - env:
             - name: PBM_AGENT_MONGODB_USERNAME
@@ -212,6 +214,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: one-pod-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-one-pod-users
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/e2e-tests/rs-shard-migration/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/rs-shard-migration/compare/statefulset_some-name-rs0-oc.yml
@@ -137,6 +137,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: some-name-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
       dnsPolicy: ClusterFirst
       initContainers:
@@ -183,6 +185,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: some-name-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-some-name-users
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/e2e-tests/rs-shard-migration/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/rs-shard-migration/compare/statefulset_some-name-rs0.yml
@@ -138,6 +138,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: some-name-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
       dnsPolicy: ClusterFirst
       initContainers:
@@ -185,6 +187,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: some-name-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-some-name-users
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/e2e-tests/scheduled-backup/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/scheduled-backup/compare/statefulset_some-name-rs0-oc.yml
@@ -131,6 +131,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: some-name-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
         - env:
             - name: PBM_AGENT_MONGODB_USERNAME
@@ -201,6 +203,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: some-name-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-some-name-users
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/e2e-tests/scheduled-backup/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/scheduled-backup/compare/statefulset_some-name-rs0.yml
@@ -138,6 +138,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: some-name-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
         - env:
             - name: PBM_AGENT_MONGODB_USERNAME
@@ -210,6 +212,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: some-name-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-some-name-users
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/e2e-tests/security-context/compare/statefulset_sec-context-rs0-changed.yml
+++ b/e2e-tests/security-context/compare/statefulset_sec-context-rs0-changed.yml
@@ -138,6 +138,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: sec-context-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
         - env:
             - name: PBM_AGENT_MONGODB_USERNAME
@@ -214,6 +216,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: sec-context-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-sec-context-users
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/e2e-tests/security-context/compare/statefulset_sec-context-rs0.yml
+++ b/e2e-tests/security-context/compare/statefulset_sec-context-rs0.yml
@@ -138,6 +138,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: sec-context-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
       dnsPolicy: ClusterFirst
       initContainers:
@@ -189,6 +191,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: sec-context-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-sec-context-users
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/e2e-tests/service-per-pod/compare/statefulset_cluster-ip-rs0-oc.yml
+++ b/e2e-tests/service-per-pod/compare/statefulset_cluster-ip-rs0-oc.yml
@@ -115,6 +115,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: cluster-ip-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
       dnsPolicy: ClusterFirst
       initContainers:
@@ -155,6 +157,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: cluster-ip-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-cluster-ip-users
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/e2e-tests/service-per-pod/compare/statefulset_cluster-ip-rs0.yml
+++ b/e2e-tests/service-per-pod/compare/statefulset_cluster-ip-rs0.yml
@@ -122,6 +122,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: cluster-ip-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
       dnsPolicy: ClusterFirst
       initContainers:
@@ -163,6 +165,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: cluster-ip-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-cluster-ip-users
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/e2e-tests/service-per-pod/compare/statefulset_local-balancer-rs0-oc.yml
+++ b/e2e-tests/service-per-pod/compare/statefulset_local-balancer-rs0-oc.yml
@@ -115,6 +115,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: local-balancer-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
       dnsPolicy: ClusterFirst
       initContainers:
@@ -155,6 +157,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: local-balancer-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-balancer-users
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/e2e-tests/service-per-pod/compare/statefulset_local-balancer-rs0.yml
+++ b/e2e-tests/service-per-pod/compare/statefulset_local-balancer-rs0.yml
@@ -168,7 +168,7 @@ spec:
         - name: users-secret-file
           secret:
             defaultMode: 420
-            secretName: internal-balancer-users
+            secretName: internal-local-balancer-users
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/e2e-tests/service-per-pod/compare/statefulset_local-balancer-rs0.yml
+++ b/e2e-tests/service-per-pod/compare/statefulset_local-balancer-rs0.yml
@@ -122,6 +122,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: local-balancer-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
       dnsPolicy: ClusterFirst
       initContainers:
@@ -163,6 +165,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: local-balancer-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-balancer-users
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/e2e-tests/smart-update/compare/statefulset_smart-update-rs0-oc.yml
+++ b/e2e-tests/smart-update/compare/statefulset_smart-update-rs0-oc.yml
@@ -131,6 +131,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: smart-update-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
       dnsPolicy: ClusterFirst
       initContainers:
@@ -177,6 +179,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: smart-update-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-smart-update-users
   updateStrategy:
     type: OnDelete
   volumeClaimTemplates:

--- a/e2e-tests/smart-update/compare/statefulset_smart-update-rs0.yml
+++ b/e2e-tests/smart-update/compare/statefulset_smart-update-rs0.yml
@@ -138,6 +138,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: smart-update-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
       dnsPolicy: ClusterFirst
       initContainers:
@@ -185,6 +187,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: smart-update-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-smart-update-users
   updateStrategy:
     type: OnDelete
   volumeClaimTemplates:

--- a/e2e-tests/storage/compare/statefulset_emptydir-rs0-oc.yml
+++ b/e2e-tests/storage/compare/statefulset_emptydir-rs0-oc.yml
@@ -115,6 +115,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: emptydir-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
       dnsPolicy: ClusterFirst
       initContainers:
@@ -155,6 +157,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: emptydir-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-emptydir-users
         - emptyDir: {}
           name: mongod-data
   updateStrategy:

--- a/e2e-tests/storage/compare/statefulset_emptydir-rs0.yml
+++ b/e2e-tests/storage/compare/statefulset_emptydir-rs0.yml
@@ -134,6 +134,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: emptydir-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
       dnsPolicy: ClusterFirst
       initContainers:
@@ -175,6 +177,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: emptydir-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-emptydir-users
         - emptyDir: {}
           name: mongod-data
   updateStrategy:

--- a/e2e-tests/storage/compare/statefulset_hostpath-rs0-oc.yml
+++ b/e2e-tests/storage/compare/statefulset_hostpath-rs0-oc.yml
@@ -115,6 +115,8 @@ spec:
         - mountPath: /etc/mongodb-encryption
           name: hostpath-mongodb-encryption-key
           readOnly: true
+        - mountPath: /etc/users-secret
+          name: users-secret-file
         workingDir: /data/db
       dnsPolicy: ClusterFirst
       initContainers:
@@ -155,6 +157,10 @@ spec:
           defaultMode: 288
           optional: true
           secretName: hostpath-ssl-internal
+      - name: users-secret-file
+        secret:
+          defaultMode: 420
+          secretName: internal-hostpath-users
       - hostPath:
           path: /run/data-dir
           type: Directory

--- a/e2e-tests/storage/compare/statefulset_hostpath-rs0.yml
+++ b/e2e-tests/storage/compare/statefulset_hostpath-rs0.yml
@@ -134,6 +134,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: hostpath-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
       dnsPolicy: ClusterFirst
       initContainers:
@@ -175,6 +177,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: hostpath-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-hostpath-users
         - hostPath:
             path: /run/data-dir
             type: Directory

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-160.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-160.yml
@@ -132,6 +132,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: some-name-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
       dnsPolicy: ClusterFirst
       initContainers:

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-160.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-160.yml
@@ -132,8 +132,6 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: some-name-mongodb-encryption-key
               readOnly: true
-            - mountPath: /etc/users-secret
-              name: users-secret-file
           workingDir: /data/db
       dnsPolicy: ClusterFirst
       initContainers:

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-170.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-170.yml
@@ -138,8 +138,6 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: some-name-mongodb-encryption-key
               readOnly: true
-            - mountPath: /etc/users-secret
-              name: users-secret-file
           workingDir: /data/db
       dnsPolicy: ClusterFirst
       initContainers:

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-170.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-170.yml
@@ -138,6 +138,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: some-name-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
       dnsPolicy: ClusterFirst
       initContainers:

--- a/e2e-tests/version-service/compare/statefulset_version-service-exact-rs0-oc.yml
+++ b/e2e-tests/version-service/compare/statefulset_version-service-exact-rs0-oc.yml
@@ -131,6 +131,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: version-service-exact-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
       dnsPolicy: ClusterFirst
       initContainers:
@@ -177,6 +179,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: version-service-exact-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-version-service-exact-users
   updateStrategy:
     type: OnDelete
   volumeClaimTemplates:

--- a/e2e-tests/version-service/compare/statefulset_version-service-exact-rs0.yml
+++ b/e2e-tests/version-service/compare/statefulset_version-service-exact-rs0.yml
@@ -138,6 +138,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: version-service-exact-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
       dnsPolicy: ClusterFirst
       initContainers:
@@ -185,6 +187,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: version-service-exact-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-version-service-exact-users
   updateStrategy:
     type: OnDelete
   volumeClaimTemplates:

--- a/e2e-tests/version-service/compare/statefulset_version-service-latest-rs0-oc.yml
+++ b/e2e-tests/version-service/compare/statefulset_version-service-latest-rs0-oc.yml
@@ -131,6 +131,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: version-service-latest-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
       dnsPolicy: ClusterFirst
       initContainers:
@@ -177,6 +179,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: version-service-latest-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-version-service-latest-users
   updateStrategy:
     type: OnDelete
   volumeClaimTemplates:

--- a/e2e-tests/version-service/compare/statefulset_version-service-latest-rs0.yml
+++ b/e2e-tests/version-service/compare/statefulset_version-service-latest-rs0.yml
@@ -138,6 +138,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: version-service-latest-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
       dnsPolicy: ClusterFirst
       initContainers:
@@ -185,6 +187,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: version-service-latest-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-version-service-latest-users
   updateStrategy:
     type: OnDelete
   volumeClaimTemplates:

--- a/e2e-tests/version-service/compare/statefulset_version-service-recommended-rs0-oc.yml
+++ b/e2e-tests/version-service/compare/statefulset_version-service-recommended-rs0-oc.yml
@@ -131,6 +131,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: version-service-recommended-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
       dnsPolicy: ClusterFirst
       initContainers:
@@ -177,6 +179,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: version-service-recommended-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-version-service-recommended-users
   updateStrategy:
     type: OnDelete
   volumeClaimTemplates:

--- a/e2e-tests/version-service/compare/statefulset_version-service-recommended-rs0.yml
+++ b/e2e-tests/version-service/compare/statefulset_version-service-recommended-rs0.yml
@@ -138,6 +138,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: version-service-recommended-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
       dnsPolicy: ClusterFirst
       initContainers:
@@ -185,6 +187,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: version-service-recommended-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-version-service-recommended-users
   updateStrategy:
     type: OnDelete
   volumeClaimTemplates:

--- a/e2e-tests/version-service/compare/statefulset_version-service-unreachable-rs0-oc.yml
+++ b/e2e-tests/version-service/compare/statefulset_version-service-unreachable-rs0-oc.yml
@@ -131,6 +131,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: version-service-unreachable-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
       dnsPolicy: ClusterFirst
       initContainers:
@@ -177,6 +179,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: version-service-unreachable-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-version-service-unreachable-users
   updateStrategy:
     type: OnDelete
   volumeClaimTemplates:

--- a/e2e-tests/version-service/compare/statefulset_version-service-unreachable-rs0.yml
+++ b/e2e-tests/version-service/compare/statefulset_version-service-unreachable-rs0.yml
@@ -138,6 +138,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: version-service-unreachable-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
       dnsPolicy: ClusterFirst
       initContainers:
@@ -185,6 +187,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: version-service-unreachable-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-version-service-unreachable-users
   updateStrategy:
     type: OnDelete
   volumeClaimTemplates:

--- a/e2e-tests/version-service/conf/crd.yaml
+++ b/e2e-tests/version-service/conf/crd.yaml
@@ -35,6 +35,9 @@ spec:
       storage: false
       served: true
     - name: v1-7-0
+      storage: false
+      served: true
+    - name: v1-8-0
       storage: true
       served: true
     - name: v9-9-9

--- a/healthcheck/tools/db/config.go
+++ b/healthcheck/tools/db/config.go
@@ -15,7 +15,6 @@
 package db
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -24,6 +23,7 @@ import (
 	"github.com/alecthomas/kingpin"
 	"github.com/percona/percona-server-mongodb-operator/healthcheck/pkg"
 	"github.com/percona/percona-server-mongodb-operator/healthcheck/tools/dcos"
+	"github.com/pkg/errors"
 	"gopkg.in/mgo.v2"
 )
 
@@ -81,7 +81,7 @@ func NewConfig(app *kingpin.Application, envUser string, envPassword string) (*C
 	).Envar(envUser).Required().StringVar(&db.DialInfo.Username)
 	pass, err := ioutil.ReadFile("/etc/users-secret/MONGODB_CLUSTER_MONITOR_PASSWORD")
 	if err != nil && err != os.ErrNotExist {
-		return nil, fmt.Errorf("read MONGODB_CLUSTER_MONITOR_PASSWORD: %v", err)
+		return nil, errors.Wrap(err, "read MONGODB_CLUSTER_MONITOR_PASSWORD")
 	}
 	if len(pass) > 0 {
 		db.DialInfo.Password = string(pass)

--- a/pkg/controller/perconaservermongodb/psmdb_controller.go
+++ b/pkg/controller/perconaservermongodb/psmdb_controller.go
@@ -866,6 +866,17 @@ func (r *ReconcilePerconaServerMongoDB) reconcileStatefulSet(arbiter bool, cr *a
 			},
 		},
 	)
+	if cr.CompareVersion("1.8.0") >= 0 {
+		sfsSpec.Template.Spec.Volumes = append(sfsSpec.Template.Spec.Volumes,
+			corev1.Volume{
+				Name: "users-secret-file",
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: "internal-" + cr.Name + "-users",
+					},
+				},
+			})
+	}
 
 	if arbiter {
 		sfsSpec.Template.Spec.Volumes = append(sfsSpec.Template.Spec.Volumes,

--- a/pkg/controller/perconaservermongodb/users.go
+++ b/pkg/controller/perconaservermongodb/users.go
@@ -167,9 +167,8 @@ func (r *ReconcilePerconaServerMongoDB) updateSysUsers(cr *api.PerconaServerMong
 			passKey: envMongoDBClusterAdminPassword,
 		},
 		{
-			nameKey:        envMongoDBClusterMonitorUser,
-			passKey:        envMongoDBClusterMonitorPassword,
-			needRestartSfs: true, //need for liveness/readiness ckeck
+			nameKey: envMongoDBClusterMonitorUser,
+			passKey: envMongoDBClusterMonitorPassword,
 		},
 		{
 			nameKey:        envMongoDBBackupUser,

--- a/pkg/psmdb/container.go
+++ b/pkg/psmdb/container.go
@@ -44,7 +44,12 @@ func container(m *api.PerconaServerMongoDB, replset *api.ReplsetSpec, name strin
 			},
 		)
 	}
-
+	if m.CompareVersion("1.8.0") >= 0 {
+		volumes = append(volumes, corev1.VolumeMount{
+			Name:      "users-secret-file",
+			MountPath: "/etc/users-secret",
+		})
+	}
 	container := corev1.Container{
 		Name:            name,
 		Image:           m.Spec.Image,


### PR DESCRIPTION
[![K8SPSMDB-380](https://badgen.net/badge/JIRA/K8SPSMDB-380/green)](https://jira.percona.com/browse/K8SPSMDB-380) [&#10088;?&#10089;](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

We need to restart mongod pods if we change monitor user because we use it for liveness checks. So in this PR we mount users secret into the pod for catching on a fly users pass change