### PR TITLE
K8SPSMDB-554 - Change default exposeType from LoadBalancer to ClusterIP

### DIFF
--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -102,7 +102,7 @@ spec:
 #      minAvailable: 0
     expose:
       enabled: false
-      exposeType: LoadBalancer
+      exposeType: ClusterIP
 #      loadBalancerSourceRanges:
 #        - 10.0.0.0/8
 #      serviceAnnotations:
@@ -262,7 +262,7 @@ spec:
         maxUnavailable: 1
       expose:
         enabled: false
-        exposeType: LoadBalancer
+        exposeType: ClusterIP
 #        loadBalancerSourceRanges:
 #          - 10.0.0.0/8
 #        serviceAnnotations:


### PR DESCRIPTION
[![K8SPSMDB-554](https://badgen.net/badge/JIRA/K8SPSMDB-554/green)](https://jira.percona.com/browse/K8SPSMDB-554) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

It was mentioned in the spec that default should be ClusterIP everywhere as default.