### PR TITLE
K8SPSMDB-574 Rollback Set certificate duration for external certificates to 100 years

### DIFF
--- a/pkg/controller/perconaservermongodb/ssl.go
+++ b/pkg/controller/perconaservermongodb/ssl.go
@@ -81,7 +81,6 @@ func (r *ReconcilePerconaServerMongoDB) createSSLByCertManager(cr *api.PerconaSe
 		},
 		Spec: cm.CertificateSpec{
 			Organization: []string{"PSMDB"},
-			Duration:     &metav1.Duration{Duration: 876000 * time.Hour}, // 100 years
 			CommonName:   cr.Name,
 			SecretName:   cr.Spec.Secrets.SSL,
 			DNSNames:     certificateDNSNames,


### PR DESCRIPTION
[![K8SPSMDB-574](https://badgen.net/badge/JIRA/K8SPSMDB-574/green)](https://jira.percona.com/browse/K8SPSMDB-574) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

rollback https://github.com/percona/percona-server-mongodb-operator/pull/779
reason: security concern, certificates should be rotated every 3 months, we are going to add a field that allows configuring certificate age.
https://jira.percona.com/browse/K8SPSMDB-574