### PR TITLE
Update cr.yaml

### DIFF
--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -47,20 +47,20 @@ spec:
 #        mode: slowOp
 #      systemLog:
 #        verbosity: 1
-#    storage:
-#      engine: wiredTiger
-#      inMemory:
-#        engineConfig:
-#          inMemorySizeRatio: 0.9
-#      wiredTiger:
-#        engineConfig:
-#          cacheSizeRatio: 0.5
-#          directoryForIndexes: false
-#          journalCompressor: snappy
-#        collectionConfig:
-#          blockCompressor: snappy
-#        indexConfig:
-#          prefixCompression: true
+#      storage:
+#        engine: wiredTiger
+#        inMemory:
+#          engineConfig:
+#            inMemorySizeRatio: 0.9
+#        wiredTiger:
+#          engineConfig:
+#            cacheSizeRatio: 0.5
+#            directoryForIndexes: false
+#            journalCompressor: snappy
+#          collectionConfig:
+#            blockCompressor: snappy
+#          indexConfig:
+#            prefixCompression: true
     affinity:
       antiAffinityTopologyKey: "kubernetes.io/hostname"
 #      advanced:


### PR DESCRIPTION
Fix wrong indention of replesets.configuration, [deploy/cr.yaml#L50-L63](https://github.com/percona/percona-server-mongodb-operator/blob/44c9db2e30792c9bece7f970a9841fa1df7d1a6d/deploy/cr.yaml#L50-L63) should have 2 more space before to make it be a string value of configuration