### PR TITLE
Add "prefix" key to backup.storages.s3 in cr.yaml

### DIFF
--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -331,6 +331,7 @@ spec:
 #          bucket: S3-BACKUP-BUCKET-NAME-HERE
 #          credentialsSecret: my-cluster-name-backup-s3
 #          region: us-west-2
+#          prefix: ""
 #      minio:
 #        type: s3
 #        s3:
@@ -338,6 +339,7 @@ spec:
 #          region: us-east-1
 #          credentialsSecret: my-cluster-name-backup-minio
 #          endpointUrl: http://minio.psmdb.svc.cluster.local:9000/minio/
+#          prefix: ""
     pitr:
       enabled: false
     tasks:


### PR DESCRIPTION
Hi! First of all, thanks a lot for working on this project, it looks awesome! 

I was running some tests today (in order to decide whether and how to use the operator in our cluster) with multiple mongodb clusters and I noticed that backups were always ending in the root of the s3 bucket, mixing up one with the other. I noticed that the `pbm` cli allowed to set a `prefix` value for the s3 upload, however that wasn't reflected in the cr.yaml storages section, so I dug in the sources of that type (https://github.com/percona/percona-server-mongodb-operator/blob/main/pkg/apis/psmdb/v1/psmdb_types.go#L455) and I noticed that prefix is a valid value.

By adding it here future users can see that it's a supported option more clearly.

If this makes sense, I can also add it to the user-facing documentation (probably in the backups section https://www.percona.com/doc/kubernetes-operator-for-psmongodb/backups.html)