### PR TITLE
Adding support for enabling replication over a service mesh

### DIFF
--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
 #  platform: openshift
 #  clusterServiceDNSSuffix: svc.cluster.local
+#  clusterServiceDNSMode: "ServiceMesh"
 #  pause: true
 #  unmanaged: false
   crVersion: 1.12.0

--- a/pkg/apis/psmdb/v1/psmdb_types.go
+++ b/pkg/apis/psmdb/v1/psmdb_types.go
@@ -3,9 +3,10 @@ package v1
 import (
 	"encoding/json"
 	"fmt"
-	"gopkg.in/yaml.v2"
 	"strconv"
 	"strings"
+
+	"gopkg.in/yaml.v2"
 
 	"github.com/go-logr/logr"
 	v "github.com/hashicorp/go-version"
@@ -71,6 +72,7 @@ type PerconaServerMongoDBSpec struct {
 	UpgradeOptions          UpgradeOptions                       `json:"upgradeOptions,omitempty"`
 	SchedulerName           string                               `json:"schedulerName,omitempty"`
 	ClusterServiceDNSSuffix string                               `json:"clusterServiceDNSSuffix,omitempty"`
+	ClusterServiceDNSMode   corev1.DnsMode                       `json:"clusterServiceDNSMode,omitempty"`
 	Sharding                Sharding                             `json:"sharding,omitempty"`
 	InitImage               string                               `json:"initImage,omitempty"`
 	TLS                     *TLSSpec                             `json:"tls,omitempty"`

--- a/pkg/apis/psmdb/v1/psmdb_types.go
+++ b/pkg/apis/psmdb/v1/psmdb_types.go
@@ -3,10 +3,9 @@ package v1
 import (
 	"encoding/json"
 	"fmt"
+	"gopkg.in/yaml.v2"
 	"strconv"
 	"strings"
-
-	"gopkg.in/yaml.v2"
 
 	"github.com/go-logr/logr"
 	v "github.com/hashicorp/go-version"

--- a/vendor/k8s.io/api/core/v1/types.go
+++ b/vendor/k8s.io/api/core/v1/types.go
@@ -4146,6 +4146,20 @@ const (
 	ServiceTypeExternalName ServiceType = "ExternalName"
 )
 
+// DNS Mode string describes the mode used to generate fqdn/ip for communication between nodes
+// +enum
+type DnsMode string
+
+const (
+	// DnsModeServiceMesh means a FQDN will be generated, assumming the FQDN is resolvable
+	// and available in all clusters
+	DnsModeServiceMesh DnsMode = "ServiceMesh"
+
+	// DnsModeInternal means a FQDN (svc.cluster.local), a ClusterIP or a public IP will be used
+	// depending on how the service is exposed
+	DnsModeInternal DnsMode = "Internal"
+)
+
 // ServiceInternalTrafficPolicyType describes the type of traffic routing for
 // internal traffic
 // +enum


### PR DESCRIPTION

Hi.

### Description

This is intended to be as an extension of support for multi-cluster replication, in this case enabling replication over a service mesh or in cases where routing is mainly done based on FQDN (i.e. routing through proxies).

This PR adds the option of using the service FQDN in the mongodb config rather than using ClusterIP or LoadBalancer IP mainly with the goal of supporting routing options where IP addresses might wary between the cluster. 

### Background

We're trying to add mongodb replication to a secondary cluster, but we didn't want to expose mongodb instances on a public network. Since we're also working on adding all clusters into a service mesh, in our case using [GlooMesh](https://www.solo.io/products/gloo-mesh/) (and by extension Istio), we figured it would be a good idea to try and get replication working within the service mesh.

After working with the engineers behind GlooMesh to manage communication between clusters within the service mesh (a bit more on the communication problem https://github.com/jlyshoel/statefulset-gloomesh-poc) we got that sorted, so all our mongodb pods are able to reach all other mongodb pods.

The problem we then ran into is that they aren't reachable by internal IP or by "[pod].[statefulset].svc.cluster.local", and by adding externalNodes in the config for the operator managed cluster, we're also required to set that all nodes are exposed using ClusterIP. 

The current way the operator works, if I set exposed=true and type=ClusterIP it will put the local IP addresses of the service into the mongodb config. These IP addresses aren't available in the remote cluster. We have to use FQDN, which are the same in all clusters, but they resolve to different IP's and are routed by the service mesh to the correct pod.

We're able to get it working by:
 - Exposing all pods as a service with ClusterIP
 - Tweaking the server addresses in the operator a bit (hence this PR), and use the FQDN of both the local and remote services

![illustration drawio](https://user-images.githubusercontent.com/25656625/159646781-bdfc3ab0-cc54-4df7-9e13-13892b49c302.png)

I do get that this is probably an edge-case, and it would need a bit more documentation to convey what's going on. Enabling this "service mesh mode" would require the clusters to already have a configured and working service mesh, otherwise it probably wont work. Using i.e. GlooMesh the [setup](https://github.com/solo-io/workshops/tree/master/gloo-mesh-2-0) is not that complicated. If there is any docs I can contribute to, please let me know. 

### Configuration

There are two options implemented: 

clusterServiceDNSMode
 - ServiceMesh: Use service FQDN (service.namespace.clusterServiceDNSSuffix) when generating host names for mongodb instances in cases where nodes are exposed.
 - Internal: Use internal DNS name if nodes are not exposed (pod.statefulset.namespace.clusterServiceDNSSuffix) and internal IP if nodes are exposed using ClusterIP. 