### PR TITLE
K8SPSMDB - Fixes for tests for 1.11.0 release

### DIFF
--- a/e2e-tests/default-cr/compare/statefulset_minimal-cluster-cfg-oc.yml
+++ b/e2e-tests/default-cr/compare/statefulset_minimal-cluster-cfg-oc.yml
@@ -4,82 +4,83 @@ metadata:
   annotations: {}
   generation: 1
   labels:
-    app.kubernetes.io/component: mongod
-    app.kubernetes.io/instance: my-cluster-name
+    app.kubernetes.io/component: cfg
+    app.kubernetes.io/instance: minimal-cluster
     app.kubernetes.io/managed-by: percona-server-mongodb-operator
     app.kubernetes.io/name: percona-server-mongodb
     app.kubernetes.io/part-of: percona-server-mongodb
-    app.kubernetes.io/replset: rs0
-  name: my-cluster-name-rs0
+    app.kubernetes.io/replset: cfg
+  name: minimal-cluster-cfg
   ownerReferences:
     - controller: true
       kind: PerconaServerMongoDB
-      name: my-cluster-name
+      name: minimal-cluster
 spec:
   podManagementPolicy: OrderedReady
-  replicas: 3
+  replicas: 1
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app.kubernetes.io/component: mongod
-      app.kubernetes.io/instance: my-cluster-name
+      app.kubernetes.io/component: cfg
+      app.kubernetes.io/instance: minimal-cluster
       app.kubernetes.io/managed-by: percona-server-mongodb-operator
       app.kubernetes.io/name: percona-server-mongodb
       app.kubernetes.io/part-of: percona-server-mongodb
-      app.kubernetes.io/replset: rs0
-  serviceName: my-cluster-name-rs0
+      app.kubernetes.io/replset: cfg
+  serviceName: minimal-cluster-cfg
   template:
     metadata:
       annotations: {}
       labels:
-        app.kubernetes.io/component: mongod
-        app.kubernetes.io/instance: my-cluster-name
+        app.kubernetes.io/component: cfg
+        app.kubernetes.io/instance: minimal-cluster
         app.kubernetes.io/managed-by: percona-server-mongodb-operator
         app.kubernetes.io/name: percona-server-mongodb
         app.kubernetes.io/part-of: percona-server-mongodb
-        app.kubernetes.io/replset: rs0
+        app.kubernetes.io/replset: cfg
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: cfg
+                  app.kubernetes.io/instance: minimal-cluster
+                  app.kubernetes.io/managed-by: percona-server-mongodb-operator
+                  app.kubernetes.io/name: percona-server-mongodb
+                  app.kubernetes.io/part-of: percona-server-mongodb
+                  app.kubernetes.io/replset: cfg
+              topologyKey: kubernetes.io/hostname
       containers:
         - args:
             - --bind_ip_all
             - --auth
             - --dbpath=/data/db
             - --port=27017
-            - --replSet=rs0
+            - --replSet=cfg
             - --storageEngine=wiredTiger
             - --relaxPermChecks
             - --sslAllowInvalidCertificates
-            - --sslMode=preferSSL
-            - --clusterAuthMode=x509
-            - --shardsvr
-            - --slowms=100
+            - --clusterAuthMode=keyFile
+            - --keyFile=/etc/mongodb-secrets/mongodb-key
+            - --configsvr
+            - --slowms=0
             - --profile=1
-            - --rateLimit=100
             - --enableEncryption
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
-            - --encryptionCipherMode=AES256-CBC
-            - --wiredTigerCacheSizeGB=0.25
-            - --wiredTigerCollectionBlockCompressor=snappy
-            - --wiredTigerJournalCompressor=snappy
             - --wiredTigerIndexPrefixCompression=true
-            - --setParameter
-            - ttlMonitorSleepSecs=60
-            - --setParameter
-            - wiredTigerConcurrentReadTransactions=128
-            - --setParameter
-            - wiredTigerConcurrentWriteTransactions=128
           command:
             - /data/db/ps-entry.sh
           env:
             - name: SERVICE_NAME
-              value: my-cluster-name
+              value: minimal-cluster
             - name: MONGODB_PORT
               value: "27017"
             - name: MONGODB_REPLSET
-              value: rs0
+              value: cfg
           envFrom:
             - secretRef:
-                name: internal-my-cluster-name-users
+                name: internal-minimal-cluster-users
                 optional: false
           imagePullPolicy: Always
           livenessProbe:
@@ -107,20 +108,14 @@ spec:
               name: mongodb
               protocol: TCP
           readinessProbe:
-            failureThreshold: 8
+            failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 3
             successThreshold: 1
             tcpSocket:
               port: 27017
             timeoutSeconds: 2
-          resources:
-            limits:
-              cpu: 300m
-              memory: 500M
-            requests:
-              cpu: 300m
-              memory: 500M
+          resources: {}
           securityContext:
             runAsNonRoot: true
           terminationMessagePath: /dev/termination-log
@@ -129,7 +124,7 @@ spec:
             - mountPath: /data/db
               name: mongod-data
             - mountPath: /etc/mongodb-secrets
-              name: my-cluster-name-mongodb-keyfile
+              name: minimal-cluster-mongodb-keyfile
               readOnly: true
             - mountPath: /etc/mongodb-ssl
               name: ssl
@@ -138,50 +133,18 @@ spec:
               name: ssl-internal
               readOnly: true
             - mountPath: /etc/mongodb-encryption
-              name: my-cluster-name-mongodb-encryption-key
+              name: minimal-cluster-mongodb-encryption-key
               readOnly: true
             - mountPath: /etc/users-secret
               name: users-secret-file
           workingDir: /data/db
-        - env:
-            - name: PBM_AGENT_MONGODB_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  key: MONGODB_BACKUP_USER
-                  name: internal-my-cluster-name-users
-                  optional: false
-            - name: PBM_AGENT_MONGODB_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  key: MONGODB_BACKUP_PASSWORD
-                  name: internal-my-cluster-name-users
-                  optional: false
-            - name: PBM_MONGODB_REPLSET
-              value: rs0
-            - name: PBM_MONGODB_PORT
-              value: "27017"
-            - name: SHARDED
-              value: "TRUE"
-          imagePullPolicy: Always
-          name: backup-agent
-          resources: {}
-          securityContext:
-            runAsNonRoot: true
-          terminationMessagePath: /dev/termination-log
-          terminationMessagePolicy: File
       dnsPolicy: ClusterFirst
       initContainers:
         - command:
             - /init-entrypoint.sh
           imagePullPolicy: Always
           name: mongo-init
-          resources:
-            limits:
-              cpu: 300m
-              memory: 500M
-            requests:
-              cpu: 300m
-              memory: 500M
+          resources: {}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:
@@ -194,32 +157,34 @@ spec:
       serviceAccountName: default
       terminationGracePeriodSeconds: 30
       volumes:
-        - name: my-cluster-name-mongodb-keyfile
+        - name: minimal-cluster-mongodb-keyfile
           secret:
             defaultMode: 288
             optional: false
-            secretName: my-cluster-name-mongodb-keyfile
-        - name: my-cluster-name-mongodb-encryption-key
+            secretName: minimal-cluster-mongodb-keyfile
+        - name: minimal-cluster-mongodb-encryption-key
           secret:
             defaultMode: 288
             optional: false
-            secretName: my-cluster-name-mongodb-encryption-key
+            secretName: minimal-cluster-mongodb-encryption-key
         - name: ssl
           secret:
             defaultMode: 288
-            optional: false
-            secretName: my-cluster-name-ssl
+            optional: true
+            secretName: minimal-cluster-ssl
         - name: ssl-internal
           secret:
             defaultMode: 288
             optional: true
-            secretName: my-cluster-name-ssl-internal
+            secretName: minimal-cluster-ssl-internal
         - name: users-secret-file
           secret:
             defaultMode: 420
-            secretName: internal-my-cluster-name-users
+            secretName: internal-minimal-cluster-users
   updateStrategy:
-    type: OnDelete
+    rollingUpdate:
+      partition: 0
+    type: RollingUpdate
   volumeClaimTemplates:
     - metadata:
         name: mongod-data

--- a/e2e-tests/default-cr/compare/statefulset_minimal-cluster-rs0-oc.yml
+++ b/e2e-tests/default-cr/compare/statefulset_minimal-cluster-rs0-oc.yml
@@ -5,40 +5,52 @@ metadata:
   generation: 1
   labels:
     app.kubernetes.io/component: mongod
-    app.kubernetes.io/instance: my-cluster-name
+    app.kubernetes.io/instance: minimal-cluster
     app.kubernetes.io/managed-by: percona-server-mongodb-operator
     app.kubernetes.io/name: percona-server-mongodb
     app.kubernetes.io/part-of: percona-server-mongodb
     app.kubernetes.io/replset: rs0
-  name: my-cluster-name-rs0
+  name: minimal-cluster-rs0
   ownerReferences:
     - controller: true
       kind: PerconaServerMongoDB
-      name: my-cluster-name
+      name: minimal-cluster
 spec:
   podManagementPolicy: OrderedReady
-  replicas: 3
+  replicas: 1
   revisionHistoryLimit: 10
   selector:
     matchLabels:
       app.kubernetes.io/component: mongod
-      app.kubernetes.io/instance: my-cluster-name
+      app.kubernetes.io/instance: minimal-cluster
       app.kubernetes.io/managed-by: percona-server-mongodb-operator
       app.kubernetes.io/name: percona-server-mongodb
       app.kubernetes.io/part-of: percona-server-mongodb
       app.kubernetes.io/replset: rs0
-  serviceName: my-cluster-name-rs0
+  serviceName: minimal-cluster-rs0
   template:
     metadata:
       annotations: {}
       labels:
         app.kubernetes.io/component: mongod
-        app.kubernetes.io/instance: my-cluster-name
+        app.kubernetes.io/instance: minimal-cluster
         app.kubernetes.io/managed-by: percona-server-mongodb-operator
         app.kubernetes.io/name: percona-server-mongodb
         app.kubernetes.io/part-of: percona-server-mongodb
         app.kubernetes.io/replset: rs0
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: mongod
+                  app.kubernetes.io/instance: minimal-cluster
+                  app.kubernetes.io/managed-by: percona-server-mongodb-operator
+                  app.kubernetes.io/name: percona-server-mongodb
+                  app.kubernetes.io/part-of: percona-server-mongodb
+                  app.kubernetes.io/replset: rs0
+              topologyKey: kubernetes.io/hostname
       containers:
         - args:
             - --bind_ip_all
@@ -49,37 +61,26 @@ spec:
             - --storageEngine=wiredTiger
             - --relaxPermChecks
             - --sslAllowInvalidCertificates
-            - --sslMode=preferSSL
-            - --clusterAuthMode=x509
+            - --clusterAuthMode=keyFile
+            - --keyFile=/etc/mongodb-secrets/mongodb-key
             - --shardsvr
-            - --slowms=100
+            - --slowms=0
             - --profile=1
-            - --rateLimit=100
             - --enableEncryption
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
-            - --encryptionCipherMode=AES256-CBC
-            - --wiredTigerCacheSizeGB=0.25
-            - --wiredTigerCollectionBlockCompressor=snappy
-            - --wiredTigerJournalCompressor=snappy
             - --wiredTigerIndexPrefixCompression=true
-            - --setParameter
-            - ttlMonitorSleepSecs=60
-            - --setParameter
-            - wiredTigerConcurrentReadTransactions=128
-            - --setParameter
-            - wiredTigerConcurrentWriteTransactions=128
           command:
             - /data/db/ps-entry.sh
           env:
             - name: SERVICE_NAME
-              value: my-cluster-name
+              value: minimal-cluster
             - name: MONGODB_PORT
               value: "27017"
             - name: MONGODB_REPLSET
               value: rs0
           envFrom:
             - secretRef:
-                name: internal-my-cluster-name-users
+                name: internal-minimal-cluster-users
                 optional: false
           imagePullPolicy: Always
           livenessProbe:
@@ -114,13 +115,7 @@ spec:
             tcpSocket:
               port: 27017
             timeoutSeconds: 2
-          resources:
-            limits:
-              cpu: 300m
-              memory: 500M
-            requests:
-              cpu: 300m
-              memory: 500M
+          resources: {}
           securityContext:
             runAsNonRoot: true
           terminationMessagePath: /dev/termination-log
@@ -129,7 +124,7 @@ spec:
             - mountPath: /data/db
               name: mongod-data
             - mountPath: /etc/mongodb-secrets
-              name: my-cluster-name-mongodb-keyfile
+              name: minimal-cluster-mongodb-keyfile
               readOnly: true
             - mountPath: /etc/mongodb-ssl
               name: ssl
@@ -138,50 +133,18 @@ spec:
               name: ssl-internal
               readOnly: true
             - mountPath: /etc/mongodb-encryption
-              name: my-cluster-name-mongodb-encryption-key
+              name: minimal-cluster-mongodb-encryption-key
               readOnly: true
             - mountPath: /etc/users-secret
               name: users-secret-file
           workingDir: /data/db
-        - env:
-            - name: PBM_AGENT_MONGODB_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  key: MONGODB_BACKUP_USER
-                  name: internal-my-cluster-name-users
-                  optional: false
-            - name: PBM_AGENT_MONGODB_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  key: MONGODB_BACKUP_PASSWORD
-                  name: internal-my-cluster-name-users
-                  optional: false
-            - name: PBM_MONGODB_REPLSET
-              value: rs0
-            - name: PBM_MONGODB_PORT
-              value: "27017"
-            - name: SHARDED
-              value: "TRUE"
-          imagePullPolicy: Always
-          name: backup-agent
-          resources: {}
-          securityContext:
-            runAsNonRoot: true
-          terminationMessagePath: /dev/termination-log
-          terminationMessagePolicy: File
       dnsPolicy: ClusterFirst
       initContainers:
         - command:
             - /init-entrypoint.sh
           imagePullPolicy: Always
           name: mongo-init
-          resources:
-            limits:
-              cpu: 300m
-              memory: 500M
-            requests:
-              cpu: 300m
-              memory: 500M
+          resources: {}
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:
@@ -194,32 +157,34 @@ spec:
       serviceAccountName: default
       terminationGracePeriodSeconds: 30
       volumes:
-        - name: my-cluster-name-mongodb-keyfile
+        - name: minimal-cluster-mongodb-keyfile
           secret:
             defaultMode: 288
             optional: false
-            secretName: my-cluster-name-mongodb-keyfile
-        - name: my-cluster-name-mongodb-encryption-key
+            secretName: minimal-cluster-mongodb-keyfile
+        - name: minimal-cluster-mongodb-encryption-key
           secret:
             defaultMode: 288
             optional: false
-            secretName: my-cluster-name-mongodb-encryption-key
+            secretName: minimal-cluster-mongodb-encryption-key
         - name: ssl
           secret:
             defaultMode: 288
-            optional: false
-            secretName: my-cluster-name-ssl
+            optional: true
+            secretName: minimal-cluster-ssl
         - name: ssl-internal
           secret:
             defaultMode: 288
             optional: true
-            secretName: my-cluster-name-ssl-internal
+            secretName: minimal-cluster-ssl-internal
         - name: users-secret-file
           secret:
             defaultMode: 420
-            secretName: internal-my-cluster-name-users
+            secretName: internal-minimal-cluster-users
   updateStrategy:
-    type: OnDelete
+    rollingUpdate:
+      partition: 0
+    type: RollingUpdate
   volumeClaimTemplates:
     - metadata:
         name: mongod-data

--- a/e2e-tests/default-cr/compare/statefulset_my-cluster-name-cfg-oc.yml
+++ b/e2e-tests/default-cr/compare/statefulset_my-cluster-name-cfg-oc.yml
@@ -39,18 +39,6 @@ spec:
         app.kubernetes.io/part-of: percona-server-mongodb
         app.kubernetes.io/replset: cfg
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchLabels:
-                  app.kubernetes.io/component: cfg
-                  app.kubernetes.io/instance: my-cluster-name
-                  app.kubernetes.io/managed-by: percona-server-mongodb-operator
-                  app.kubernetes.io/name: percona-server-mongodb
-                  app.kubernetes.io/part-of: percona-server-mongodb
-                  app.kubernetes.io/replset: cfg
-              topologyKey: kubernetes.io/hostname
       containers:
         - args:
             - --bind_ip_all

--- a/e2e-tests/default-cr/compare/statefulset_my-cluster-name-cfg.yml
+++ b/e2e-tests/default-cr/compare/statefulset_my-cluster-name-cfg.yml
@@ -39,18 +39,6 @@ spec:
         app.kubernetes.io/part-of: percona-server-mongodb
         app.kubernetes.io/replset: cfg
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchLabels:
-                  app.kubernetes.io/component: cfg
-                  app.kubernetes.io/instance: my-cluster-name
-                  app.kubernetes.io/managed-by: percona-server-mongodb-operator
-                  app.kubernetes.io/name: percona-server-mongodb
-                  app.kubernetes.io/part-of: percona-server-mongodb
-                  app.kubernetes.io/replset: cfg
-              topologyKey: kubernetes.io/hostname
       containers:
         - args:
             - --bind_ip_all

--- a/e2e-tests/default-cr/compare/statefulset_my-cluster-name-rs0.yml
+++ b/e2e-tests/default-cr/compare/statefulset_my-cluster-name-rs0.yml
@@ -39,18 +39,6 @@ spec:
         app.kubernetes.io/part-of: percona-server-mongodb
         app.kubernetes.io/replset: rs0
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchLabels:
-                  app.kubernetes.io/component: mongod
-                  app.kubernetes.io/instance: my-cluster-name
-                  app.kubernetes.io/managed-by: percona-server-mongodb-operator
-                  app.kubernetes.io/name: percona-server-mongodb
-                  app.kubernetes.io/part-of: percona-server-mongodb
-                  app.kubernetes.io/replset: rs0
-              topologyKey: kubernetes.io/hostname
       containers:
         - args:
             - --bind_ip_all

--- a/e2e-tests/default-cr/run
+++ b/e2e-tests/default-cr/run
@@ -53,7 +53,13 @@ function main() {
 	kubectl_bin apply -f $deploy_dir/operator.yaml
 	kubectl_bin apply -f $conf_dir/client.yml
 
-	yq w $deploy_dir/cr.yaml 'spec.upgradeOptions.versionServiceEndpoint' 'https://check-dev.percona.com' | kubectl_bin apply -f -
+	yq w $deploy_dir/cr.yaml 'spec.upgradeOptions.versionServiceEndpoint' 'https://check-dev.percona.com' \
+		| yq w - 'spec.replsets.*.affinity.antiAffinityTopologyKey' 'none' \
+		| yq w - 'spec.replsets.*.nonvoting.affinity.antiAffinityTopologyKey' 'none' \
+		| yq w - 'spec.replsets.*.arbiter.affinity.antiAffinityTopologyKey' 'none' \
+		| yq w - 'spec.sharding.configsvrReplSet.affinity.antiAffinityTopologyKey' 'none' \
+		| yq w - 'spec.sharding.mongos.affinity.antiAffinityTopologyKey' 'none' \
+		| kubectl_bin apply -f -
 	desc 'check if all 3 Pods started'
 	wait_cluster_consistency $cluster
 
@@ -66,7 +72,16 @@ function main() {
 	compare_generation "1" "psmdb" "${cluster}"
 
 	desc 'starting PMM up'
-	retry 10 60 helm install monitoring --set platform=kubernetes https://percona-charts.storage.googleapis.com/pmm-server-${PMM_SERVER_VER}.tgz
+	if [ ! -z "$OPENSHIFT" ]; then
+		platform=openshift
+		oc create sa pmm-server
+		oc adm policy add-scc-to-user privileged -z pmm-server
+		oc create rolebinding pmm-psmdb-operator-namespace-only --role percona-server-mongodb-operator --serviceaccount=$namespace:pmm-server
+		oc patch role/percona-server-mongodb-operator --type json -p='[{"op":"add","path": "/rules/-","value":{"apiGroups":["security.openshift.io"],"resources":["securitycontextconstraints"],"verbs":["use"],"resourceNames":["privileged"]}}]'
+		retry 10 60 helm install monitoring --set platform=$platform --set sa=pmm-server --set supresshttp2=false https://percona-charts.storage.googleapis.com/pmm-server-${PMM_SERVER_VER}.tgz
+	else
+		helm install monitoring --set platform=$platform https://percona-charts.storage.googleapis.com/pmm-server-${PMM_SERVER_VER}.tgz
+	fi
 	sleep 20
 	kubectl_bin patch psmdb ${cluster} --type=merge --patch '{
 			"spec": {"pmm":{"enabled":true}}

--- a/e2e-tests/init-deploy/compare/clusterAdmin-50.json
+++ b/e2e-tests/init-deploy/compare/clusterAdmin-50.json
@@ -211,6 +211,7 @@
           "listShards",
           "logRotate",
           "netstat",
+          "oidReset",
           "operationMetrics",
           "removeShard",
           "replSetConfigure",


### PR DESCRIPTION
- fix default-cr test for openshift
- remove antiAffinity in default-cr to allow the test to run on more environments
- fix init-deploy for PSMDB 5.0