### PR TITLE
K8SPSMDB-681: Fix SSL errors after upgrading from 1.11.0

### DIFF
--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -630,7 +630,6 @@ spec:
                             required:
                               - bucket
                               - credentialsSecret
-                              - insecureSkipTLSVerify
                             type: object
                           type:
                             type: string

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -630,7 +630,6 @@ spec:
                             required:
                               - bucket
                               - credentialsSecret
-                              - insecureSkipTLSVerify
                             type: object
                           type:
                             type: string
@@ -20721,7 +20720,6 @@ spec:
                   required:
                     - bucket
                     - credentialsSecret
-                    - insecureSkipTLSVerify
                   type: object
                 start:
                   format: date-time
@@ -20841,7 +20839,6 @@ spec:
                       required:
                         - bucket
                         - credentialsSecret
-                        - insecureSkipTLSVerify
                       type: object
                     start:
                       format: date-time

--- a/e2e-tests/version-service/conf/crd.yaml
+++ b/e2e-tests/version-service/conf/crd.yaml
@@ -630,7 +630,6 @@ spec:
                             required:
                               - bucket
                               - credentialsSecret
-                              - insecureSkipTLSVerify
                             type: object
                           type:
                             type: string
@@ -20746,7 +20745,6 @@ spec:
                   required:
                     - bucket
                     - credentialsSecret
-                    - insecureSkipTLSVerify
                   type: object
                 start:
                   format: date-time
@@ -20866,7 +20864,6 @@ spec:
                       required:
                         - bucket
                         - credentialsSecret
-                        - insecureSkipTLSVerify
                       type: object
                     start:
                       format: date-time

--- a/pkg/apis/psmdb/v1/psmdb_types.go
+++ b/pkg/apis/psmdb/v1/psmdb_types.go
@@ -661,7 +661,7 @@ type BackupStorageS3Spec struct {
 	UploadPartSize        int    `json:"uploadPartSize,omitempty"`
 	MaxUploadParts        int    `json:"maxUploadParts,omitempty"`
 	StorageClass          string `json:"storageClass,omitempty"`
-	InsecureSkipTLSVerify bool   `json:"insecureSkipTLSVerify"`
+	InsecureSkipTLSVerify bool   `json:"insecureSkipTLSVerify,omitempty"`
 }
 
 type BackupStorageAzureSpec struct {


### PR DESCRIPTION
[![K8SPSMDB-681](https://badgen.net/badge/JIRA/K8SPSMDB-681/green)](https://jira.percona.com/browse/K8SPSMDB-681) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

After upgrading the operator from 1.11.0, SSL secrets are updated
immediately to include MCS SANs. This were causing SSL errors during
smart update since the operator immediately starts using the new
certificate but the mongod containers continue using the old ones. We
shouldn't update SSL certs when their secrets already exist.