### PR TITLE
Fix version of go-licenses

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -233,7 +233,7 @@ pipeline {
                             -v $WORKSPACE/src/github.com/percona/percona-server-mongodb-operator:/go/src/github.com/percona/percona-server-mongodb-operator \
                             -w /go/src/github.com/percona/percona-server-mongodb-operator \
                             golang:1.17 sh -c '
-                                go install github.com/google/go-licenses@latest;
+                                go install github.com/google/go-licenses@v1.0.0;
                                 /go/bin/go-licenses csv github.com/percona/percona-server-mongodb-operator/cmd/manager \
                                     | cut -d , -f 3 \
                                     | sort -u \


### PR DESCRIPTION
A few hours ago v1.1.0 released and now it breaks our builds.
See: https://github.com/google/go-licenses/issues/125