### PR TITLE
K8SPSMDB-433 and  K8SPSMDB-438: label sts with rv and check before deletion

### DIFF
--- a/pkg/controller/perconaservermongodb/psmdb_controller.go
+++ b/pkg/controller/perconaservermongodb/psmdb_controller.go
@@ -948,9 +948,7 @@ func (r *ReconcilePerconaServerMongoDB) reconcileStatefulSet(arbiter bool, cr *a
 		return nil, errors.Wrapf(err, "get StatefulSet %s", sfs.Name)
 	}
 
-	if _, ok := matchLabels["app.kubernetes.io/owner-rv"]; ok {  // clear the rv label in matchLabels for each new sfs
-		delete(matchLabels, "app.kubernetes.io/owner-rv")
-	}
+	delete(matchLabels, "app.kubernetes.io/owner-rv")
 	if cr.CompareVersion("1.6.0") >= 0 { // For compatibility: sfs is only labeled when cr version >= 1.6.0
 		if k8serrors.IsNotFound(errGet) {
 			matchLabels["app.kubernetes.io/owner-rv"] = cr.ResourceVersion

--- a/pkg/controller/perconaservermongodb/psmdb_controller.go
+++ b/pkg/controller/perconaservermongodb/psmdb_controller.go
@@ -333,7 +333,7 @@ func (r *ReconcilePerconaServerMongoDB) Reconcile(request reconcile.Request) (re
 			"app.kubernetes.io/replset":    replset.Name,
 			"app.kubernetes.io/managed-by": "percona-server-mongodb-operator",
 			"app.kubernetes.io/part-of":    "percona-server-mongodb",
-			"app.kubernetes.io/owner-rv":	cr.ResourceVersion,
+			"app.kubernetes.io/owner-rv":   cr.ResourceVersion,
 		}
 
 		pods, err := r.getRSPods(cr, replset.Name)

--- a/pkg/controller/perconaservermongodb/psmdb_controller.go
+++ b/pkg/controller/perconaservermongodb/psmdb_controller.go
@@ -361,7 +361,7 @@ func (r *ReconcilePerconaServerMongoDB) Reconcile(request reconcile.Request) (re
 		} else {
 			sfs := appsv1.StatefulSet{}
 			err = r.client.Get(context.TODO(), types.NamespacedName{
-				Name: cr.Name+"-"+replset.Name+"-arbiter",
+				Name:      cr.Name + "-" + replset.Name + "-arbiter",
 				Namespace: cr.Namespace,
 			}, &sfs)
 			if err != nil && !k8serrors.IsNotFound(err) {


### PR DESCRIPTION
[![K8SPSMDB-433](https://badgen.net/badge/JIRA/K8SPSMDB-433/green)](https://jira.percona.com/browse/K8SPSMDB-433) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->
[![K8SPSMDB-438](https://badgen.net/badge/JIRA/K8SPSMDB-438/green)](https://jira.percona.com/browse/K8SPSMDB-438) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Fix https://jira.percona.com/browse/K8SPSMDB-433
Fix https://jira.percona.com/browse/K8SPSMDB-438
Label the rv to the statefulset when creation, and check whether PerconaServerMongoDB has a larger rv than the labeled one inside `reconcileStatefulSet`.