### PR TITLE
K8SPSMDB-387: improve e2e pitr test (restore to date)

### DIFF
--- a/e2e-tests/pitr/compare/find-3rd.json
+++ b/e2e-tests/pitr/compare/find-3rd.json
@@ -1,4 +1,5 @@
 switched to db myApp
 { "_id" : , "x" : 100500 }
 { "_id" : , "x" : 100500 }
+{ "_id" : , "x" : 100501 }
 bye

--- a/e2e-tests/pitr/run
+++ b/e2e-tests/pitr/run
@@ -6,19 +6,25 @@ set -o xtrace
 test_dir=$(realpath $(dirname $0))
 . ${test_dir}/../functions
 
+write_document() {
+	local cmp_postfix=$1
+
+	run_mongo \
+		'use myApp\n db.test.insert({ x: 100500 })' \
+		"myApp:myPass@$cluster.$namespace"
+	sleep 10 # for minikube
+	compare_mongo_cmd "find" "myApp:myPass@$cluster-0.$cluster.$namespace" "$cmp_postfix"
+	compare_mongo_cmd "find" "myApp:myPass@$cluster-1.$cluster.$namespace" "$cmp_postfix"
+	compare_mongo_cmd "find" "myApp:myPass@$cluster-2.$cluster.$namespace" "$cmp_postfix"
+}
+
 write_initial_data() {
 	desc 'write initial data, read from all'
 	run_mongo \
 		'db.createUser({user:"myApp",pwd:"myPass",roles:[{db:"myApp",role:"readWrite"}]})' \
 		"userAdmin:userAdmin123456@$cluster.$namespace"
 	sleep 2
-	run_mongo \
-		'use myApp\n db.test.insert({ x: 100500 })' \
-		"myApp:myPass@$cluster.$namespace"
-	sleep 10 # for minikube
-	compare_mongo_cmd "find" "myApp:myPass@$cluster-0.$cluster.$namespace"
-	compare_mongo_cmd "find" "myApp:myPass@$cluster-1.$cluster.$namespace"
-	compare_mongo_cmd "find" "myApp:myPass@$cluster-2.$cluster.$namespace"
+	write_document
 }
 
 run_backup() {
@@ -93,13 +99,16 @@ main() {
 
 	run_backup $backup_name_minio 0
 
+	write_document "-2nd"
+	sleep 2
+
 	time_now=$(run_mongo 'new Date().toISOString()' "myApp:myPass@$cluster.$namespace" "mongodb" "" "--quiet" | grep -E -v 'I NETWORK|W NETWORK|Error saving history file|Percona Server for MongoDB|connecting to:|Unable to reach primary for set|Implicit session:|versions do not match' | cut -c1-19 | tr T " ")
 
-	check_recovery $backup_name_minio-0 date "$time_now"
+	check_recovery $backup_name_minio-0 date "$time_now" "-2nd"
 
 	run_backup $backup_name_minio 1
 
-	check_recovery $backup_name_minio-1 latest "" "-2nd"
+	check_recovery $backup_name_minio-1 latest "" "-3rd"
 
 	destroy $namespace
 }


### PR DESCRIPTION
[![K8SPSMDB-387](https://badgen.net/badge/JIRA/K8SPSMDB-387/green)](https://jira.percona.com/browse/K8SPSMDB-387) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://jira.percona.com/browse/K8SPSMDB-387

Fixes the same issue @dAdAbird mentioned in #637 but for PITR test in a non-sharded cluster