### PR TITLE
Revert "K8SPSMDB-636: add `databaseAdmin` to `users` test and fix this test"

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -949,7 +949,7 @@ patch_secret() {
 getSecretData() {
 	local secretName=$1
 	local dataKey=$2
-	local data=$(kubectl get secrets/${secretName} --template={{.data.${dataKey}}} | base64 -d)
+	local data=$(kubectl get secrets/${secretName} --template={{.data.${dataKey}}} | base64 -D)
 	echo "$data"
 }
 

--- a/e2e-tests/users/run
+++ b/e2e-tests/users/run
@@ -27,16 +27,6 @@ wait_for_running $cluster 3
 
 backup_name="backup-minio"
 
-desc 'Change MONGODB_DATABASE_ADMIN_PASSWORD'
-patch_secret "some-users" "MONGODB_DATABASE_ADMIN_PASSWORD" "$newpassencrypted"
-sleep 25
-wait_cluster_consistency $psmdb
-sleep 15
-user=$(getSecretData "some-users" "MONGODB_DATABASE_ADMIN_USER")
-check_mongo_auth "$user:$newpass@$cluster-0.$cluster.$namespace"
-check_mongo_auth "$user:$newpass@$cluster-1.$cluster.$namespace"
-check_mongo_auth "$user:$newpass@$cluster-2.$cluster.$namespace"
-
 desc 'Change MONGODB_BACKUP_PASSWORD'
 patch_secret "some-users" "MONGODB_BACKUP_PASSWORD" "$newpassencrypted"
 sleep 25
@@ -129,8 +119,6 @@ check_mongo_auth "$user:$pass@$cluster-2.$cluster.$namespace"
 desc 'Secret without userAdmin'
 kubectl_bin apply -f "${test_dir}/conf/secrets.yml"
 sleep 25
-user=$(getSecretData "some-users" "MONGODB_USER_ADMIN_USER")
-pass=$(getSecretData "some-users" "MONGODB_USER_ADMIN_PASSWORD")
 check_mongo_auth "$user:$pass@$cluster-0.$cluster.$namespace"
 check_mongo_auth "$user:$pass@$cluster-1.$cluster.$namespace"
 check_mongo_auth "$user:$pass@$cluster-2.$cluster.$namespace"

--- a/pkg/controller/perconaservermongodb/users.go
+++ b/pkg/controller/perconaservermongodb/users.go
@@ -227,14 +227,6 @@ func (r *ReconcilePerconaServerMongoDB) updateSysUsers(ctx context.Context, cr *
 			passKey: envMongoDBUserAdminPassword,
 		},
 	}
-	if cr.CompareVersion("1.13.0") >= 0 {
-		users = append([]user{
-			{
-				nameKey: envMongoDBDatabaseAdminUser,
-				passKey: envMongoDBDatabaseAdminPassword,
-			},
-		}, users...)
-	}
 	if cr.Spec.PMM.Enabled {
 		// insert in front
 		users = append([]user{


### PR DESCRIPTION
[![K8SPSMDB-636](https://badgen.net/badge/JIRA/K8SPSMDB-636/green)](https://jira.percona.com/browse/K8SPSMDB-636) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Reverts percona/percona-server-mongodb-operator#987