### PR TITLE
K8SPSMDB-640: Fix updating custom labels

### DIFF
--- a/pkg/controller/perconaservermongodb/psmdb_controller.go
+++ b/pkg/controller/perconaservermongodb/psmdb_controller.go
@@ -1180,6 +1180,17 @@ func (r *ReconcilePerconaServerMongoDB) reconcileStatefulSet(
 		volumeSpec = replset.NonVoting.VolumeSpec
 	}
 
+	customLabels := make(map[string]string, len(matchLabels))
+	for k, v := range matchLabels {
+		customLabels[k] = v
+	}
+
+	for k, v := range multiAZ.Labels {
+		if _, ok := customLabels[k]; !ok {
+			customLabels[k] = v
+		}
+	}
+
 	sfs := psmdb.NewStatefulSet(sfsName, cr.Namespace)
 	err := setControllerReference(cr, sfs, r.scheme)
 	if err != nil {
@@ -1205,7 +1216,7 @@ func (r *ReconcilePerconaServerMongoDB) reconcileStatefulSet(
 		return nil, errors.Wrap(err, "check if mongod custom configuration exists")
 	}
 
-	sfsSpec, err := psmdb.StatefulSpec(cr, replset, containerName, matchLabels,
+	sfsSpec, err := psmdb.StatefulSpec(cr, replset, containerName, matchLabels, customLabels,
 		multiAZ, size, internalKeyName, inits, log, customConfig, resources,
 		podSecurityContext, containerSecurityContext, livenessProbe, readinessProbe,
 		configuration, configName)
@@ -1282,7 +1293,7 @@ func (r *ReconcilePerconaServerMongoDB) reconcileStatefulSet(
 	} else {
 		if volumeSpec.PersistentVolumeClaim != nil {
 			sfsSpec.VolumeClaimTemplates = []corev1.PersistentVolumeClaim{
-				psmdb.PersistentVolumeClaim(psmdb.MongodDataVolClaimName, cr.Namespace, replset.Labels, volumeSpec.PersistentVolumeClaim),
+				psmdb.PersistentVolumeClaim(psmdb.MongodDataVolClaimName, cr.Namespace, volumeSpec.PersistentVolumeClaim),
 			}
 		} else {
 			sfsSpec.Template.Spec.Volumes = append(sfsSpec.Template.Spec.Volumes,
@@ -1345,8 +1356,10 @@ func (r *ReconcilePerconaServerMongoDB) reconcileStatefulSet(
 	}
 
 	sfs.Spec = sfsSpec
-	if cr.CompareVersion("1.6.0") >= 0 {
+	if cr.CompareVersion("1.6.0") >= 0 && cr.CompareVersion("1.12.0") < 0 {
 		sfs.Labels = matchLabels
+	} else if cr.CompareVersion("1.12.0") >= 0 {
+		sfs.Labels = customLabels
 	}
 
 	err = r.createOrUpdate(sfs)
@@ -1359,11 +1372,42 @@ func (r *ReconcilePerconaServerMongoDB) reconcileStatefulSet(
 		return nil, errors.Wrapf(err, "PodDisruptionBudget for %s", sfs.Name)
 	}
 
+	if err := r.reconcilePVCs(sfs, matchLabels); err != nil {
+		return nil, errors.Wrapf(err, "reconcile PVCs for %s", sfs.Name)
+	}
+
 	if err := r.smartUpdate(cr, sfs, replset); err != nil {
 		return nil, errors.Wrap(err, "failed to run smartUpdate")
 	}
 
 	return sfs, nil
+}
+
+func (r *ReconcilePerconaServerMongoDB) reconcilePVCs(sfs *appsv1.StatefulSet, ls map[string]string) error {
+	pvcList := &corev1.PersistentVolumeClaimList{}
+	err := r.client.List(context.TODO(), pvcList, &client.ListOptions{
+		Namespace:     sfs.Namespace,
+		LabelSelector: labels.SelectorFromSet(ls),
+	})
+	if err != nil {
+		return errors.Wrap(err, "list PVCs")
+	}
+
+	for _, pvc := range pvcList.Items {
+		if compareMaps(sfs.Labels, pvc.Labels) {
+			continue
+		}
+
+		orig := pvc.DeepCopy()
+		pvc.Labels = sfs.Labels
+		patch := client.MergeFrom(orig)
+
+		if err := r.client.Patch(context.TODO(), &pvc, patch); err != nil {
+			log.Error(err, "patch PVC", "PVC", pvc.Name)
+		}
+	}
+
+	return nil
 }
 
 func (r *ReconcilePerconaServerMongoDB) operatorPod() (corev1.Pod, error) {
@@ -1558,6 +1602,7 @@ func OwnerRef(ro runtime.Object, scheme *runtime.Scheme) (metav1.OwnerReference,
 	}, nil
 }
 
+// compareMaps returns true if two maps are equal
 func compareMaps(x, y map[string]string) bool {
 	if len(x) != len(y) {
 		return false

--- a/pkg/psmdb/statefulset.go
+++ b/pkg/psmdb/statefulset.go
@@ -31,7 +31,7 @@ var secretFileMode int32 = 288
 // StatefulSpec returns spec for stateful set
 // TODO: Unify Arbiter and Node. Shoudn't be 100500 parameters
 func StatefulSpec(m *api.PerconaServerMongoDB, replset *api.ReplsetSpec, containerName string,
-	ls map[string]string, multiAZ api.MultiAZ, size int32, ikeyName string,
+	ls map[string]string, customLabels map[string]string, multiAZ api.MultiAZ, size int32, ikeyName string,
 	initContainers []corev1.Container, log logr.Logger, customConf CustomConfig,
 	resourcesSpec *api.ResourcesSpec, podSecurityContext *corev1.PodSecurityContext,
 	containerSecurityContext *corev1.SecurityContext, livenessProbe *api.LivenessProbeExtended,
@@ -43,17 +43,6 @@ func StatefulSpec(m *api.PerconaServerMongoDB, replset *api.ReplsetSpec, contain
 	resources, err := CreateResources(resourcesSpec)
 	if err != nil {
 		return appsv1.StatefulSetSpec{}, fmt.Errorf("resource creation: %v", err)
-	}
-
-	customLabels := make(map[string]string, len(ls))
-	for k, v := range ls {
-		customLabels[k] = v
-	}
-
-	for k, v := range multiAZ.Labels {
-		if _, ok := customLabels[k]; !ok {
-			customLabels[k] = v
-		}
 	}
 
 	volumes := []corev1.Volume{
@@ -155,7 +144,7 @@ func MongosCustomConfigName(clusterName string) string {
 }
 
 // PersistentVolumeClaim returns a Persistent Volume Claims for Mongod pod
-func PersistentVolumeClaim(name, namespace string, labels map[string]string, spec *corev1.PersistentVolumeClaimSpec) corev1.PersistentVolumeClaim {
+func PersistentVolumeClaim(name, namespace string, spec *corev1.PersistentVolumeClaimSpec) corev1.PersistentVolumeClaim {
 	return corev1.PersistentVolumeClaim{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PersistentVolumeClaim",
@@ -164,7 +153,6 @@ func PersistentVolumeClaim(name, namespace string, labels map[string]string, spe
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
-			Labels:    labels,
 		},
 		Spec: *spec,
 	}


### PR DESCRIPTION
We were passing custom labels defined in CR to
PersistentVolumeClaimTemplate in StatefulSets to fix K8SPSMDB-437.
Although it's working for the *initial deploy*, if the user updates the
custom labels the reconciliation stuck because it's not allowed to
update PVC template in StatefulSet.

To fix this problem, this commit introduces a new function that patches
PVCs to update their labels in every reconciliation and ensure
StatefulSet labels match the PVC labels.