### PR TITLE
Make data-sharded test run on older MongoDB versions

### DIFF
--- a/e2e-tests/data-sharded/run
+++ b/e2e-tests/data-sharded/run
@@ -21,31 +21,31 @@ desc 'check if all 3 Pods started'
 wait_for_running $cluster-rs0 3
 wait_for_running $cluster-cfg 3 "false"
 
-desc 'create user, enable sharding'
+desc 'create user'
 
 run_mongos \
     'db.createUser({user:"user",pwd:"pass",roles:[{db:"app",role:"readWrite"}]})' \
     "userAdmin:userAdmin123456@$cluster-mongos.$namespace"
 sleep 2
 
+desc 'set chunk size to 32 MB'
+run_mongos \
+    "use config\n db.settings.save( { _id:\"chunksize\", value: 32 } )" \
+    "clusterAdmin:clusterAdmin123456@$cluster-mongos.$namespace"
+sleep 2
+
+desc 'write data'
+run_script_mongos "${test_dir}/data.js" "user:pass@$cluster-mongos.$namespace"
+
+desc 'shard collection'
 run_mongos \
     'sh.enableSharding("app")' \
     "clusterAdmin:clusterAdmin123456@$cluster-mongos.$namespace"
 sleep 2
 
 run_mongos \
-    'sh.shardCollection("app.city", { zipcode: 1 } )' \
+    'sh.shardCollection("app.city", { _id: 1 } )' \
     "clusterAdmin:clusterAdmin123456@$cluster-mongos.$namespace"
-sleep 2
-
-desc 'set chunk size to 1 MB'
-run_mongos \
-    "use config\n db.settings.save( { _id:\"chunksize\", value: 1 } )" \
-    "clusterAdmin:clusterAdmin123456@$cluster-mongos.$namespace"
-sleep 2
-
-desc 'write data'
-run_script_mongos "${test_dir}/data.js" "user:pass@$cluster-mongos.$namespace"
 
 sleep 120
 desc 'check chunks'


### PR DESCRIPTION
`data-sharded` test was failing on PSMDB 4.0 and 3.6 and it seems because of small chunk size and some performance issues if bulk data insertion is happening together with data migrations on older versions.
So I have changed a little bit how it works:
1. first insert data, then enable sharding on collection (this way migrations and data insert are not happening at the same time)
2. put `_id` field as a shard field instead of `zipcode` since this is already indexed so the second index is not created (it's not important for us)
3. increased chunk size from 1MB to half of the default value to 32Mb (default is 64Mb) - this might not even be important with the changed operation order, but it shouldn't hurt.