### PR TITLE
K8SPSMDB-386 fix: cluster status for enabled PITR without full backup

### DIFF
--- a/pkg/controller/perconaservermongodb/backup.go
+++ b/pkg/controller/perconaservermongodb/backup.go
@@ -231,7 +231,8 @@ func (r *ReconcilePerconaServerMongoDB) updatePITR(cr *api.PerconaServerMongoDB)
 		}
 
 		if !hasFullBackup {
-			return errors.New("Point-in-time recovery will work only with full backup. Please create one manually or wait for scheduled backup to be created (if configured).")
+			log.Info("Point-in-time recovery will work only with full backup. Please create one manually or wait for scheduled backup to be created (if configured).")
+			return nil
 		}
 	}
 


### PR DESCRIPTION
[![K8SPSMDB-386](https://badgen.net/badge/JIRA/K8SPSMDB-386/green)](https://jira.percona.com/browse/K8SPSMDB-386) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://jira.percona.com/browse/K8SPSMDB-386

Cluster with enabled PITR and no full backup has error status and requires a backup. But it's not possible to create a backup in such a cluster.

Also, as described in spec, the operator must try to enable PITR once there is a backup.