### PR TITLE
K8SPSMDB-691: Fix empty SSL secret name after patching CR

### DIFF
--- a/pkg/controller/perconaservermongodb/version.go
+++ b/pkg/controller/perconaservermongodb/version.go
@@ -281,7 +281,7 @@ func (r *ReconcilePerconaServerMongoDB) ensureVersion(ctx context.Context, cr *a
 		cr.Spec.PMM.Image = newVersion.PMMImage
 	}
 
-	err = r.client.Patch(ctx, cr, patch)
+	err = r.client.Patch(ctx, cr.DeepCopy(), patch)
 	if err != nil {
 		return errors.Wrap(err, "failed to update CR")
 	}


### PR DESCRIPTION
[![K8SPSMDB-691](https://badgen.net/badge/JIRA/K8SPSMDB-691/green)](https://jira.percona.com/browse/K8SPSMDB-691) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Patch updates the object with values returned from API server. This behavior removes our in-memory values.