### PR TITLE
K8SPSMDB-836 - Fix pbmStartingDeadline for backups in starting status

### DIFF
--- a/e2e-tests/demand-backup-sharded/run
+++ b/e2e-tests/demand-backup-sharded/run
@@ -52,6 +52,7 @@ sleep 2
 run_mongos \
 	'sh.enableSharding("myApp","rs0")' \
 	"myApp:myPass@$cluster-mongos.$namespace"
+sleep 2 # wait for propagation to cfg replica
 run_mongos \
 	'use myApp\n db.test.insert({ x: 100500 })' \
 	"myApp:myPass@$cluster-mongos.$namespace"

--- a/e2e-tests/demand-backup-sharded/run
+++ b/e2e-tests/demand-backup-sharded/run
@@ -48,11 +48,9 @@ desc 'write data, read from all'
 run_mongos \
 	'db.createUser({user:"myApp",pwd:"myPass",roles:[{db:"myApp",role:"readWrite"}]})' \
 	"userAdmin:userAdmin123456@$cluster-mongos.$namespace"
-sleep 2
 run_mongos \
-	'sh.enableSharding("myApp","rs0")' \
-	"myApp:myPass@$cluster-mongos.$namespace"
-sleep 2 # wait for propagation to cfg replica
+    'sh.enableSharding("myApp","rs0")' \
+    "clusterAdmin:clusterAdmin123456@$cluster-mongos.$namespace"
 run_mongos \
 	'use myApp\n db.test.insert({ x: 100500 })' \
 	"myApp:myPass@$cluster-mongos.$namespace"

--- a/e2e-tests/demand-backup-sharded/run
+++ b/e2e-tests/demand-backup-sharded/run
@@ -49,8 +49,8 @@ run_mongos \
 	'db.createUser({user:"myApp",pwd:"myPass",roles:[{db:"myApp",role:"readWrite"}]})' \
 	"userAdmin:userAdmin123456@$cluster-mongos.$namespace"
 run_mongos \
-    'sh.enableSharding("myApp","rs0")' \
-    "clusterAdmin:clusterAdmin123456@$cluster-mongos.$namespace"
+	'sh.enableSharding("myApp","rs0")' \
+	"clusterAdmin:clusterAdmin123456@$cluster-mongos.$namespace"
 run_mongos \
 	'use myApp\n db.test.insert({ x: 100500 })' \
 	"myApp:myPass@$cluster-mongos.$namespace"

--- a/pkg/controller/perconaservermongodbbackup/backup.go
+++ b/pkg/controller/perconaservermongodbbackup/backup.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	// pbmStartingDeadline is timeout after which continuous starting state is considered as error
-	pbmStartingDeadline       = time.Duration(120)
+	pbmStartingDeadline       = time.Duration(120) * time.Second
 	pbmStartingDeadlineErrMsg = "starting deadline exceeded"
 )
 


### PR DESCRIPTION
[![K8SPSMDB-836](https://badgen.net/badge/JIRA/K8SPSMDB-836/green)](https://jira.percona.com/browse/K8SPSMDB-836) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
Backups in starting status get immediatly tagged as error.

**Cause:**
`pbmStartingDeadline` variable is not set properly to 120 seconds, but uses nanoseconds instead.

**Solution:**
Convert variable to seconds.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Are E2E tests passing?
- [ ] Are unit tests passing?
- [ ] Are linting tests passing?
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?