### PR TITLE
K8SPSMDB-650: Reconcile should not be scheduled until operator has work to do

### DIFF
--- a/pkg/controller/perconaservermongodb/balancer.go
+++ b/pkg/controller/perconaservermongodb/balancer.go
@@ -13,23 +13,23 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func (r *ReconcilePerconaServerMongoDB) enableBalancerIfNeeded(cr *api.PerconaServerMongoDB) error {
+func (r *ReconcilePerconaServerMongoDB) enableBalancerIfNeeded(cr *api.PerconaServerMongoDB) (bool, error) {
 	if !cr.Spec.Sharding.Enabled || cr.Spec.Sharding.Mongos.Size == 0 || cr.Spec.Unmanaged {
-		return nil
+		return true, nil
 	}
 
 	uptodate, err := r.isAllSfsUpToDate(cr)
 	if err != nil {
-		return errors.Wrap(err, "failed to chaeck if all sfs are up to date")
+		return false, errors.Wrap(err, "failed to chaeck if all sfs are up to date")
 	}
 
 	rstRunning, err := r.isRestoreRunning(cr)
 	if err != nil {
-		return errors.Wrap(err, "failed to check running restores")
+		return false, errors.Wrap(err, "failed to check running restores")
 	}
 
 	if !uptodate || rstRunning {
-		return nil
+		return false, nil
 	}
 
 	msDepl := psmdb.MongosDeployment(cr)
@@ -37,7 +37,7 @@ func (r *ReconcilePerconaServerMongoDB) enableBalancerIfNeeded(cr *api.PerconaSe
 	for {
 		err = r.client.Get(context.TODO(), types.NamespacedName{Name: msDepl.Name, Namespace: msDepl.Namespace}, msDepl)
 		if err != nil && !k8sErrors.IsNotFound(err) {
-			return errors.Wrapf(err, "get deployment %s", msDepl.Name)
+			return false, errors.Wrapf(err, "get deployment %s", msDepl.Name)
 		}
 
 		if msDepl.ObjectMeta.Generation == msDepl.Status.ObservedGeneration {
@@ -49,31 +49,31 @@ func (r *ReconcilePerconaServerMongoDB) enableBalancerIfNeeded(cr *api.PerconaSe
 
 	if msDepl.Status.UpdatedReplicas < msDepl.Status.Replicas {
 		log.Info("waiting for mongos update")
-		return nil
+		return false, nil
 	}
 
 	mongosPods, err := r.getMongosPods(cr)
 	if err != nil && !k8sErrors.IsNotFound(err) {
-		return errors.Wrap(err, "get pods list for mongos")
+		return false, errors.Wrap(err, "get pods list for mongos")
 	}
 
 	if len(mongosPods.Items) == 0 {
-		return nil
+		return false, nil
 	}
 	for _, p := range mongosPods.Items {
 		if p.Status.Phase != corev1.PodRunning {
-			return nil
+			return false, nil
 		}
 		for _, cs := range p.Status.ContainerStatuses {
 			if !cs.Ready {
-				return nil
+				return false, nil
 			}
 		}
 	}
 
 	mongosSession, err := r.mongosClientWithRole(cr, roleClusterAdmin)
 	if err != nil {
-		return errors.Wrap(err, "failed to get mongos connection")
+		return false, errors.Wrap(err, "failed to get mongos connection")
 	}
 
 	defer func() {
@@ -85,19 +85,19 @@ func (r *ReconcilePerconaServerMongoDB) enableBalancerIfNeeded(cr *api.PerconaSe
 
 	run, err := mongo.IsBalancerRunning(context.TODO(), mongosSession)
 	if err != nil {
-		return errors.Wrap(err, "failed to check if balancer running")
+		return false, errors.Wrap(err, "failed to check if balancer running")
 	}
 
 	if !run {
 		err := mongo.StartBalancer(context.TODO(), mongosSession)
 		if err != nil {
-			return errors.Wrap(err, "failed to start balancer")
+			return false, errors.Wrap(err, "failed to start balancer")
 		}
 
 		log.Info("balancer enabled")
 	}
 
-	return nil
+	return true, nil
 }
 
 func (r *ReconcilePerconaServerMongoDB) disableBalancer(cr *api.PerconaServerMongoDB) error {

--- a/pkg/controller/perconaservermongodb/finalizers.go
+++ b/pkg/controller/perconaservermongodb/finalizers.go
@@ -27,6 +27,10 @@ func (r *ReconcilePerconaServerMongoDB) checkFinalizers(cr *api.PerconaServerMon
 	cr.SetFinalizers(finalizers)
 	err := r.client.Update(context.TODO(), cr)
 
+	if err == nil && len(finalizers) > 0 {
+		err = errors.New("failed to run finalizers")
+	}
+
 	return err
 }
 

--- a/pkg/controller/perconaservermongodbrestore/perconaservermongodbrestore_controller.go
+++ b/pkg/controller/perconaservermongodbrestore/perconaservermongodbrestore_controller.go
@@ -96,7 +96,7 @@ func (r *ReconcilePerconaServerMongoDBRestore) Reconcile(request reconcile.Reque
 			// Request object not found, could have been deleted after reconcile request.
 			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
 			// Return and don't requeue
-			return rr, nil
+			return reconcile.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
 		return rr, err
@@ -132,6 +132,11 @@ func (r *ReconcilePerconaServerMongoDBRestore) Reconcile(request reconcile.Reque
 	status, err = r.reconcileRestore(cr)
 	if err != nil {
 		return rr, fmt.Errorf("reconcile: %v", err)
+	}
+
+	switch status.State {
+	case psmdbv1.RestoreStateReady, psmdbv1.RestoreStateError:
+		return reconcile.Result{}, nil
 	}
 
 	return rr, nil


### PR DESCRIPTION
[![K8SPSMDB-650](https://badgen.net/badge/JIRA/K8SPSMDB-650/green)](https://jira.percona.com/browse/K8SPSMDB-650) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Currently reconcile returns `RequeueAfter` set to 5 seconds even on success. This leads to reconcile object every 5 seconds forever.