### PR TITLE
K8SPSMDB-430: checking UID before deleting sts

### DIFF
--- a/pkg/controller/perconaservermongodb/finalizers.go
+++ b/pkg/controller/perconaservermongodb/finalizers.go
@@ -5,7 +5,6 @@ import (
 
 	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
 	"github.com/pkg/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func (r *ReconcilePerconaServerMongoDB) checkFinalizers(cr *api.PerconaServerMongoDB) error {
@@ -45,15 +44,6 @@ func (r *ReconcilePerconaServerMongoDB) deletePvcFinalizer(cr *api.PerconaServer
 	return nil
 }
 
-func (r *ReconcilePerconaServerMongoDB) matchUID(cr *api.PerconaServerMongoDB, obj metav1.Object) bool {
-	if ref := metav1.GetControllerOf(obj); ref != nil {
-		if string(cr.GetUID()) == string(ref.UID) {
-			return true
-		}
-	}
-	return false
-}
-
 func (r *ReconcilePerconaServerMongoDB) deleteAllStatefulsets(cr *api.PerconaServerMongoDB) error {
 	stsList, err := r.getAllstatefulsets(cr)
 	if err != nil {
@@ -61,9 +51,6 @@ func (r *ReconcilePerconaServerMongoDB) deleteAllStatefulsets(cr *api.PerconaSer
 	}
 
 	for _, sts := range stsList.Items {
-		if !r.matchUID(cr, &sts) {
-			continue
-		}
 		log.Info("deleting StatefulSet", "name", sts.Name)
 		err := r.client.Delete(context.TODO(), &sts)
 		if err != nil {

--- a/pkg/controller/perconaservermongodb/finalizers.go
+++ b/pkg/controller/perconaservermongodb/finalizers.go
@@ -5,6 +5,7 @@ import (
 
 	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
 	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func (r *ReconcilePerconaServerMongoDB) checkFinalizers(cr *api.PerconaServerMongoDB) error {
@@ -44,6 +45,15 @@ func (r *ReconcilePerconaServerMongoDB) deletePvcFinalizer(cr *api.PerconaServer
 	return nil
 }
 
+func (r *ReconcilePerconaServerMongoDB) matchUID(cr *api.PerconaServerMongoDB, obj metav1.Object) bool {
+	if ref := metav1.GetControllerOf(obj); ref != nil {
+		if string(cr.GetUID()) == string(ref.UID) {
+			return true
+		}
+	}
+	return false
+}
+
 func (r *ReconcilePerconaServerMongoDB) deleteAllStatefulsets(cr *api.PerconaServerMongoDB) error {
 	stsList, err := r.getAllstatefulsets(cr)
 	if err != nil {
@@ -51,6 +61,9 @@ func (r *ReconcilePerconaServerMongoDB) deleteAllStatefulsets(cr *api.PerconaSer
 	}
 
 	for _, sts := range stsList.Items {
+		if !r.matchUID(cr, &sts) {
+			continue
+		}
 		log.Info("deleting StatefulSet", "name", sts.Name)
 		err := r.client.Delete(context.TODO(), &sts)
 		if err != nil {

--- a/pkg/controller/perconaservermongodb/getters.go
+++ b/pkg/controller/perconaservermongodb/getters.go
@@ -140,7 +140,7 @@ func (r *ReconcilePerconaServerMongoDB) getAllstatefulsets(cr *api.PerconaServer
 	)
 
 	for _, sts := range list.Items {
-		if !r.matchUID(cr, &sts) {
+		if r.matchUID(cr, &sts) {
 			filteredList.Items = append(filteredList.Items, sts)
 		}
 	}

--- a/pkg/controller/perconaservermongodb/getters.go
+++ b/pkg/controller/perconaservermongodb/getters.go
@@ -118,15 +118,6 @@ func (r *ReconcilePerconaServerMongoDB) getMongodStatefulsets(cr *api.PerconaSer
 	return list, err
 }
 
-func (r *ReconcilePerconaServerMongoDB) matchUID(cr *api.PerconaServerMongoDB, obj metav1.Object) bool {
-	if ref := metav1.GetControllerOf(obj); ref != nil {
-		if string(cr.GetUID()) == string(ref.UID) {
-			return true
-		}
-	}
-	return false
-}
-
 func (r *ReconcilePerconaServerMongoDB) getAllstatefulsets(cr *api.PerconaServerMongoDB) (appsv1.StatefulSetList, error) {
 	list := appsv1.StatefulSetList{}
 	filteredList := appsv1.StatefulSetList{}
@@ -140,7 +131,7 @@ func (r *ReconcilePerconaServerMongoDB) getAllstatefulsets(cr *api.PerconaServer
 	)
 
 	for _, sts := range list.Items {
-		if r.matchUID(cr, &sts) {
+		if metav1.IsControlledBy(&sts, cr) {
 			filteredList.Items = append(filteredList.Items, sts)
 		}
 	}


### PR DESCRIPTION
[![K8SPSMDB-430](https://badgen.net/badge/JIRA/K8SPSMDB-430/green)](https://jira.percona.com/browse/K8SPSMDB-430) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Fixing https://jira.percona.com/browse/K8SPSMDB-430
Double checking the UID of the controllerRef of the statefulset before deleting it in `deleteAllStatefulsets`.
It seems that PVC is not tagged with the controllerRef. We can later issue another patch to label PVC with UID of PerconaServerMongoDB and perform the check before deleting PVC.