### PR TITLE
Add env vars to control log output.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,7 @@ fabric.properties
 
 e2e-tests/init-deploy/smallrun
 deploy/crds/
+
+### VisualStudioCode ###
+.vscode/*
+.history

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -8,6 +8,9 @@ import (
 	"os"
 	"runtime"
 
+	"github.com/go-logr/logr"
+	uzap "go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
@@ -58,7 +61,8 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 
 	opts := zap.Options{
-		Development: false,
+		Encoder: getLogEncoder(setupLog),
+		Level:   getLogLevel(setupLog),
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
@@ -142,4 +146,43 @@ func main() {
 		os.Exit(1)
 	}
 
+}
+
+func getLogEncoder(log logr.Logger) zapcore.Encoder {
+	consoleEnc := zapcore.NewConsoleEncoder(uzap.NewDevelopmentEncoderConfig())
+
+	s, found := os.LookupEnv("LOG_STRUCTURED")
+	if !found {
+		return consoleEnc
+	}
+
+	useJson, err := strconv.ParseBool(s)
+	if err != nil {
+		log.Info(fmt.Sprintf("can't parse LOG_STRUCTURED env var: %s, using console logger", s))
+		return consoleEnc
+	}
+	if !useJson {
+		return consoleEnc
+	}
+
+	return zapcore.NewJSONEncoder(uzap.NewProductionEncoderConfig())
+}
+
+func getLogLevel(log logr.Logger) zapcore.LevelEnabler {
+	l, found := os.LookupEnv("LOG_LEVEL")
+	if !found {
+		return zapcore.InfoLevel
+	}
+
+	switch strings.ToUpper(l) {
+	case "DEBUG":
+		return zapcore.DebugLevel
+	case "INFO":
+		return zapcore.InfoLevel
+	case "ERROR":
+		return zapcore.ErrorLevel
+	default:
+		log.Info(fmt.Sprintf("unsupported log level: %s, using INFO level", l))
+		return zapcore.InfoLevel
+	}
 }

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -7,6 +7,8 @@ import (
 	"k8s.io/client-go/discovery"
 	"os"
 	"runtime"
+	"strconv"
+	"strings"
 
 	"github.com/go-logr/logr"
 	uzap "go.uber.org/zap"

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -31798,6 +31798,10 @@ spec:
           - percona-server-mongodb-operator
           imagePullPolicy: Always
           env:
+            - name: LOG_STRUCTURED
+              value: 'false'
+            - name: LOG_LEVEL
+              value: INFO
             - name: WATCH_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -24,6 +24,10 @@ spec:
           - percona-server-mongodb-operator
           imagePullPolicy: Always
           env:
+            - name: LOG_STRUCTURED
+              value: 'false'
+            - name: LOG_LEVEL
+              value: INFO
             - name: WATCH_NAMESPACE
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
Currently, the PSMDB operator had configured only structured logs which, when looking in the console, is really hard to parse.

Just as we have it in PSO, I added two env vars to control the log output, log level, and log formatting (structured or console).

```
          env:
            - name: LOG_STRUCTURED
              value: 'false'
            - name: LOG_LEVEL
              value: INFO
```