### PR TITLE
K8SPSMDB-631 - Remove cacheSizeRatio/inMemorySizeRatio from custom config

### DIFF
--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -58,12 +58,8 @@ spec:
 #        verbosity: 1
 #      storage:
 #        engine: wiredTiger
-#        inMemory:
-#          engineConfig:
-#            inMemorySizeRatio: 0.9
 #        wiredTiger:
 #          engineConfig:
-#            cacheSizeRatio: 0.5
 #            directoryForIndexes: false
 #            journalCompressor: snappy
 #          collectionConfig:
@@ -94,6 +90,20 @@ spec:
 #      rack: rack-22
 #    nodeSelector:
 #      disktype: ssd
+#    storage:
+#      engine: wiredTiger
+#      wiredTiger:
+#        engineConfig:
+#          cacheSizeRatio: 0.5
+#          directoryForIndexes: false
+#          journalCompressor: snappy
+#        collectionConfig:
+#          blockCompressor: snappy
+#        indexConfig:
+#          prefixCompression: true
+#      inMemory:
+#        engineConfig:
+#           inMemorySizeRatio: 0.5
 #    livenessProbe:
 #      failureThreshold: 4
 #      initialDelaySeconds: 60
@@ -293,17 +303,6 @@ spec:
 #        rack: rack-22
 #      nodeSelector:
 #        disktype: ssd
-#      storage:
-#        engine: wiredTiger
-#        wiredTiger:
-#          engineConfig:
-#            cacheSizeRatio: 0.5
-#            directoryForIndexes: false
-#            journalCompressor: snappy
-#          collectionConfig:
-#            blockCompressor: snappy
-#          indexConfig:
-#            prefixCompression: true
 #      livenessProbe:
 #        failureThreshold: 4
 #        initialDelaySeconds: 60


### PR DESCRIPTION
[![K8SPSMDB-631](https://badgen.net/badge/JIRA/K8SPSMDB-631/green)](https://jira.percona.com/browse/K8SPSMDB-631) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

So `cacheSizeRatio` and `inMemorySizeRatio` need to be used from `replsets.storage` section since they are not mongodb options but operator options.