### PR TITLE
K8SPSMDB-488 - Fix version-service test for minikube

### DIFF
--- a/e2e-tests/version-service/conf/version-service-exact-rs0.yml
+++ b/e2e-tests/version-service/conf/version-service-exact-rs0.yml
@@ -2,6 +2,8 @@ apiVersion: psmdb.percona.com/v1
 kind: PerconaServerMongoDB
 metadata:
   name: version-service-exact
+  finalizers:
+    - delete-psmdb-pvc
 spec:
   image:
   initImage: #initImage

--- a/e2e-tests/version-service/conf/version-service-latest-rs0.yml
+++ b/e2e-tests/version-service/conf/version-service-latest-rs0.yml
@@ -2,6 +2,8 @@ apiVersion: psmdb.percona.com/v1
 kind: PerconaServerMongoDB
 metadata:
   name: version-service-latest
+  finalizers:
+    - delete-psmdb-pvc
 spec:
   image:
   initImage: #initImage

--- a/e2e-tests/version-service/conf/version-service-major-rs0.yml
+++ b/e2e-tests/version-service/conf/version-service-major-rs0.yml
@@ -2,6 +2,8 @@ apiVersion: psmdb.percona.com/v1
 kind: PerconaServerMongoDB
 metadata:
   name: version-service-major
+  finalizers:
+    - delete-psmdb-pvc
 spec:
   image:
   initImage: #initImage

--- a/e2e-tests/version-service/conf/version-service-recommended-rs0.yml
+++ b/e2e-tests/version-service/conf/version-service-recommended-rs0.yml
@@ -2,6 +2,8 @@ apiVersion: psmdb.percona.com/v1
 kind: PerconaServerMongoDB
 metadata:
   name: version-service-recommended
+  finalizers:
+    - delete-psmdb-pvc
 spec:
   image:
   initImage: #initImage

--- a/e2e-tests/version-service/conf/version-service-unreachable-rs0.yml
+++ b/e2e-tests/version-service/conf/version-service-unreachable-rs0.yml
@@ -2,6 +2,8 @@ apiVersion: psmdb.percona.com/v1
 kind: PerconaServerMongoDB
 metadata:
   name: version-service-unreachable
+  finalizers:
+    - delete-psmdb-pvc
 spec:
   image:
   initImage: #initImage


### PR DESCRIPTION
[![K8SPSMDB-488](https://badgen.net/badge/JIRA/K8SPSMDB-488/green)](https://jira.percona.com/browse/K8SPSMDB-488) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Jenkins nodes don't have too much space in `/tmp` and seems minikube is storing stuff inside `/tmp/hostpath-provisioner`
so sometimes tests start failing with disk space issue.
We already added cleanup before every test, but since this test is running several tests inside one test the cleanup doesn't start so this is adding finalizer for pvc's.