### PR TITLE
K8SPSMDB-365: Allow backups even if just a single node is available

### DIFF
--- a/pkg/apis/psmdb/v1/psmdb_types.go
+++ b/pkg/apis/psmdb/v1/psmdb_types.go
@@ -7,6 +7,7 @@ import (
 	v "github.com/hashicorp/go-version"
 	"github.com/percona/percona-backup-mongodb/pbm"
 	"github.com/percona/percona-server-mongodb-operator/version"
+	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -603,4 +604,22 @@ func (cr *PerconaServerMongoDB) StatefulsetNamespacedName(rsName string) types.N
 
 func (cr *PerconaServerMongoDB) MongosNamespacedName() types.NamespacedName {
 	return types.NamespacedName{Name: cr.Name + "-" + "mongos", Namespace: cr.Namespace}
+}
+
+func (cr *PerconaServerMongoDB) CanBackup() error {
+	if cr.Status.State == AppStateReady {
+		return nil
+	}
+
+	if !cr.Spec.UnsafeConf {
+		return errors.Errorf("allowUnsafeConfigurations must be true to run backup on cluster with status %s", cr.Status.State)
+	}
+
+	for rsName, rs := range cr.Status.Replsets {
+		if rs.Ready < int32(1) {
+			return errors.New(rsName + " has no ready nodes")
+		}
+	}
+
+	return nil
 }

--- a/pkg/controller/perconaservermongodbbackup/perconaservermongodbbackup_controller.go
+++ b/pkg/controller/perconaservermongodbbackup/perconaservermongodbbackup_controller.go
@@ -2,10 +2,10 @@ package perconaservermongodbbackup
 
 import (
 	"context"
-	"fmt"
+	"time"
+
 	"github.com/percona/percona-backup-mongodb/pbm"
 	"go.mongodb.org/mongo-driver/bson/primitive"
-	"time"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -157,8 +157,8 @@ func (r *ReconcilePerconaServerMongoDBBackup) reconcile(cr *psmdbv1.PerconaServe
 		return errors.Wrapf(err, "get cluster %s/%s", cr.Namespace, cr.Spec.PSMDBCluster)
 	}
 
-	if cluster.Status.State != api.AppStateReady {
-		return fmt.Errorf("failed to run backup on cluster with status %s", cluster.Status.State)
+	if err := cluster.CanBackup(); err != nil {
+		return errors.Wrap(err, "failed to run backup")
 	}
 
 	cjobs, err := backup.HasActiveJobs(r.client, cluster, backup.NewBackupJob(cr.Name), backup.NotPITRLock)


### PR DESCRIPTION
[![K8SPSMDB-365](https://badgen.net/badge/JIRA/K8SPSMDB-365/green)](https://jira.percona.com/browse/K8SPSMDB-365) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

