### PR TITLE
Fix diff in monitoring-2-0 e2e test for mongos deployment

### DIFF
--- a/e2e-tests/monitoring-2-0/compare/deployment_monitoring-mongos-oc.yml
+++ b/e2e-tests/monitoring-2-0/compare/deployment_monitoring-mongos-oc.yml
@@ -52,9 +52,9 @@ spec:
             - --bind_ip_all
             - --port=27017
             - --sslAllowInvalidCertificates
-            - --relaxPermChecks
             - --configdb
             - cfg/monitoring-cfg-0.monitoring-cfg.NAME_SPACE.svc.cluster.local:27017,monitoring-cfg-1.monitoring-cfg.NAME_SPACE.svc.cluster.local:27017,monitoring-cfg-2.monitoring-cfg.NAME_SPACE.svc.cluster.local:27017
+            - --relaxPermChecks
             - --sslMode=preferSSL
             - --clusterAuthMode=x509
           command:

--- a/e2e-tests/monitoring-2-0/compare/deployment_monitoring-mongos.yml
+++ b/e2e-tests/monitoring-2-0/compare/deployment_monitoring-mongos.yml
@@ -52,9 +52,9 @@ spec:
             - --bind_ip_all
             - --port=27017
             - --sslAllowInvalidCertificates
-            - --relaxPermChecks
             - --configdb
             - cfg/monitoring-cfg-0.monitoring-cfg.NAME_SPACE.svc.cluster.local:27017,monitoring-cfg-1.monitoring-cfg.NAME_SPACE.svc.cluster.local:27017,monitoring-cfg-2.monitoring-cfg.NAME_SPACE.svc.cluster.local:27017
+            - --relaxPermChecks
             - --sslMode=preferSSL
             - --clusterAuthMode=x509
           command:


### PR DESCRIPTION
monitoring-2-0 test was failing with this diff:
```
+ diff -u /mnt/jenkins/workspace/psmdb-operator-gke-version/source/e2e-tests/monitoring-2-0/compare/deployment_monitoring-mongos.yml /tmp/tmp.y48SGaoAZY/deployment_monitoring-mongos.yml
--- /mnt/jenkins/workspace/psmdb-operator-gke-version/source/e2e-tests/monitoring-2-0/compare/deployment_monitoring-mongos.yml	2021-02-24 14:20:36.000000000 +0000
+++ /tmp/tmp.y48SGaoAZY/deployment_monitoring-mongos.yml	2021-02-24 14:32:19.047396776 +0000
@@ -52,9 +52,9 @@
             - --bind_ip_all
             - --port=27017
             - --sslAllowInvalidCertificates
-            - --relaxPermChecks
             - --configdb
             - cfg/monitoring-cfg-0.monitoring-cfg.NAME_SPACE.svc.cluster.local:27017,monitoring-cfg-1.monitoring-cfg.NAME_SPACE.svc.cluster.local:27017,monitoring-cfg-2.monitoring-cfg.NAME_SPACE.svc.cluster.local:27017
+            - --relaxPermChecks
             - --sslMode=preferSSL
             - --clusterAuthMode=x509
           command:
```
https://cloud.cd.percona.com/job/psmdb-operator-gke-version/310/execution/node/115/log/