### PR TITLE
K8SPSMDB-793 Removing irrelavent example

### DIFF
--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -236,10 +236,6 @@ spec:
           cpu: "300m"
           memory: "0.5G"
       volumeSpec:
-#      annotations:
-#        service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
-#      labels:
-#        rack: rack-22
 #        emptyDir: {}
 #        hostPath:
 #          path: /data
@@ -361,10 +357,6 @@ spec:
           cpu: "300m"
           memory: "0.5G"
       volumeSpec:
-#      annotations:
-#        service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
-#      labels:
-#        rack: rack-22
 #       emptyDir: {}
 #       hostPath:
 #         path: /data


### PR DESCRIPTION
[![K8SPSMDB-793](https://badgen.net/badge/JIRA/K8SPSMDB-793/green)](https://jira.percona.com/browse/K8SPSMDB-793) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Due to https://github.com/percona/percona-server-mongodb-operator/blob/804f6418792732b189b2b5bde1d03560da8cac7e/pkg/apis/psmdb/v1/psmdb_types.go#L549 we need to keep annotations only under persistentVolumeClaim

**CHANGE DESCRIPTION**
---
**Problem:**
*Some annotations/labels example is misleading*
**Cause:**
*Human factor possible*
**Solution:**
*Remove irrelevant*

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Are E2E tests passing?
- [ ] Are unit tests passing?
- [ ] Are linting tests passing?
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?