### PR TITLE
K8SPSMDB-455: Fix rollback after major upgrade

### DIFF
--- a/pkg/controller/perconaservermongodb/version.go
+++ b/pkg/controller/perconaservermongodb/version.go
@@ -108,11 +108,11 @@ func jobName(cr *api.PerconaServerMongoDB) string {
 func isUpdateValid(current, desired string) bool {
 	switch current {
 	case "3.6":
-		return desired == "4.0"
+		return desired == "3.6" || desired == "4.0"
 	case "4.0":
-		return desired == "4.2"
+		return desired == "4.0" || desired == "4.2"
 	case "4.2":
-		return desired == "4.4"
+		return desired == "4.2" || desired == "4.4"
 	default:
 		return false
 	}

--- a/pkg/controller/perconaservermongodb/version_test.go
+++ b/pkg/controller/perconaservermongodb/version_test.go
@@ -142,7 +142,7 @@ func Test_majorUpgradeRequested(t *testing.T) {
 				cr: &api.PerconaServerMongoDB{
 					Spec: api.PerconaServerMongoDBSpec{
 						UpgradeOptions: api.UpgradeOptions{
-							Apply: "4.0.4.0-recommended",
+							Apply: "3.7.4.0-recommended",
 						},
 					},
 					Status: api.PerconaServerMongoDBStatus{


### PR DESCRIPTION
[![K8SPSMDB-455](https://badgen.net/badge/JIRA/K8SPSMDB-455/green)](https://jira.percona.com/browse/K8SPSMDB-455) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

If cluster upgraded to next major version with setFCV false, mongod
binaries replaced with new version but FeatureCompabilityVersion remains
unchanged. If user tries to rollback to previous version operator won't
allow the operation due to our checks and user is forced to manually
set FCV twice. This change allows user to update the cluster to same
version as FCV.