### PR TITLE
K8SPSMDB-512: Add CustomWriteConcern type

### DIFF
--- a/pkg/psmdb/mongo/models.go
+++ b/pkg/psmdb/mongo/models.go
@@ -15,6 +15,9 @@ const (
 // Replica Set tags: https://docs.mongodb.com/manual/tutorial/configure-replica-set-tag-sets/#add-tag-sets-to-a-replica-set
 type ReplsetTags map[string]string
 
+// Custom Write Concern: https://docs.mongodb.com/manual/tutorial/configure-replica-set-tag-sets/#custom-multi-datacenter-write-concerns
+type CustomWriteConcern map[string]int
+
 // RSMember document from 'replSetGetConfig': https://docs.mongodb.com/manual/reference/command/replSetGetConfig/#dbcmd.replSetGetConfig
 type ConfigMember struct {
 	ID           int         `bson:"_id" json:"_id"`
@@ -42,14 +45,14 @@ type RSConfig struct {
 
 // Settings document from 'replSetGetConfig': https://docs.mongodb.com/manual/reference/command/replSetGetConfig/#dbcmd.replSetGetConfig
 type Settings struct {
-	ChainingAllowed         bool                   `bson:"chainingAllowed,omitempty" json:"chainingAllowed,omitempty"`
-	HeartbeatIntervalMillis int64                  `bson:"heartbeatIntervalMillis,omitempty" json:"heartbeatIntervalMillis,omitempty"`
-	HeartbeatTimeoutSecs    int                    `bson:"heartbeatTimeoutSecs,omitempty" json:"heartbeatTimeoutSecs,omitempty"`
-	ElectionTimeoutMillis   int64                  `bson:"electionTimeoutMillis,omitempty" json:"electionTimeoutMillis,omitempty"`
-	CatchUpTimeoutMillis    int64                  `bson:"catchUpTimeoutMillis,omitempty" json:"catchUpTimeoutMillis,omitempty"`
-	GetLastErrorModes       map[string]ReplsetTags `bson:"getLastErrorModes,omitempty" json:"getLastErrorModes,omitempty"`
-	GetLastErrorDefaults    WriteConcern           `bson:"getLastErrorDefaults,omitempty" json:"getLastErrorDefaults,omitempty"`
-	ReplicaSetID            primitive.ObjectID     `bson:"replicaSetId,omitempty" json:"replicaSetId,omitempty"`
+	ChainingAllowed         bool                          `bson:"chainingAllowed,omitempty" json:"chainingAllowed,omitempty"`
+	HeartbeatIntervalMillis int64                         `bson:"heartbeatIntervalMillis,omitempty" json:"heartbeatIntervalMillis,omitempty"`
+	HeartbeatTimeoutSecs    int                           `bson:"heartbeatTimeoutSecs,omitempty" json:"heartbeatTimeoutSecs,omitempty"`
+	ElectionTimeoutMillis   int64                         `bson:"electionTimeoutMillis,omitempty" json:"electionTimeoutMillis,omitempty"`
+	CatchUpTimeoutMillis    int64                         `bson:"catchUpTimeoutMillis,omitempty" json:"catchUpTimeoutMillis,omitempty"`
+	GetLastErrorModes       map[string]CustomWriteConcern `bson:"getLastErrorModes,omitempty" json:"getLastErrorModes,omitempty"`
+	GetLastErrorDefaults    WriteConcern                  `bson:"getLastErrorDefaults,omitempty" json:"getLastErrorDefaults,omitempty"`
+	ReplicaSetID            primitive.ObjectID            `bson:"replicaSetId,omitempty" json:"replicaSetId,omitempty"`
 }
 
 // Response document from 'replSetGetConfig': https://docs.mongodb.com/manual/reference/command/replSetGetConfig/#dbcmd.replSetGetConfig

--- a/pkg/psmdb/mongo/mongo.go
+++ b/pkg/psmdb/mongo/mongo.go
@@ -71,7 +71,7 @@ func ReadConfig(ctx context.Context, client *mongo.Client) (RSConfig, error) {
 		return RSConfig{}, errors.Wrap(res.Err(), "replSetGetConfig")
 	}
 	if err := res.Decode(&resp); err != nil {
-		return RSConfig{}, errors.Wrap(err, "failed to decoge to replSetGetConfig")
+		return RSConfig{}, errors.Wrap(err, "failed to decode to replSetGetConfig")
 	}
 
 	if resp.Config == nil {
@@ -170,7 +170,7 @@ func WriteConfig(ctx context.Context, client *mongo.Client, cfg RSConfig) error 
 	}
 
 	if err := res.Decode(&resp); err != nil {
-		return errors.Wrap(err, "failed to decoge to replSetReconfigResponse")
+		return errors.Wrap(err, "failed to decode to replSetReconfigResponse")
 	}
 
 	if resp.OK != 1 {


### PR DESCRIPTION
[![K8SPSMDB-512](https://badgen.net/badge/JIRA/K8SPSMDB-512/green)](https://jira.percona.com/browse/K8SPSMDB-512) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The `GetLastErrorModes` setting is defined as the wrong type. Configuring `getLastErrorModes` in the replicaset causes the Operator to fail to reconcile with the error:

```
get mongo config: failed to decoge to replSetGetConfig: cannot decode 32-bit integer into a string type
```

Currently, the Operator defines GetLastErrorModes as a `map[string]ReplsetTags`, where `ReplsetTags` is a `map[string]string`. In mongoDB, the `getLastErrorModes` setting can be configured like so:

```
conf.settings = { getLastErrorModes: { MultipleDC : { "dc_va": 2, "dc_ca": 1 } } };
```

Notice the innermost map is of type `map[string]int`, not `map[string]string`. This PR adds a type `CustomWriteConcern` that is `map[string]int` to replace the existing usage of `ReplsetTags` here. It also fixes a couple typos in the related log messages.