### PR TITLE
K8SPSMDB-745: fix telemetry when `upgradeOptions.apply` is set to `disabled` or `never`

### DIFF
--- a/pkg/controller/perconaservermongodb/vs.go
+++ b/pkg/controller/perconaservermongodb/vs.go
@@ -51,6 +51,11 @@ func (vs VersionServiceClient) GetExactVersion(cr *api.PerconaServerMongoDB, end
 		return DepVersion{}, err
 	}
 
+	// When Apply is set to "disabled" or "never" the payload will be empty
+	if !versionUpgradeEnabled(cr) {
+		return DepVersion{}, nil
+	}
+
 	if len(resp.Payload.Versions) == 0 {
 		return DepVersion{}, fmt.Errorf("empty versions response")
 	}


### PR DESCRIPTION
[![K8SPSMDB-745](https://badgen.net/badge/JIRA/K8SPSMDB-745/green)](https://jira.percona.com/browse/K8SPSMDB-745) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://jira.percona.com/browse/K8SPSMDB-745