### PR TITLE
K8SPXC-761 use numeric id in USER instruction

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -46,4 +46,4 @@ COPY build/ps-entry.sh /ps-entry.sh
 # Mozilla licensed source code should be included
 COPY vendor/github.com/hashicorp /lib
 
-USER nobody
+USER 2


### PR DESCRIPTION
[![K8SPXC-761](https://badgen.net/badge/JIRA/K8SPXC-761/green)](https://jira.percona.com/browse/K8SPXC-761) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

1. Use numeric id instead of username in USER instruction
2. Use id 2(daemon), reasons:
   - nobody user id changed in rhel/centos/ubi 8 from 2 to 65534
   - unify with percona-postgresql-operator