### PR TITLE
K8SPSMDB-760 pdb is policy/v1 since v1.21.0

### DIFF
--- a/pkg/psmdb/pdb.go
+++ b/pkg/psmdb/pdb.go
@@ -1,23 +1,23 @@
 package psmdb
 
 import (
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
 )
 
-func PodDisruptionBudget(spec *api.PodDisruptionBudgetSpec, labels map[string]string, namespace string) *policyv1beta1.PodDisruptionBudget {
-	return &policyv1beta1.PodDisruptionBudget{
+func PodDisruptionBudget(spec *api.PodDisruptionBudgetSpec, labels map[string]string, namespace string) *policyv1.PodDisruptionBudget {
+	return &policyv1.PodDisruptionBudget{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "policy/v1beta1",
+			APIVersion: "policy/v1",
 			Kind:       "PodDisruptionBudget",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      labels["app.kubernetes.io/instance"] + "-" + labels["app.kubernetes.io/component"] + "-" + labels["app.kubernetes.io/replset"],
 			Namespace: namespace,
 		},
-		Spec: policyv1beta1.PodDisruptionBudgetSpec{
+		Spec: policyv1.PodDisruptionBudgetSpec{
 			MinAvailable:   spec.MinAvailable,
 			MaxUnavailable: spec.MaxUnavailable,
 			Selector: &metav1.LabelSelector{


### PR DESCRIPTION
[![K8SPSMDB-760](https://badgen.net/badge/JIRA/K8SPSMDB-760/green)](https://jira.percona.com/browse/K8SPSMDB-760) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Since version 1.21.0 of kubernetes, PodDisruptionBudget is at policy/v1, and since v1.25.0, policy/v1beta is not available anymore. This change will use v1 instead of v1beta for the PDB.