### PR TITLE
K8SPSMDB-571 - Fix failures in some tests

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -602,7 +602,7 @@ compare_mongo_cmd() {
 	local suffix="$4"
 
 	run_mongo "use myApp\n db.test.${command}()" "$uri" "mongodb" "$suffix" \
-		| egrep -v 'I NETWORK|W NETWORK|Error saving history file|Percona Server for MongoDB|connecting to:|Unable to reach primary for set|Implicit session:|versions do not match' \
+		| egrep -v 'I NETWORK|W NETWORK|F NETWORK|Error saving history file|Percona Server for MongoDB|connecting to:|Unable to reach primary for set|Implicit session:|versions do not match' \
 		| $sed -re 's/ObjectId\("[0-9a-f]+"\)//; s/-[0-9]+.svc/-xxx.svc/' \
 			>$tmp_dir/${command}
 	diff ${test_dir}/compare/${command}${postfix}.json $tmp_dir/${command}


### PR DESCRIPTION
[![K8SPSMDB-571](https://badgen.net/badge/JIRA/K8SPSMDB-571/green)](https://jira.percona.com/browse/K8SPSMDB-571) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

arbiter and users tests were failing in some environments with following diffs:
arbiter
```
+ diff /Users/plavi/Development/percona/kubernetes-operators/production/percona-server-mongodb-operator/e2e-tests/arbiter/compare/find.json /var/folders/fw/lxhtthdn7d9610w5p3wb33340000gn/T/tmp.zZiizUaJ/find
0a1
> 2021-12-09T16:15:22.023+0000 F NETWORK  [ReplicaSetMonitor-TaskExecutor-0] ReplicaSetMonitor rs0 recieved error while monitoring arbiter-rs0-1.arbiter-rs0.arbiter-xxx.svc.cluster.local:27017: Location40356: con
nection pool: connect failed arbiter-rs0-1.arbiter-rs0.arbiter-1818.svc.cluster.local:27017 : couldn't connect to server arbiter-rs0-1.arbiter-rs0.arbiter-1818.svc.cluster.local:27017, connection attempt failed:
HostNotFound: Could not find address for arbiter-rs0-1.arbiter-rs0.arbiter-1818.svc.cluster.local:27017: SocketException: Host not found (authoritative)(3 ms)
```

users:
```
-----------------------------------------------------------------------------------
ping return
-----------------------------------------------------------------------------------

+ '[' '2021-12-09T12:35:31.947+0000 F NETWORK  [ReplicaSetMonitor-TaskExecutor-1] ReplicaSetMonitor rs0 recieved error while monitoring some-name-rs0-1.some-name-rs0.users-10246.svc.cluster.local:27017: Location40356: connection pool: connect failed some-name-rs0-1.some-name-rs0.users-10246.svc.cluster.local:27017 : couldn'\''t connect to server some-name-rs0-1.some-name-rs0.users-10246.svc.cluster.local:27017, connection attempt failed: HostNotFound: Could not find address for some-name-rs0-1.some-name-rs0.users-10246.svc.cluster.local:27017: SocketException: Host not found (authoritative)(6 ms)
1
2021-12-09T12:35:31.954+0000 F NETWORK  [ReplicaSetMonitor-TaskExecutor-1] ReplicaSetMonitor rs0 recieved error while monitoring some-name-rs0-2.some-name-rs0.users-10246.svc.cluster.local:27017: Location40356: connection pool: connect failed some-name-rs0-2.some-name-rs0.users-10246.svc.cluster.local:27017 : couldn'\''t connect to server some-name-rs0-2.some-name-rs0.users-10246.svc.cluster.local:27017, connection attempt failed: HostNotFound: Could not find address for some-name-rs0-2.some-name-rs0.users-10246.svc.cluster.local:27017: SocketException: Host not found (authoritative)(6 ms)' '!=' 1 ']'
+ return 1
```