### PR TITLE
K8SPSMDB-442 - fix rs-shard-migration and service-per-pod tests

### DIFF
--- a/e2e-tests/demand-backup-sharded/compare/deployment_some-name-mongos-4-oc.yml
+++ b/e2e-tests/demand-backup-sharded/compare/deployment_some-name-mongos-4-oc.yml
@@ -128,6 +128,9 @@ spec:
             - mountPath: /etc/mongodb-ssl-internal
               name: ssl-internal
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
+              readOnly: true
           workingDir: /data/db
         - args:
             - -c
@@ -174,3 +177,7 @@ spec:
             secretName: some-name-ssl-internal
         - emptyDir: {}
           name: mongod-data
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-some-name-users

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-cfg-4-oc.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-cfg-4-oc.yml
@@ -143,6 +143,8 @@ spec:
             - mountPath: /etc/mongodb-encryption
               name: some-name-mongodb-encryption-key
               readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
           workingDir: /data/db
         - args:
             - -c
@@ -220,6 +222,10 @@ spec:
             defaultMode: 288
             optional: true
             secretName: some-name-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-some-name-users
   updateStrategy:
     rollingUpdate:
       partition: 0

--- a/e2e-tests/limits/run
+++ b/e2e-tests/limits/run
@@ -24,7 +24,7 @@ check_cr_config() {
         | sed -e 's/500M/1G/' \
         | sed -e 's/0.5G/1G/' \
         | kubectl_bin apply -f-
-    sleep 10
+    sleep 20
 
     # check if statefulset was updated with expected config
     compare_kubectl statefulset/$cluster "-increased"

--- a/e2e-tests/rs-shard-migration/run
+++ b/e2e-tests/rs-shard-migration/run
@@ -57,7 +57,7 @@ function main() {
 
     desc 'Get back from sharded cluster to replicaset'
     kubectl_bin patch psmdb/${cluster} --type json -p='[{"op":"remove","path":"/spec/sharding"}]'
-    sleep 10
+    sleep 20
     wait_for_running "${cluster}-rs0" "${CLUSTER_SIZE}" "true"
 
     simple_data_check "${cluster}-rs0" "${CLUSTER_SIZE}"

--- a/e2e-tests/service-per-pod/run
+++ b/e2e-tests/service-per-pod/run
@@ -20,7 +20,7 @@ check_cr_config() {
     compare_kubectl service/$cluster-0
 
     local URI="$(get_service_ip $cluster-0),$(get_service_ip $cluster-1),$(get_service_ip $cluster-2)"
-    sleep 10
+    sleep 20
 
     # check read and write
     run_mongo \


### PR DESCRIPTION
[![K8SPSMDB-442](https://badgen.net/badge/JIRA/K8SPSMDB-442/green)](https://jira.percona.com/browse/K8SPSMDB-442) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Fixes rs-shard-migration and service-per-pod on openshift 4 and some sporadic failures in other environments.