### PR TITLE
K8SPSMDB-488 - Fix diff in some e2e-tests on kubernetes 1.21

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -483,6 +483,8 @@ compare_kubectl() {
 		| yq d - '**.(name==PBM_AGENT_SERVER_ADDRESS)' \
 		| yq d - 'spec.volumeClaimTemplates.*.apiVersion' \
 		| yq d - 'spec.volumeClaimTemplates.*.kind' \
+		| yq d - 'spec.ipFamilies' \
+		| yq d - 'spec.ipFamilyPolicy' \
 		| $sed "s/${namespace}/NAME_SPACE/g" \
 		| $sed "s#^apiVersion: extensions/v1beta1#apiVersion: apps/v1#" \
 			>${new_result}


### PR DESCRIPTION
[![K8SPSMDB-488](https://badgen.net/badge/JIRA/K8SPSMDB-488/green)](https://jira.percona.com/browse/K8SPSMDB-488) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Several tests are failing on kubernetes 1.21 like this:
```
+ diff -u /mnt/jenkins/workspace/psmdb-operator-gke-version/source/e2e-tests/monitoring-2-0/compare/service_monitoring-rs0.yml /tmp/tmp.3ptFKa1i6I/service_monitoring-rs0.yml
--- /mnt/jenkins/workspace/psmdb-operator-gke-version/source/e2e-tests/monitoring-2-0/compare/service_monitoring-rs0.yml	2021-06-14 08:00:27.000000000 +0000
+++ /tmp/tmp.3ptFKa1i6I/service_monitoring-rs0.yml	2021-06-14 08:17:46.625177446 +0000
@@ -8,6 +8,9 @@
       kind: PerconaServerMongoDB
       name: monitoring
 spec:
+  ipFamilies:
+    - IPv4
+  ipFamilyPolicy: SingleStack
   ports:
     - name: mongodb
       port: 27017
```