### PR TITLE
K8SPSMDB-553: Don't allow running status in stuck backups

### DIFF
--- a/pkg/controller/perconaservermongodbbackup/backup.go
+++ b/pkg/controller/perconaservermongodbbackup/backup.go
@@ -109,6 +109,8 @@ func (b *Backup) Status(cr *api.PerconaServerMongoDBBackup) (api.PerconaServerMo
 		status.CompletedAt = &metav1.Time{
 			Time: time.Unix(meta.LastTransitionTS, 0),
 		}
+	case pbm.StatusStarting:
+		status.State = api.BackupStateRequested
 	default:
 		status.State = api.BackupStateRunning
 	}


### PR DESCRIPTION
[![K8SPSMDB-553](https://badgen.net/badge/JIRA/K8SPSMDB-553/green)](https://jira.percona.com/browse/K8SPSMDB-553) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://jira.percona.com/browse/K8SPSMDB-553

Actually, in the right conditions backup will be updated as "error" if s3 credentials are wrong:

```
% kubectl get perconaservermongodbbackup.psmdb.percona.com/backup2 -o yaml | yq r - status
destination: "2021-09-09T04:57:01Z"
error: "mongodump: write data: upload to S3: InvalidAccessKeyId: The Access Key Id you provided does not exist in our records.\n\tstatus code: 403, request id: 16A30E825A595D82, host id: ."
lastTransition: "2021-09-09T04:57:23Z"
pbmName: "2021-09-09T04:57:01Z"
s3:
  bucket: operator-testing
  credentialsSecret: minio-secret
  endpointUrl: http://minio-service:9000
  region: us-east-1
start: "2021-09-09T04:57:19Z"
state: error
storageName: minio
```

The problem is that PBM periodically checks the connection to the storage provider and if the credentials are wrong the backup-agent will start to log following error:

```
2021-09-09T05:22:34.000+0000 E [agentCheckup] check storage connecion: storage check failed with: get S3 object header: Forbidden: Forbidden
        status code: 403, request id: 16A30FE258F6916C, host id:
```

If storage connection fails, it doesn't start any backup jobs. But, unless the status of the backup job is "error" or "done" in PBM collection, we consider the backup as running and thus we update it as "running" although it's not started yet, due to storage error.

I added another case that handles "starting" status from PBM. If backups are stuck with the storage error like above, at least they'll stuck with "requested" status.