### PR TITLE
CLOUD-616 fix golangci-lint timeout issue

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -11,6 +11,7 @@ jobs:
         with:
           version: latest
           only-new-issues: true
+          args: --timeout 5m
 
   gofmt:
     name: runner / suggester / gofmt


### PR DESCRIPTION
[![CLOUD-616](https://badgen.net/badge/JIRA/CLOUD-616/green)](https://jira.percona.com/browse/CLOUD-616) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

