### PR TITLE
[K8SPSMDB-595] cfg rs service is required to be exposed with unmanaged flag enabled

### DIFF
--- a/pkg/apis/psmdb/v1/psmdb_defaults.go
+++ b/pkg/apis/psmdb/v1/psmdb_defaults.go
@@ -390,7 +390,7 @@ func (cr *PerconaServerMongoDB) CheckNSetDefaults(platform version.Platform, log
 			replset.ServiceAccountName = WorkloadSA
 		}
 
-		if cr.Spec.Unmanaged && !replset.Expose.Enabled {
+		if cr.Spec.Unmanaged && !replset.Expose.Enabled && replset.Name != ConfigReplSetName {
 			return errors.Errorf("replset %s needs to be exposed if cluster is unmanaged", replset.Name)
 		}
 


### PR DESCRIPTION
[![K8SPSMDB-595](https://badgen.net/badge/JIRA/K8SPSMDB-595/green)](https://jira.percona.com/browse/K8SPSMDB-595) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

