### PR TITLE
CLOUD-739 Watch the operators' namespace in any case

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -82,6 +82,12 @@ func main() {
 		os.Exit(1)
 	}
 
+	operatorNamespace, err := k8s.GetOperatorNamespace()
+	if err != nil {
+		setupLog.Error(err, "failed to get operators' namespace")
+		os.Exit(1)
+	}
+
 	config, err := ctrl.GetConfig()
 	if err != nil {
 		setupLog.Error(err, "failed to get config")
@@ -99,9 +105,9 @@ func main() {
 	}
 
 	// Add support for MultiNamespace set in WATCH_NAMESPACE
-	if strings.Contains(namespace, ",") {
+	if len(namespace) > 0 {
 		options.Namespace = ""
-		options.NewCache = cache.MultiNamespacedCacheBuilder(strings.Split(namespace, ","))
+		options.NewCache = cache.MultiNamespacedCacheBuilder(append(strings.Split(namespace, ","), operatorNamespace))
 	}
 
 	mgr, err := ctrl.NewManager(config, options)

--- a/pkg/k8s/utils.go
+++ b/pkg/k8s/utils.go
@@ -2,7 +2,9 @@ package k8s
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
+	"strings"
 )
 
 const WatchNamespaceEnvVar = "WATCH_NAMESPACE"
@@ -14,4 +16,14 @@ func GetWatchNamespace() (string, error) {
 		return "", fmt.Errorf("%s must be set", WatchNamespaceEnvVar)
 	}
 	return ns, nil
+}
+
+// GetOperatorNamespace returns the namespace of the operator pod
+func GetOperatorNamespace() (string, error) {
+	nsBytes, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(string(nsBytes)), nil
 }


### PR DESCRIPTION
[![CLOUD-739](https://badgen.net/badge/JIRA/CLOUD-739/green)](https://jira.percona.com/browse/CLOUD-739) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The bug in K8SPXC-1123 revealed the flaw in our cw operation mode - basically we are ignoring the namespace where operator resides and it could lead to some issues. Fixing that.