### PR TITLE
K8SPSMDB-596: Move encryptionKeySecret to new variable

### DIFF
--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -24,6 +24,7 @@ spec:
     setFCV: false
   secrets:
     users: my-cluster-name-secrets
+    encryptionKey: my-cluster-name-mongodb-encryption-key
   pmm:
     enabled: false
     image: percona/pmm-client:2.21.0
@@ -389,7 +390,6 @@ spec:
     security:
       redactClientLogData: false
       enableEncryption: true
-      encryptionKeySecret: my-cluster-name-mongodb-encryption-key
       encryptionCipherMode: AES256-CBC
     setParameter:
       ttlMonitorSleepSecs: 60

--- a/pkg/apis/psmdb/v1/psmdb_defaults.go
+++ b/pkg/apis/psmdb/v1/psmdb_defaults.go
@@ -88,8 +88,8 @@ func (cr *PerconaServerMongoDB) CheckNSetDefaults(platform version.Platform, log
 	}
 
 	if *cr.Spec.Mongod.Security.EnableEncryption &&
-		cr.Spec.Mongod.Security.EncryptionKeySecret == "" {
-		cr.Spec.Mongod.Security.EncryptionKeySecret = cr.Name + "-mongodb-encryption-key"
+		cr.Spec.EncryptionKeySecretName() == "" {
+		cr.Spec.Secrets.EncryptionKey = cr.Name + "-mongodb-encryption-key"
 	}
 
 	if cr.Spec.Secrets.SSL == "" {

--- a/pkg/apis/psmdb/v1/psmdb_types.go
+++ b/pkg/apis/psmdb/v1/psmdb_types.go
@@ -73,6 +73,20 @@ type PerconaServerMongoDBSpec struct {
 	InitImage               string                               `json:"initImage,omitempty"`
 }
 
+// EncryptionKeySecretName returns spec.Secrets.EncryptionKey.
+// If it's empty, spec.Mongod.Security.EncryptionKeySecret is returned.
+//
+// TODO: Remove after 1.14
+func (spec *PerconaServerMongoDBSpec) EncryptionKeySecretName() string {
+	if spec.Secrets != nil && spec.Secrets.EncryptionKey != "" {
+		return spec.Secrets.EncryptionKey
+	}
+	if spec.Mongod != nil && spec.Mongod.Security != nil {
+		return spec.Mongod.Security.EncryptionKeySecret
+	}
+	return ""
+}
+
 const (
 	SmartUpdateStatefulSetStrategyType appsv1.StatefulSetUpdateStrategyType = "SmartUpdate"
 )
@@ -361,9 +375,10 @@ type ResourcesSpec struct {
 }
 
 type SecretsSpec struct {
-	Users       string `json:"users,omitempty"`
-	SSL         string `json:"ssl,omitempty"`
-	SSLInternal string `json:"sslInternal,omitempty"`
+	Users         string `json:"users,omitempty"`
+	SSL           string `json:"ssl,omitempty"`
+	SSLInternal   string `json:"sslInternal,omitempty"`
+	EncryptionKey string `json:"encryptionKey,omitempty"`
 }
 
 type MongosSpec struct {

--- a/pkg/controller/perconaservermongodb/psmdb_controller.go
+++ b/pkg/controller/perconaservermongodb/psmdb_controller.go
@@ -315,13 +315,13 @@ func (r *ReconcilePerconaServerMongoDB) Reconcile(request reconcile.Request) (re
 	}
 
 	if *cr.Spec.Mongod.Security.EnableEncryption {
-		created, err := r.ensureSecurityKey(cr, cr.Spec.Mongod.Security.EncryptionKeySecret, psmdb.EncryptionKeyName, 32, false)
+		created, err := r.ensureSecurityKey(cr, cr.Spec.EncryptionKeySecretName(), psmdb.EncryptionKeyName, 32, false)
 		if err != nil {
-			err = errors.Wrapf(err, "ensure mongo Key %s", cr.Spec.Mongod.Security.EncryptionKeySecret)
+			err = errors.Wrapf(err, "ensure mongo Key %s", cr.Spec.EncryptionKeySecretName())
 			return reconcile.Result{}, err
 		}
 		if created {
-			logger.Info("Created a new mongo key", "KeyName", cr.Spec.Mongod.Security.EncryptionKeySecret)
+			logger.Info("Created a new mongo key", "KeyName", cr.Spec.EncryptionKeySecretName())
 		}
 	}
 

--- a/pkg/psmdb/container.go
+++ b/pkg/psmdb/container.go
@@ -47,7 +47,7 @@ func container(cr *api.PerconaServerMongoDB, replset *api.ReplsetSpec, name stri
 	if *cr.Spec.Mongod.Security.EnableEncryption {
 		volumes = append(volumes,
 			corev1.VolumeMount{
-				Name:      cr.Spec.Mongod.Security.EncryptionKeySecret,
+				Name:      cr.Spec.EncryptionKeySecretName(),
 				MountPath: mongodRESTencryptDir,
 				ReadOnly:  true,
 			},

--- a/pkg/psmdb/statefulset.go
+++ b/pkg/psmdb/statefulset.go
@@ -79,11 +79,11 @@ func StatefulSpec(m *api.PerconaServerMongoDB, replset *api.ReplsetSpec, contain
 	if *m.Spec.Mongod.Security.EnableEncryption {
 		volumes = append(volumes,
 			corev1.Volume{
-				Name: m.Spec.Mongod.Security.EncryptionKeySecret,
+				Name: m.Spec.EncryptionKeySecretName(),
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
 						DefaultMode: &secretFileMode,
-						SecretName:  m.Spec.Mongod.Security.EncryptionKeySecret,
+						SecretName:  m.Spec.EncryptionKeySecretName(),
 						Optional:    &fvar,
 					},
 				},


### PR DESCRIPTION
[![K8SPSMDB-596](https://badgen.net/badge/JIRA/K8SPSMDB-596/green)](https://jira.percona.com/browse/K8SPSMDB-596) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://jira.percona.com/browse/K8SPSMDB-596

Create variable `spec.secrets.encryptionKey` and still support backward-compatibility for `spec.mongod.security.encryptionKeySecret`