### PR TITLE
K8SPSMDB-488 - Fix security-context and scheduled-backup tests

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -493,6 +493,7 @@ compare_kubectl() {
 		| yq d - 'spec.ipFamilyPolicy' \
 		| $sed "s/${namespace}/NAME_SPACE/g" \
 		| $sed "s#^apiVersion: extensions/v1beta1#apiVersion: apps/v1#" \
+		| $sed "s#^apiVersion: batch/v1beta1#apiVersion: batch/v1#" \
 			>${new_result}
 
 	diff -u "$expected_result" "$new_result"

--- a/e2e-tests/scheduled-backup/compare/cronjob_some-name-backup-every-min-aws-s3-oc.yml
+++ b/e2e-tests/scheduled-backup/compare/cronjob_some-name-backup-every-min-aws-s3-oc.yml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   annotations: {}

--- a/e2e-tests/scheduled-backup/compare/cronjob_some-name-backup-every-min-aws-s3.yml
+++ b/e2e-tests/scheduled-backup/compare/cronjob_some-name-backup-every-min-aws-s3.yml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   annotations: {}

--- a/e2e-tests/scheduled-backup/compare/cronjob_some-name-backup-every-min-gcp-cs-oc.yml
+++ b/e2e-tests/scheduled-backup/compare/cronjob_some-name-backup-every-min-gcp-cs-oc.yml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   annotations: {}

--- a/e2e-tests/scheduled-backup/compare/cronjob_some-name-backup-every-min-gcp-cs.yml
+++ b/e2e-tests/scheduled-backup/compare/cronjob_some-name-backup-every-min-gcp-cs.yml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   annotations: {}

--- a/e2e-tests/scheduled-backup/compare/cronjob_some-name-backup-every-min-minio-oc.yml
+++ b/e2e-tests/scheduled-backup/compare/cronjob_some-name-backup-every-min-minio-oc.yml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   annotations: {}

--- a/e2e-tests/scheduled-backup/compare/cronjob_some-name-backup-every-min-minio.yml
+++ b/e2e-tests/scheduled-backup/compare/cronjob_some-name-backup-every-min-minio.yml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   annotations: {}

--- a/e2e-tests/security-context/compare/cronjob.batch_sec-context-backup-each-hour.yml
+++ b/e2e-tests/security-context/compare/cronjob.batch_sec-context-backup-each-hour.yml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   annotations: {}


### PR DESCRIPTION
[![K8SPSMDB-488](https://badgen.net/badge/JIRA/K8SPSMDB-488/green)](https://jira.percona.com/browse/K8SPSMDB-488) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

`security-context` and `scheduled-backup` tests are failing on 1.21 with:
```
+ diff -u /mnt/jenkins/workspace/psmdb-operator-gke-version/source/e2e-tests/security-context/compare/cronjob.batch_sec-context-backup-each-hour.yml /tmp/tmp.1OtgrJU1dl/cronjob.batch_sec-context-backup-each-hour.yml
--- /mnt/jenkins/workspace/psmdb-operator-gke-version/source/e2e-tests/security-context/compare/cronjob.batch_sec-context-backup-each-hour.yml	2021-06-18 09:10:11.000000000 +0000
+++ /tmp/tmp.1OtgrJU1dl/cronjob.batch_sec-context-backup-each-hour.yml	2021-06-18 09:42:57.285287185 +0000
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   annotations: {}
```