### PR TITLE
K8SPSMDB-604: Add `startupDelaySeconds` option for mongos liveness probe

### DIFF
--- a/e2e-tests/demand-backup-sharded/compare/deployment_some-name-mongos-4-oc.yml
+++ b/e2e-tests/demand-backup-sharded/compare/deployment_some-name-mongos-4-oc.yml
@@ -85,6 +85,8 @@ spec:
                 - /etc/mongodb-ssl/ca.crt
                 - --sslPEMKeyFile
                 - /tmp/tls.pem
+                - --startupDelaySeconds
+                - "10"
             failureThreshold: 4
             initialDelaySeconds: 60
             periodSeconds: 30

--- a/e2e-tests/demand-backup-sharded/compare/deployment_some-name-mongos-oc.yml
+++ b/e2e-tests/demand-backup-sharded/compare/deployment_some-name-mongos-oc.yml
@@ -85,6 +85,8 @@ spec:
                 - /etc/mongodb-ssl/ca.crt
                 - --sslPEMKeyFile
                 - /tmp/tls.pem
+                - --startupDelaySeconds
+                - "10"
             failureThreshold: 4
             initialDelaySeconds: 60
             periodSeconds: 30

--- a/e2e-tests/demand-backup-sharded/compare/deployment_some-name-mongos-secret.yml
+++ b/e2e-tests/demand-backup-sharded/compare/deployment_some-name-mongos-secret.yml
@@ -85,6 +85,8 @@ spec:
                 - /etc/mongodb-ssl/ca.crt
                 - --sslPEMKeyFile
                 - /tmp/tls.pem
+                - --startupDelaySeconds
+                - "10"
             failureThreshold: 4
             initialDelaySeconds: 60
             periodSeconds: 30

--- a/e2e-tests/demand-backup-sharded/compare/deployment_some-name-mongos.yml
+++ b/e2e-tests/demand-backup-sharded/compare/deployment_some-name-mongos.yml
@@ -85,6 +85,8 @@ spec:
                 - /etc/mongodb-ssl/ca.crt
                 - --sslPEMKeyFile
                 - /tmp/tls.pem
+                - --startupDelaySeconds
+                - "10"
             failureThreshold: 4
             initialDelaySeconds: 60
             periodSeconds: 30

--- a/e2e-tests/monitoring-2-0/compare/deployment_monitoring-mongos-oc.yml
+++ b/e2e-tests/monitoring-2-0/compare/deployment_monitoring-mongos-oc.yml
@@ -84,6 +84,8 @@ spec:
                 - /etc/mongodb-ssl/ca.crt
                 - --sslPEMKeyFile
                 - /tmp/tls.pem
+                - --startupDelaySeconds
+                - "10"
             failureThreshold: 4
             initialDelaySeconds: 60
             periodSeconds: 30

--- a/e2e-tests/monitoring-2-0/compare/deployment_monitoring-mongos.yml
+++ b/e2e-tests/monitoring-2-0/compare/deployment_monitoring-mongos.yml
@@ -84,6 +84,8 @@ spec:
                 - /etc/mongodb-ssl/ca.crt
                 - --sslPEMKeyFile
                 - /tmp/tls.pem
+                - --startupDelaySeconds
+                - "10"
             failureThreshold: 4
             initialDelaySeconds: 60
             periodSeconds: 30

--- a/e2e-tests/pitr-sharded/compare/deployment_some-name-mongos-4-oc.yml
+++ b/e2e-tests/pitr-sharded/compare/deployment_some-name-mongos-4-oc.yml
@@ -84,6 +84,8 @@ spec:
                 - /etc/mongodb-ssl/ca.crt
                 - --sslPEMKeyFile
                 - /tmp/tls.pem
+                - --startupDelaySeconds
+                - "10"
             failureThreshold: 4
             initialDelaySeconds: 60
             periodSeconds: 30

--- a/e2e-tests/pitr-sharded/compare/deployment_some-name-mongos-oc.yml
+++ b/e2e-tests/pitr-sharded/compare/deployment_some-name-mongos-oc.yml
@@ -84,6 +84,8 @@ spec:
                 - /etc/mongodb-ssl/ca.crt
                 - --sslPEMKeyFile
                 - /tmp/tls.pem
+                - --startupDelaySeconds
+                - "10"
             failureThreshold: 4
             initialDelaySeconds: 60
             periodSeconds: 30

--- a/e2e-tests/pitr-sharded/compare/deployment_some-name-mongos.yml
+++ b/e2e-tests/pitr-sharded/compare/deployment_some-name-mongos.yml
@@ -84,6 +84,8 @@ spec:
                 - /etc/mongodb-ssl/ca.crt
                 - --sslPEMKeyFile
                 - /tmp/tls.pem
+                - --startupDelaySeconds
+                - "10"
             failureThreshold: 4
             initialDelaySeconds: 60
             periodSeconds: 30

--- a/pkg/apis/psmdb/v1/psmdb_defaults.go
+++ b/pkg/apis/psmdb/v1/psmdb_defaults.go
@@ -190,7 +190,7 @@ func (cr *PerconaServerMongoDB) CheckNSetDefaults(platform version.Platform, log
 						"--sslPEMKeyFile", "/tmp/tls.pem")
 			}
 
-			if cr.CompareVersion("1.4.0") >= 0 && !cr.Spec.Sharding.Mongos.LivenessProbe.CommandHas(startupDelaySecondsFlag) {
+			if cr.CompareVersion("1.11.0") >= 0 && !cr.Spec.Sharding.Mongos.LivenessProbe.CommandHas(startupDelaySecondsFlag) {
 				cr.Spec.Sharding.Mongos.LivenessProbe.Exec.Command = append(
 					cr.Spec.Sharding.Mongos.LivenessProbe.Exec.Command,
 					startupDelaySecondsFlag, strconv.Itoa(cr.Spec.Sharding.Mongos.LivenessProbe.StartupDelaySeconds))

--- a/pkg/apis/psmdb/v1/psmdb_defaults.go
+++ b/pkg/apis/psmdb/v1/psmdb_defaults.go
@@ -169,6 +169,10 @@ func (cr *PerconaServerMongoDB) CheckNSetDefaults(platform version.Platform, log
 			cr.Spec.Sharding.Mongos.LivenessProbe = new(LivenessProbeExtended)
 		}
 
+		if cr.Spec.Sharding.Mongos.LivenessProbe.StartupDelaySeconds < 1 {
+			cr.Spec.Sharding.Mongos.LivenessProbe.StartupDelaySeconds = 10
+		}
+
 		if cr.Spec.Sharding.Mongos.LivenessProbe.Exec == nil {
 			cr.Spec.Sharding.Mongos.LivenessProbe.Exec = &corev1.ExecAction{
 				Command: []string{
@@ -185,6 +189,12 @@ func (cr *PerconaServerMongoDB) CheckNSetDefaults(platform version.Platform, log
 						"--sslCAFile", "/etc/mongodb-ssl/ca.crt",
 						"--sslPEMKeyFile", "/tmp/tls.pem")
 			}
+
+			if cr.CompareVersion("1.4.0") >= 0 && !cr.Spec.Sharding.Mongos.LivenessProbe.CommandHas(startupDelaySecondsFlag) {
+				cr.Spec.Sharding.Mongos.LivenessProbe.Exec.Command = append(
+					cr.Spec.Sharding.Mongos.LivenessProbe.Exec.Command,
+					startupDelaySecondsFlag, strconv.Itoa(cr.Spec.Sharding.Mongos.LivenessProbe.StartupDelaySeconds))
+			}
 		}
 
 		if cr.Spec.Sharding.Mongos.LivenessProbe.InitialDelaySeconds < 1 {
@@ -198,9 +208,6 @@ func (cr *PerconaServerMongoDB) CheckNSetDefaults(platform version.Platform, log
 		}
 		if cr.Spec.Sharding.Mongos.LivenessProbe.FailureThreshold < 1 {
 			cr.Spec.Sharding.Mongos.LivenessProbe.FailureThreshold = failureThresholdDefault
-		}
-		if cr.Spec.Sharding.Mongos.LivenessProbe.StartupDelaySeconds < 1 {
-			cr.Spec.Sharding.Mongos.LivenessProbe.StartupDelaySeconds = 10
 		}
 
 		if cr.Spec.Sharding.Mongos.ReadinessProbe == nil {


### PR DESCRIPTION
[![K8SPSMDB-604](https://badgen.net/badge/JIRA/K8SPSMDB-604/green)](https://jira.percona.com/browse/K8SPSMDB-604) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://jira.percona.com/browse/K8SPSMDB-604