### PR TITLE
K8SPSMDB-631 - Fix diff in scaling test for Minikube 1.23

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -508,6 +508,7 @@ compare_kubectl() {
 		| yq d - '**."cloud.google.com/neg"' \
 		| yq d - '**.volumeName' \
 		| yq d - '**."volume.beta.kubernetes.io/storage-provisioner"' \
+		| yq d - '**."volume.kubernetes.io/storage-provisioner"' \
 		| yq d - 'spec.volumeMode' \
 		| yq d - '**."volume.kubernetes.io/selected-node"' \
 		| yq d - '**."percona.com/ssl*"' \


### PR DESCRIPTION
[![K8SPSMDB-631](https://badgen.net/badge/JIRA/K8SPSMDB-631/green)](https://jira.percona.com/browse/K8SPSMDB-631) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Diff:
```
+ diff -u /mnt/jenkins/workspace/psmdb-operator-minikube/source/e2e-tests/scaling/compare/pvc_mongod-data-some-name-rs0-3.yml /tmp/tmp.HhcdGDSkU8/pvc_mongod-data-some-name-rs0-3.yml
--- /mnt/jenkins/workspace/psmdb-operator-minikube/source/e2e-tests/scaling/compare/pvc_mongod-data-some-name-rs0-3.yml	2022-01-24 09:12:20.000000000 +0000
+++ /tmp/tmp.HhcdGDSkU8/pvc_mongod-data-some-name-rs0-3.yml	2022-01-24 10:34:06.502590738 +0000
@@ -4,6 +4,7 @@
   annotations:
     pv.kubernetes.io/bind-completed: "yes"
     pv.kubernetes.io/bound-by-controller: "yes"
+    volume.kubernetes.io/storage-provisioner: k8s.io/minikube-hostpath
   labels:
     app.kubernetes.io/component: mongod
     app.kubernetes.io/instance: some-name
```