### PR TITLE
K8SPSMDB-434 fixed by checking nil pointer before dereference

### DIFF
--- a/pkg/controller/perconaservermongodb/mgo.go
+++ b/pkg/controller/perconaservermongodb/mgo.go
@@ -81,6 +81,7 @@ func (r *ReconcilePerconaServerMongoDB) reconcileCluster(cr *api.PerconaServerMo
 		!rstRunning &&
 		cr.Status.Replsets[replset.Name].Initialized &&
 		cr.Status.Replsets[replset.Name].Status == api.AppStateReady &&
+		cr.Status.Mongos != nil &&
 		cr.Status.Mongos.Status == api.AppStateReady &&
 		replset.ClusterRole == api.ClusterRoleShardSvr &&
 		len(mongosPods) > 0 {


### PR DESCRIPTION
[![K8SPSMDB-434](https://badgen.net/badge/JIRA/K8SPSMDB-434/green)](https://jira.percona.com/browse/K8SPSMDB-434) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Fixing https://jira.percona.com/browse/K8SPSMDB-434

Checking nil pointer before dereferencing `cr.Status.Mongos`