### PR TITLE
K8SPSMDB-632: Fix smart update on initial deployment

### DIFF
--- a/pkg/controller/perconaservermongodb/smart.go
+++ b/pkg/controller/perconaservermongodb/smart.go
@@ -78,7 +78,7 @@ func (r *ReconcilePerconaServerMongoDB) smartUpdate(cr *api.PerconaServerMongoDB
 		}
 	}
 
-	log.Info("statefullSet was changed, start smart update", "name", sfs.Name)
+	log.Info("StatefulSet is changed, starting smart update", "name", sfs.Name)
 
 	if sfs.Status.ReadyReplicas < sfs.Status.Replicas {
 		log.Info("can't start/continue 'SmartUpdate': waiting for all replicas are ready")
@@ -263,6 +263,10 @@ func (r *ReconcilePerconaServerMongoDB) waitPodRestart(cr *api.PerconaServerMong
 }
 
 func isSfsChanged(sfs *appsv1.StatefulSet, podList *corev1.PodList) bool {
+	if sfs.Status.UpdateRevision == "" {
+		return false
+	}
+
 	for _, pod := range podList.Items {
 		if pod.Labels["app.kubernetes.io/component"] != sfs.Labels["app.kubernetes.io/component"] {
 			continue


### PR DESCRIPTION
[![K8SPSMDB-632](https://badgen.net/badge/JIRA/K8SPSMDB-632/green)](https://jira.percona.com/browse/K8SPSMDB-632) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The operator was starting smart update just after the CR applied. When
statefulset is created, its update revision is empty and it's updated
after some time.