### PR TITLE
K8SPSMDB-560: `serviceName` tag not set to all members in rs

### DIFF
--- a/pkg/psmdb/mongo/mongo.go
+++ b/pkg/psmdb/mongo/mongo.go
@@ -480,8 +480,8 @@ func (m *ConfigMembers) FixTags(compareWith ConfigMembers) (changes bool) {
 
 	for i := 0; i < len(*m); i++ {
 		member := []ConfigMember(*m)[i]
-		if c, ok := cm[member.Host]; ok && len(member.Tags) > 0 {
-			changes = !reflect.DeepEqual(member.Tags, c)
+		if c, ok := cm[member.Host]; ok && !reflect.DeepEqual(member.Tags, c) {
+			changes = true
 			[]ConfigMember(*m)[i].Tags = c
 		}
 	}


### PR DESCRIPTION
[![K8SPSMDB-560](https://badgen.net/badge/JIRA/K8SPSMDB-560/green)](https://jira.percona.com/browse/K8SPSMDB-560) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://jira.percona.com/browse/K8SPSMDB-560

Fix `(m *ConfigMembers) FixTags` method