### PR TITLE
K8SPSMDB-571 - Rename helm del to uninstall

### DIFF
--- a/e2e-tests/default-cr/run
+++ b/e2e-tests/default-cr/run
@@ -79,7 +79,7 @@ function main() {
 			"spec": {"pmm":{"enabled":false}}
 		}'
 	sleep 120
-	helm delete monitoring
+	helm uninstall monitoring
 	wait_cluster_consistency $cluster
 
 	desc 'enabling arbiter'

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -328,7 +328,7 @@ deploy_operator() {
 
 deploy_minio() {
 	desc 'install Minio'
-	helm del minio-service || :
+	helm uninstall minio-service || :
 	helm repo remove minio || :
 	helm repo add minio https://helm.min.io/
 	# kubectl_bin delete pvc minio-service --force

--- a/e2e-tests/monitoring-2-0/run
+++ b/e2e-tests/monitoring-2-0/run
@@ -14,7 +14,7 @@ deploy_operator
 desc 'install PMM Server'
 platform=kubernetes
 
-helm del --purge monitoring || :
+helm uninstall monitoring || :
 helm repo remove stable || :
 helm repo add stable https://charts.helm.sh/stable
 if [[ -n ${OPENSHIFT} ]]; then
@@ -70,5 +70,5 @@ if [[ -n ${OPENSHIFT} ]]; then
 	oc adm policy remove-scc-from-user privileged -z percona-server-mongodb-operator
 fi
 
-helm delete monitoring
+helm uninstall monitoring
 destroy $namespace


### PR DESCRIPTION
`--purge` option doesn't exist any more for helm del and delete was renamed to uninstall so better to use it (https://helm.sh/docs/helm/helm_delete/).