### PR TITLE
K8SPSMDB-506: Fix restarting primary pod on smart update

### DIFF
--- a/pkg/controller/perconaservermongodb/smart.go
+++ b/pkg/controller/perconaservermongodb/smart.go
@@ -3,11 +3,8 @@ package perconaservermongodb
 import (
 	"context"
 	"fmt"
-	"sort"
-	"strings"
-	"time"
-
 	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
+	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb"
 	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb/backup"
 	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb/mongo"
 	"github.com/pkg/errors"
@@ -17,7 +14,10 @@ import (
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sort"
+	"strings"
+	"time"
 )
 
 func (r *ReconcilePerconaServerMongoDB) smartUpdate(cr *api.PerconaServerMongoDB, sfs *appsv1.StatefulSet,
@@ -88,7 +88,7 @@ func (r *ReconcilePerconaServerMongoDB) smartUpdate(cr *api.PerconaServerMongoDB
 	list := corev1.PodList{}
 	if err := r.client.List(context.TODO(),
 		&list,
-		&client.ListOptions{
+		&k8sclient.ListOptions{
 			Namespace: cr.Namespace,
 			LabelSelector: labels.SelectorFromSet(map[string]string{
 				"app.kubernetes.io/name":       "percona-server-mongodb",
@@ -129,26 +129,38 @@ func (r *ReconcilePerconaServerMongoDB) smartUpdate(cr *api.PerconaServerMongoDB
 
 	var primaryPod corev1.Pod
 	for _, pod := range list.Items {
-		pod := pod
+		if replset.Expose.Enabled {
+			host, err := psmdb.MongoHost(r.client, cr, replset.Name, replset.Expose.Enabled, pod)
+			if err != nil {
+				return errors.Wrapf(err, "get mongo host for pod %s", pod.Name)
+			}
+
+			if host == primary {
+				primaryPod = pod
+				continue
+			}
+		}
+
 		if strings.HasPrefix(primary, fmt.Sprintf("%s.%s.%s", pod.Name, sfs.Name, sfs.Namespace)) {
 			primaryPod = pod
-		} else {
-			log.Info(fmt.Sprintf("apply changes to secondary pod %s", pod.Name))
+			continue
+		}
 
-			updateRevision := sfs.Status.UpdateRevision
+		log.Info(fmt.Sprintf("apply changes to secondary pod %s", pod.Name))
 
-			if pod.Labels["app.kubernetes.io/component"] == "arbiter" {
-				arbiterSfs, err := r.getArbiterStatefulset(cr, pod.Labels["app.kubernetes.io/replset"])
-				if err != nil {
-					return errors.Wrap(err, "failed to get arbiter statefilset")
-				}
+		updateRevision := sfs.Status.UpdateRevision
 
-				updateRevision = arbiterSfs.Status.UpdateRevision
+		if pod.Labels["app.kubernetes.io/component"] == "arbiter" {
+			arbiterSfs, err := r.getArbiterStatefulset(cr, pod.Labels["app.kubernetes.io/replset"])
+			if err != nil {
+				return errors.Wrap(err, "failed to get arbiter statefilset")
 			}
 
-			if err := r.applyNWait(cr, updateRevision, &pod, waitLimit); err != nil {
-				return fmt.Errorf("failed to apply changes: %v", err)
-			}
+			updateRevision = arbiterSfs.Status.UpdateRevision
+		}
+
+		if err := r.applyNWait(cr, updateRevision, &pod, waitLimit); err != nil {
+			return errors.Wrap(err, "failed to apply changes")
 		}
 	}
 
@@ -172,7 +184,7 @@ func (r *ReconcilePerconaServerMongoDB) smartUpdate(cr *api.PerconaServerMongoDB
 func (r *ReconcilePerconaServerMongoDB) isAllSfsUpToDate(cr *api.PerconaServerMongoDB) (bool, error) {
 	sfsList := appsv1.StatefulSetList{}
 	if err := r.client.List(context.TODO(), &sfsList,
-		&client.ListOptions{
+		&k8sclient.ListOptions{
 			Namespace: cr.Namespace,
 			LabelSelector: labels.SelectorFromSet(map[string]string{
 				"app.kubernetes.io/instance": cr.Name,

--- a/pkg/controller/perconaservermongodb/smart.go
+++ b/pkg/controller/perconaservermongodb/smart.go
@@ -3,6 +3,10 @@ package perconaservermongodb
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strings"
+	"time"
+
 	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
 	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb"
 	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb/backup"
@@ -15,9 +19,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
-	"sort"
-	"strings"
-	"time"
 )
 
 func (r *ReconcilePerconaServerMongoDB) smartUpdate(cr *api.PerconaServerMongoDB, sfs *appsv1.StatefulSet,

--- a/pkg/psmdb/mongo/mongo.go
+++ b/pkg/psmdb/mongo/mongo.go
@@ -71,7 +71,7 @@ func ReadConfig(ctx context.Context, client *mongo.Client) (RSConfig, error) {
 		return RSConfig{}, errors.Wrap(res.Err(), "replSetGetConfig")
 	}
 	if err := res.Decode(&resp); err != nil {
-		return RSConfig{}, errors.Wrap(err, "failed to decoge to replSetGetConfig")
+		return RSConfig{}, errors.Wrap(err, "failed to decode to replSetGetConfig")
 	}
 
 	if resp.Config == nil {
@@ -170,7 +170,7 @@ func WriteConfig(ctx context.Context, client *mongo.Client, cfg RSConfig) error 
 	}
 
 	if err := res.Decode(&resp); err != nil {
-		return errors.Wrap(err, "failed to decoge to replSetReconfigResponse")
+		return errors.Wrap(err, "failed to decode to replSetReconfigResponse")
 	}
 
 	if resp.OK != 1 {


### PR DESCRIPTION
[![K8SPSMDB-506](https://badgen.net/badge/JIRA/K8SPSMDB-506/green)](https://jira.percona.com/browse/K8SPSMDB-506) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

We try to decide which pod is primary by running `rs.status()` and
getting `name` field of PRIMARY. If replset is not exposed `name` is
local FQDN of service and since service name and pod name is the same, we
can select the right pod. But if replset is exposed, node names are
external hostnames and selecting the primary pod is not straightforward.
We need to get the external address of each pod in the replset and
compare with primary host.