### PR TITLE
K8SPSMDB-527 timeout should be less or equal than period

### DIFF
--- a/e2e-tests/demand-backup-sharded/compare/deployment_some-name-mongos-4-oc.yml
+++ b/e2e-tests/demand-backup-sharded/compare/deployment_some-name-mongos-4-oc.yml
@@ -113,7 +113,7 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 1
             successThreshold: 1
-            timeoutSeconds: 2
+            timeoutSeconds: 1
           resources: {}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File

--- a/e2e-tests/demand-backup-sharded/compare/deployment_some-name-mongos-oc.yml
+++ b/e2e-tests/demand-backup-sharded/compare/deployment_some-name-mongos-oc.yml
@@ -113,7 +113,7 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 1
             successThreshold: 1
-            timeoutSeconds: 2
+            timeoutSeconds: 1
           resources: {}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File

--- a/e2e-tests/demand-backup-sharded/compare/deployment_some-name-mongos-secret.yml
+++ b/e2e-tests/demand-backup-sharded/compare/deployment_some-name-mongos-secret.yml
@@ -113,7 +113,7 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 1
             successThreshold: 1
-            timeoutSeconds: 2
+            timeoutSeconds: 1
           resources: {}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File

--- a/e2e-tests/demand-backup-sharded/compare/deployment_some-name-mongos.yml
+++ b/e2e-tests/demand-backup-sharded/compare/deployment_some-name-mongos.yml
@@ -113,7 +113,7 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 1
             successThreshold: 1
-            timeoutSeconds: 2
+            timeoutSeconds: 1
           resources: {}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -504,6 +504,7 @@ compare_kubectl() {
 		| yq d - '**.storageClassName' \
 		| yq d - '**.finalizers' \
 		| yq d - '**."kubernetes.io/pvc-protection"' \
+		| yq d - '**."cloud.google.com/neg"' \
 		| yq d - '**.volumeName' \
 		| yq d - '**."volume.beta.kubernetes.io/storage-provisioner"' \
 		| yq d - 'spec.volumeMode' \

--- a/e2e-tests/monitoring-2-0/compare/deployment_monitoring-mongos-oc.yml
+++ b/e2e-tests/monitoring-2-0/compare/deployment_monitoring-mongos-oc.yml
@@ -112,7 +112,7 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 1
             successThreshold: 1
-            timeoutSeconds: 2
+            timeoutSeconds: 1
           resources:
             limits:
               cpu: 300m

--- a/e2e-tests/monitoring-2-0/compare/deployment_monitoring-mongos.yml
+++ b/e2e-tests/monitoring-2-0/compare/deployment_monitoring-mongos.yml
@@ -112,7 +112,7 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 1
             successThreshold: 1
-            timeoutSeconds: 2
+            timeoutSeconds: 1
           resources:
             limits:
               cpu: 300m

--- a/e2e-tests/pitr-sharded/compare/deployment_some-name-mongos-4-oc.yml
+++ b/e2e-tests/pitr-sharded/compare/deployment_some-name-mongos-4-oc.yml
@@ -112,7 +112,7 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 1
             successThreshold: 1
-            timeoutSeconds: 2
+            timeoutSeconds: 1
           resources: {}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File

--- a/e2e-tests/pitr-sharded/compare/deployment_some-name-mongos-oc.yml
+++ b/e2e-tests/pitr-sharded/compare/deployment_some-name-mongos-oc.yml
@@ -112,7 +112,7 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 1
             successThreshold: 1
-            timeoutSeconds: 2
+            timeoutSeconds: 1
           resources: {}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File

--- a/e2e-tests/pitr-sharded/compare/deployment_some-name-mongos.yml
+++ b/e2e-tests/pitr-sharded/compare/deployment_some-name-mongos.yml
@@ -112,7 +112,7 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 1
             successThreshold: 1
-            timeoutSeconds: 2
+            timeoutSeconds: 1
           resources: {}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File

--- a/pkg/apis/psmdb/v1/psmdb_defaults.go
+++ b/pkg/apis/psmdb/v1/psmdb_defaults.go
@@ -230,6 +230,9 @@ func (cr *PerconaServerMongoDB) CheckNSetDefaults(platform version.Platform, log
 		}
 		if cr.Spec.Sharding.Mongos.ReadinessProbe.TimeoutSeconds < 1 {
 			cr.Spec.Sharding.Mongos.ReadinessProbe.TimeoutSeconds = 2
+			if cr.CompareVersion("1.11.0") >= 0 {
+				cr.Spec.Sharding.Mongos.ReadinessProbe.TimeoutSeconds = 1
+			}
 		}
 		if cr.Spec.Sharding.Mongos.ReadinessProbe.PeriodSeconds < 1 {
 			cr.Spec.Sharding.Mongos.ReadinessProbe.PeriodSeconds = 1


### PR DESCRIPTION
[![K8SPSMDB-527](https://badgen.net/badge/JIRA/K8SPSMDB-527/green)](https://jira.percona.com/browse/K8SPSMDB-527) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

[K8SPSMDB-527](https://jira.percona.com/browse/K8SPSMDB-527)

timeout should be less or equal than the period otherwise possible to get errors in some configurations
```
  Normal   LoadBalancerNegWithoutHealthCheck  10m   neg-readiness-reflector  Pod is in NEG "Key{\"k8s1-2615dab0-run-main-4664-my-cluster-name-mongo-2701-24107fd7\", zone: \"europe-west1-c\"}". NEG is not attached to any BackendService with health checking. Marking condition "cloud.google.com/load-balancer-neg-ready" to True.
  ```