### PR TITLE
K8SPSMDB-669 fix: encryption turns on while updating to 1.12.0

### DIFF
--- a/pkg/apis/psmdb/v1/psmdb_types.go
+++ b/pkg/apis/psmdb/v1/psmdb_types.go
@@ -367,20 +367,21 @@ func (conf MongoConfiguration) GetOptions(name string) (map[interface{}]interfac
 	return options, nil
 }
 
-func (conf MongoConfiguration) IsEncryptionEnabled() (bool, error) {
+// IsEncryptionEnabled returns nil if "enableEncryption" field is not specified or the pointer to the value of this field
+func (conf MongoConfiguration) IsEncryptionEnabled() (*bool, error) {
 	m, err := conf.GetOptions("security")
 	if err != nil || m == nil {
-		return true, err // true by default
+		return nil, err
 	}
 	enabled, ok := m["enableEncryption"]
 	if !ok {
-		return true, nil // true by default
+		return nil, nil
 	}
 	b, ok := enabled.(bool)
 	if !ok {
-		return false, errors.New("enableEncryption value is not bool")
+		return nil, errors.New("enableEncryption value is not bool")
 	}
-	return b, nil
+	return &b, nil
 }
 
 // setEncryptionDefaults sets encryptionKeyFile to a default value if enableEncryption is specified.
@@ -881,5 +882,5 @@ func (cr *PerconaServerMongoDB) GetExternalNodes() []*ExternalNode {
 }
 
 func (cr *PerconaServerMongoDB) MCSEnabled() bool {
-    return mcs.IsAvailable() && cr.Spec.MultiCluster.Enabled
+	return mcs.IsAvailable() && cr.Spec.MultiCluster.Enabled
 }

--- a/pkg/psmdb/statefulset.go
+++ b/pkg/psmdb/statefulset.go
@@ -203,7 +203,13 @@ func isEncryptionEnabled(cr *api.PerconaServerMongoDB, replset *api.ReplsetSpec)
 		if err != nil {
 			return false, errors.Wrap(err, "failed to parse replset configuration")
 		}
-		return enabled, nil
+		if enabled == nil {
+			if cr.Spec.Mongod.Security != nil && cr.Spec.Mongod.Security.EnableEncryption != nil {
+				return *cr.Spec.Mongod.Security.EnableEncryption, nil
+			}
+			return true, nil // true by default
+		}
+		return *enabled, nil
 	}
 	return *cr.Spec.Mongod.Security.EnableEncryption, nil
 }


### PR DESCRIPTION
[![K8SPSMDB-669](https://badgen.net/badge/JIRA/K8SPSMDB-669/green)](https://jira.percona.com/browse/K8SPSMDB-669) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://jira.percona.com/browse/K8SPSMDB-669

Fixed `isEncyptionEnabled` func. On the 1.12.0 version, we were ignoring the `mongod.security.enableEncryption` field and set it to true by default if another value was not specified in the replset's `configuration` section. Now we use mongod's value if it's not specified in the configuration section