### PR TITLE
K8SPSMDB-488 - Fix runtimeclass handler for EKS in e2e-tests

### DIFF
--- a/e2e-tests/demand-backup-sharded/run
+++ b/e2e-tests/demand-backup-sharded/run
@@ -18,7 +18,7 @@ kubectl_bin apply \
 	-f "$conf_dir/client.yml"
 
 apply_s3_storage_secrets
-if [[ $(version_gt "1.19") && $EKS -ne 1 ]]; then
+if version_gt "1.19" && [ $EKS -ne 1 ]; then
 	cat "$conf_dir/container-rc.yaml" | $sed 's/docker/runc/g' | kubectl_bin apply -f -
 else
 	kubectl_bin apply -f "$conf_dir/container-rc.yaml"

--- a/e2e-tests/demand-backup-sharded/run
+++ b/e2e-tests/demand-backup-sharded/run
@@ -14,13 +14,13 @@ deploy_minio
 desc 'create first PSMDB cluster'
 cluster="some-name"
 kubectl_bin apply \
-    -f "$conf_dir/secrets.yml" \
-    -f "$conf_dir/client.yml"
+	-f "$conf_dir/secrets.yml" \
+	-f "$conf_dir/client.yml"
 
 apply_s3_storage_secrets
-if [[ ${OPENSHIFT} == 4 ]] || [[ $(echo "$KUBE_VERSION >= 1.19" | bc -l) -eq 1 ]]; then
+if [[ $(version_gt "1.19") && $EKS -ne 1 ]]; then
 	cat "$conf_dir/container-rc.yaml" | $sed 's/docker/runc/g' | kubectl_bin apply -f -
-elif [[ -z ${OPENSHIFT} ]]; then
+else
 	kubectl_bin apply -f "$conf_dir/container-rc.yaml"
 fi
 
@@ -39,12 +39,12 @@ compare_kubectl deployment/$cluster-mongos ""
 
 desc 'write data, read from all'
 run_mongos \
-    'db.createUser({user:"myApp",pwd:"myPass",roles:[{db:"myApp",role:"readWrite"}]})' \
-    "userAdmin:userAdmin123456@$cluster-mongos.$namespace"
+	'db.createUser({user:"myApp",pwd:"myPass",roles:[{db:"myApp",role:"readWrite"}]})' \
+	"userAdmin:userAdmin123456@$cluster-mongos.$namespace"
 sleep 2
 run_mongos \
-    'use myApp\n db.test.insert({ x: 100500 })' \
-    "myApp:myPass@$cluster-mongos.$namespace"
+	'use myApp\n db.test.insert({ x: 100500 })' \
+	"myApp:myPass@$cluster-mongos.$namespace"
 sleep 10 # for minikube
 compare_mongos_cmd "find" "myApp:myPass@$cluster-mongos.$namespace"
 
@@ -64,40 +64,38 @@ backup_name_gcp="backup-gcp-cs"
 desc 'run backups'
 run_backup minio
 if [ -z "$SKIP_BACKUPS_TO_AWS_GCP" ]; then
-    run_backup aws-s3
-    run_backup gcp-cs
+	run_backup aws-s3
+	run_backup gcp-cs
 
-    wait_backup "$backup_name_aws"
-    wait_backup "$backup_name_gcp"
+	wait_backup "$backup_name_aws"
+	wait_backup "$backup_name_gcp"
 fi
 wait_backup "$backup_name_minio"
 
 sleep 5
 
 if [ -z "$SKIP_BACKUPS_TO_AWS_GCP" ]; then
-    desc 'check backup and restore -- aws-s3'
-    backup_dest_aws=$(get_backup_dest "$backup_name_aws")
-    curl -s "https://s3.amazonaws.com/operator-testing/${backup_dest_aws}_rs0.dump.gz" | gunzip >/dev/null
-    run_restore $backup_name_aws 3 1 "-mongos"
-    wait_restore $backup_name_aws 3 1 "-mongos"
+	desc 'check backup and restore -- aws-s3'
+	backup_dest_aws=$(get_backup_dest "$backup_name_aws")
+	curl -s "https://s3.amazonaws.com/operator-testing/${backup_dest_aws}_rs0.dump.gz" | gunzip >/dev/null
+	run_restore $backup_name_aws 3 1 "-mongos"
+	wait_restore $backup_name_aws 3 1 "-mongos"
 
-    desc 'check backup and restore -- gcp-cs'
-    backup_dest_gcp=$(get_backup_dest "$backup_name_gcp")
-    curl -s "https://storage.googleapis.com/operator-testing/${backup_dest_gcp}_rs0.dump.gz" | gunzip >/dev/null
-    run_restore $backup_name_gcp 3 1 "-mongos"
-    wait_restore $backup_name_gcp 3 1 "-mongos"
+	desc 'check backup and restore -- gcp-cs'
+	backup_dest_gcp=$(get_backup_dest "$backup_name_gcp")
+	curl -s "https://storage.googleapis.com/operator-testing/${backup_dest_gcp}_rs0.dump.gz" | gunzip >/dev/null
+	run_restore $backup_name_gcp 3 1 "-mongos"
+	wait_restore $backup_name_gcp 3 1 "-mongos"
 fi
 
 desc 'check backup and restore -- minio'
 backup_dest_minio=$(get_backup_dest "$backup_name_minio")
 kubectl_bin run -i --rm aws-cli --image=perconalab/awscli --restart=Never -- \
-    /usr/bin/env AWS_ACCESS_KEY_ID=some-access-key AWS_SECRET_ACCESS_KEY=some-secret-key AWS_DEFAULT_REGION=us-east-1 \
-    /usr/bin/aws --endpoint-url http://minio-service:9000 s3 ls "s3://operator-testing/${backup_dest_minio}" |
-    grep "${backup_dest_minio}_rs0.dump.gz"
+	/usr/bin/env AWS_ACCESS_KEY_ID=some-access-key AWS_SECRET_ACCESS_KEY=some-secret-key AWS_DEFAULT_REGION=us-east-1 \
+	/usr/bin/aws --endpoint-url http://minio-service:9000 s3 ls "s3://operator-testing/${backup_dest_minio}" \
+	| grep "${backup_dest_minio}_rs0.dump.gz"
 run_restore $backup_name_minio 3 1 "-mongos"
 wait_restore $backup_name_minio 3 1 "-mongos"
 
-if [[ "$OPENSHIFT" != "3.11" ]]; then
-  kubectl_bin delete -f "$conf_dir/container-rc.yaml"
-fi
+kubectl_bin delete -f "$conf_dir/container-rc.yaml"
 destroy "$namespace"

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -32,6 +32,12 @@ if oc get projects; then
 	esac
 fi
 
+if [ $(kubectl version -o json | jq -r '.serverVersion.gitVersion' | grep "\-eks\-") ]; then
+	EKS=1
+else
+	EKS=0
+fi
+
 KUBE_VERSION=$(kubectl version -o json | jq -r '.serverVersion.major + "." + .serverVersion.minor' | $sed -r 's/[^0-9.]+//g')
 
 version_gt() {

--- a/e2e-tests/init-deploy/run
+++ b/e2e-tests/init-deploy/run
@@ -17,9 +17,9 @@ kubectl_bin apply \
 	-f $conf_dir/secrets.yml \
 	-f $conf_dir/client.yml
 
-if [[ ${OPENSHIFT} == 4 ]] || [[ $(echo "$KUBE_VERSION >= 1.19" | bc -l) -eq 1 ]]; then
+if [[ $(version_gt "1.19") && $EKS -ne 1 ]]; then
 	cat "$conf_dir/container-rc.yaml" | $sed 's/docker/runc/g' | kubectl_bin apply -f -
-elif [[ -z ${OPENSHIFT} ]]; then
+else
 	kubectl_bin apply -f "$conf_dir/container-rc.yaml"
 fi
 
@@ -37,25 +37,25 @@ compare_mongo_user "backup:backup123456@$cluster.$namespace"
 compare_mongo_user "clusterAdmin:clusterAdmin123456@$cluster.$namespace"
 compare_mongo_user "clusterMonitor:clusterMonitor123456@$cluster.$namespace"
 # check that test user don't have access
-( run_mongo 'db.runCommand({connectionStatus:1,showPrivileges:true})' "test:test@$cluster.$namespace" || :) 2>&1 \
-    | grep 'Authentication failed'
+(run_mongo 'db.runCommand({connectionStatus:1,showPrivileges:true})' "test:test@$cluster.$namespace" || :) 2>&1 \
+	| grep 'Authentication failed'
 
 desc 'write data, read from all'
 run_mongo \
-    'db.createUser({user:"myApp",pwd:"myPass",roles:[{db:"myApp",role:"readWrite"}]})' \
-    "userAdmin:userAdmin123456@$cluster.$namespace"
+	'db.createUser({user:"myApp",pwd:"myPass",roles:[{db:"myApp",role:"readWrite"}]})' \
+	"userAdmin:userAdmin123456@$cluster.$namespace"
 sleep 2
 run_mongo \
-    'use myApp\n db.test.insert({ x: 100500 })' \
-    "myApp:myPass@$cluster.$namespace"
+	'use myApp\n db.test.insert({ x: 100500 })' \
+	"myApp:myPass@$cluster.$namespace"
 compare_mongo_cmd "find" "myApp:myPass@$cluster-0.$cluster.$namespace"
 compare_mongo_cmd "find" "myApp:myPass@$cluster-1.$cluster.$namespace"
 compare_mongo_cmd "find" "myApp:myPass@$cluster-2.$cluster.$namespace"
 
 desc 'check number of connections'
 conn_count=$(run_mongo 'db.serverStatus().connections.current' "clusterAdmin:clusterAdmin123456@$cluster.$namespace" | egrep -v 'I NETWORK|W NETWORK|Error saving history file|Percona Server for MongoDB|connecting to:|Unable to reach primary for set|Implicit session:|versions do not match|bye')
-if [ ${conn_count} -gt ${max_conn} ];then
-  exit 1
+if [ ${conn_count} -gt ${max_conn} ]; then
+	exit 1
 fi
 
 desc 'kill Primary Pod, check reelection, check data'
@@ -65,8 +65,8 @@ wait_for_running $cluster 3
 changed_primary=$(get_mongo_primary "clusterAdmin:clusterAdmin123456@$cluster.$namespace" "$cluster")
 [ "$initial_primary" != "$changed_primary" ]
 run_mongo \
-    'use myApp\n db.test.insert({ x: 100501 })' \
-    "myApp:myPass@$cluster.$namespace"
+	'use myApp\n db.test.insert({ x: 100501 })' \
+	"myApp:myPass@$cluster.$namespace"
 compare_mongo_cmd "find" "myApp:myPass@$cluster-0.$cluster.$namespace" "-2nd"
 compare_mongo_cmd "find" "myApp:myPass@$cluster-1.$cluster.$namespace" "-2nd"
 compare_mongo_cmd "find" "myApp:myPass@$cluster-2.$cluster.$namespace" "-2nd"
@@ -82,13 +82,14 @@ compare_kubectl service/$cluster2
 
 desc 'write data, read from all'
 run_mongo \
-    'db.createUser({user:"myApp",pwd:"myPass",roles:[{db:"myApp",role:"readWrite"}]})' \
-    "userAdmin:userAdmin123456@$cluster2.$namespace"
+	'db.createUser({user:"myApp",pwd:"myPass",roles:[{db:"myApp",role:"readWrite"}]})' \
+	"userAdmin:userAdmin123456@$cluster2.$namespace"
 run_mongo \
-    'use myApp\n db.test.insert({ x: 100502 })' \
-    "myApp:myPass@$cluster2.$namespace"
+	'use myApp\n db.test.insert({ x: 100502 })' \
+	"myApp:myPass@$cluster2.$namespace"
 compare_mongo_cmd "find" "myApp:myPass@$cluster2-0.$cluster2.$namespace" "-3rd"
 compare_mongo_cmd "find" "myApp:myPass@$cluster2-1.$cluster2.$namespace" "-3rd"
 compare_mongo_cmd "find" "myApp:myPass@$cluster2-2.$cluster2.$namespace" "-3rd"
 
+kubectl_bin delete -f "$conf_dir/container-rc.yaml"
 destroy $namespace

--- a/e2e-tests/init-deploy/run
+++ b/e2e-tests/init-deploy/run
@@ -17,7 +17,7 @@ kubectl_bin apply \
 	-f $conf_dir/secrets.yml \
 	-f $conf_dir/client.yml
 
-if [[ $(version_gt "1.19") && $EKS -ne 1 ]]; then
+if version_gt "1.19" && [ $EKS -ne 1 ]; then
 	cat "$conf_dir/container-rc.yaml" | $sed 's/docker/runc/g' | kubectl_bin apply -f -
 else
 	kubectl_bin apply -f "$conf_dir/container-rc.yaml"

--- a/e2e-tests/pitr-sharded/run
+++ b/e2e-tests/pitr-sharded/run
@@ -85,7 +85,7 @@ main() {
 		-f "$conf_dir/client.yml" \
 		-f $conf_dir/minio-secret.yml
 
-	if [[ $(version_gt "1.19") && $EKS -ne 1 ]]; then
+	if version_gt "1.19" && [ $EKS -ne 1 ]; then
 		cat "$conf_dir/container-rc.yaml" | $sed 's/docker/runc/g' | kubectl_bin apply -f -
 	else
 		kubectl_bin apply -f "$conf_dir/container-rc.yaml"

--- a/e2e-tests/pitr-sharded/run
+++ b/e2e-tests/pitr-sharded/run
@@ -85,9 +85,9 @@ main() {
 		-f "$conf_dir/client.yml" \
 		-f $conf_dir/minio-secret.yml
 
-	if [[ ${OPENSHIFT} == 4 ]]; then
+	if [[ $(version_gt "1.19") && $EKS -ne 1 ]]; then
 		cat "$conf_dir/container-rc.yaml" | $sed 's/docker/runc/g' | kubectl_bin apply -f -
-	elif [[ -z ${OPENSHIFT} ]]; then
+	else
 		kubectl_bin apply -f "$conf_dir/container-rc.yaml"
 	fi
 
@@ -132,9 +132,7 @@ main() {
 
 	check_recovery $backup_name_minio-1 latest "" "-3rd"
 
-	if [[ $OPENSHIFT != "3.11" ]]; then
-		kubectl_bin delete -f "$conf_dir/container-rc.yaml"
-	fi
+	kubectl_bin delete -f "$conf_dir/container-rc.yaml"
 	destroy $namespace
 }
 


### PR DESCRIPTION
[![K8SPSMDB-488](https://badgen.net/badge/JIRA/K8SPSMDB-488/green)](https://jira.percona.com/browse/K8SPSMDB-488) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

I'm seeing following issue on EKS 1.20:
`Warning  FailedCreatePodSandBox  60s (x71 over 16m)  kubelet                  Failed to create pod sandbox: rpc error: code = Unknown desc = RuntimeHandler "runc" not supported`
so this will continue to use `docker` instead of `runc` on EKS.