### PR TITLE
K8SPSMDB-636: add `databaseAdmin` to `users` test and fix this test

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -936,7 +936,7 @@ patch_secret() {
 getSecretData() {
 	local secretName=$1
 	local dataKey=$2
-	local data=$(kubectl get secrets/${secretName} --template={{.data.${dataKey}}} | base64 -D)
+	local data=$(kubectl get secrets/${secretName} --template={{.data.${dataKey}}} | base64 -d)
 	echo "$data"
 }
 

--- a/e2e-tests/users/run
+++ b/e2e-tests/users/run
@@ -27,6 +27,16 @@ wait_for_running $cluster 3
 
 backup_name="backup-minio"
 
+desc 'Change MONGODB_DATABASE_ADMIN_PASSWORD'
+patch_secret "some-users" "MONGODB_DATABASE_ADMIN_PASSWORD" "$newpassencrypted"
+sleep 25
+wait_cluster_consistency $psmdb
+sleep 15
+user=$(getSecretData "some-users" "MONGODB_DATABASE_ADMIN_USER")
+check_mongo_auth "$user:$newpass@$cluster-0.$cluster.$namespace"
+check_mongo_auth "$user:$newpass@$cluster-1.$cluster.$namespace"
+check_mongo_auth "$user:$newpass@$cluster-2.$cluster.$namespace"
+
 desc 'Change MONGODB_BACKUP_PASSWORD'
 patch_secret "some-users" "MONGODB_BACKUP_PASSWORD" "$newpassencrypted"
 sleep 25

--- a/pkg/controller/perconaservermongodb/users.go
+++ b/pkg/controller/perconaservermongodb/users.go
@@ -227,6 +227,14 @@ func (r *ReconcilePerconaServerMongoDB) updateSysUsers(ctx context.Context, cr *
 			passKey: envMongoDBUserAdminPassword,
 		},
 	}
+	if cr.CompareVersion("1.13.0") >= 0 {
+		users = append([]user{
+			{
+				nameKey: envMongoDBDatabaseAdminUser,
+				passKey: envMongoDBDatabaseAdminPassword,
+			},
+		}, users...)
+	}
 	if cr.Spec.PMM.Enabled {
 		// insert in front
 		users = append([]user{


### PR DESCRIPTION
https://jira.percona.com/browse/K8SPSMDB-636

GNU coreutils base64 doesn't have `-D` flag. Because of that `getSecretData` function was failing.