### PR TITLE
K8SPSMDB-504: Fix cluster failure if replset exposed with LoadBalancer

### DIFF
--- a/pkg/controller/perconaservermongodb/status.go
+++ b/pkg/controller/perconaservermongodb/status.go
@@ -348,7 +348,7 @@ func (r *ReconcilePerconaServerMongoDB) connectionEndpoint(cr *api.PerconaServer
 		}
 		addrs, err := psmdb.GetReplsetAddrs(r.client, cr, rs.Name, rs.Expose.Enabled, list.Items)
 		if err != nil {
-			return "", err
+			return "", errors.Wrap(err, "get replset addresses")
 		}
 		return strings.Join(addrs, ","), nil
 	}


### PR DESCRIPTION
[![K8SPSMDB-504](https://badgen.net/badge/JIRA/K8SPSMDB-504/green)](https://jira.percona.com/browse/K8SPSMDB-504) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This commit fixes a sporadic bug. It occurs as follows:

1. You apply the CR with replset is exposed with LoadBalancer type and
   sharding disabled.
2. Operator creates the statefulset and first pod is created.
3. A service with type LoadBalancer and same name as pod is created.
   Then, operator blocks the reconciliation until an external IP is
   assigned to LoadBalancer or reaches timeout.
4. Second pod is created while waiting the service of the first pod but in
   this time window second pod never becomes ready and operator starts
   to wait for the IP of the second LoadBalancer.
5. After the second load balancer gets its IP reconciliation continues
   and replset is initialized before the third service is created. Then,
   operator tries to create system users and fails get external hostname
   for last pod.
6. Since we consider replset as initialized only after creating system
   users, operator tries to initialize the replset again and cluster
   crashes with various errors.

The bug is sporadic because if the second pod is created and becomes
ready while waiting the external IP for the service of first pod, third
pod and service is created and it doesn't occur.