### PR TITLE
K8SPSMDB-763: Fix TLS config in healthcheck

### DIFF
--- a/healthcheck/tools/db/config.go
+++ b/healthcheck/tools/db/config.go
@@ -99,9 +99,6 @@ func NewConfig(app *kingpin.Application, envUser string, envPassword string) (*C
 	).Envar(pkg.EnvMongoDBNetSSLInsecure).BoolVar(&ssl.Insecure)
 
 	conf.SSL = ssl
-	if err := conf.configureTLS(); err != nil {
-		return nil, errors.Wrap(err, "get TLS config")
-	}
 
 	return conf, nil
 }

--- a/healthcheck/tools/db/db.go
+++ b/healthcheck/tools/db/db.go
@@ -36,6 +36,10 @@ func Dial(conf *Config) (*mgo.Client, error) {
 		"ssl_secure": conf.SSL.Insecure,
 	}).Debug("Connecting to mongodb")
 
+	if err := conf.configureTLS(); err != nil {
+		return nil, errors.Wrap(err, "configure TLS")
+	}
+
 	opts := options.Client().
 		SetHosts(conf.Hosts).
 		SetReplicaSet(conf.ReplSetName).


### PR DESCRIPTION
[![K8SPSMDB-763](https://badgen.net/badge/JIRA/K8SPSMDB-763/green)](https://jira.percona.com/browse/K8SPSMDB-763) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Turns out TLS configuration in mongodb-healthcheck is broken since
v1.12.0. kingpin fills config variables after `app.Parse` is called,
which makes effing sense.