### PR TITLE
K8SPSMDB-488 - Remove operationProfiling option from mongos (not supported)

### DIFF
--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -224,8 +224,6 @@ spec:
       size: 3
 #      # for more configuration fields refer to https://docs.mongodb.com/manual/reference/configuration-options/
 #      configuration: |
-#        operationProfiling:
-#          mode: slowOp
 #        systemLog:
 #           verbosity: 1
       affinity:


### PR DESCRIPTION
[![K8SPSMDB-488](https://badgen.net/badge/JIRA/K8SPSMDB-488/green)](https://jira.percona.com/browse/K8SPSMDB-488) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This removes the operationProfiling.mode option from custom config example for `mongos` since this is something that can only be configured for `mongod`, so the error was visible:
```
+ exec mongos --bind_ip_all --port=27017 --configdb cfg/my-cluster-name-cfg-0.my-cluster-name-cfg.psmdb-test.svc.cluster.local:27017,my-cluster-name-cfg-1.my-cluster-name-cfg.psmdb-test.svc.cluster.local:27017,my-cluster-name-cfg-2.my-cluster-name-cfg.psmdb-test.svc.cluster.local:27017 --relaxPermChecks --clusterAuthMode=x509 --config=/etc/mongos-config/mongos.conf --tlsMode preferTLS --tlsCertificateKeyFile /tmp/tls.pem --tlsAllowInvalidCertificates --tlsClusterFile /tmp/tls-internal.pem --tlsCAFile /etc/mongodb-ssl/ca.crt --tlsClusterCAFile /etc/mongodb-ssl-internal/ca.crt
Unrecognized option: operationProfiling.mode
try 'mongos --help' for more information
```