### PR TITLE
K8SPSMDB-820 Display namespace for removed backup job

### DIFF
--- a/pkg/controller/perconaservermongodb/backup.go
+++ b/pkg/controller/perconaservermongodb/backup.go
@@ -4,6 +4,9 @@ import (
 	"container/heap"
 	"context"
 	"fmt"
+	"reflect"
+	"strconv"
+
 	"github.com/robfig/cron/v3"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
@@ -11,9 +14,7 @@ import (
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
-	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"strconv"
 
 	"github.com/pkg/errors"
 
@@ -149,7 +150,7 @@ func (r *ReconcilePerconaServerMongoDB) deleteOldBackupTasks(ctx context.Context
 
 			}
 		} else {
-			log.Info("deleting outdated backup job", "name", item.Name)
+			log.Info("deleting outdated backup job", "name", item.Name, "namespace", cr.Namespace)
 			r.deleteBackupTask(cr, item.BackupTaskSpec)
 		}
 

--- a/pkg/controller/perconaservermongodb/backup.go
+++ b/pkg/controller/perconaservermongodb/backup.go
@@ -76,7 +76,7 @@ func (r *ReconcilePerconaServerMongoDB) createOrUpdateBackupTask(ctx context.Con
 	}
 
 	if !ok || t.Schedule != task.Schedule || t.StorageName != task.StorageName {
-		log.Info("Creating or updating backup job", "name", task.Name, "namespace", cr.Namespace, "schedule", task.Schedule)
+		log.Info("Creating or updating backup job", "cluster", cr.Name, "name", task.Name, "namespace", cr.Namespace, "schedule", task.Schedule)
 		r.deleteBackupTask(cr, t.BackupTaskSpec)
 		jobID, err := r.crons.crons.AddFunc(task.Schedule, r.createBackupTask(ctx, cr, task))
 		if err != nil {
@@ -150,7 +150,7 @@ func (r *ReconcilePerconaServerMongoDB) deleteOldBackupTasks(ctx context.Context
 
 			}
 		} else {
-			log.Info("deleting outdated backup job", "name", item.Name, "namespace", cr.Namespace)
+			log.Info("deleting outdated backup job", "cluster", cr.Name, "name", item.Name, "namespace", cr.Namespace)
 			r.deleteBackupTask(cr, item.BackupTaskSpec)
 		}
 


### PR DESCRIPTION
[![K8SPSMDB-820](https://badgen.net/badge/JIRA/K8SPSMDB-820/green)](https://jira.percona.com/browse/K8SPSMDB-820) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

With cluster-wide adoption we may need to extend some of our loggin messages

**CHANGE DESCRIPTION**
---
**Problem:**
*Namespace for backup job to be removed is not displayed. Operator log message is not informative in cluster-wide mode.*
`2023-02-01T14:38:53.680ZINFO    controller_psmdb        deleting outdated backup job    {"name": "weekly"}`
**Cause:**
*Just an improvement.*

**Solution:**
*Extending logmessage like in https://github.com/percona/percona-server-mongodb-operator/pull/1093/files#diff-e6b80da1c497ca61485fd1b6ab8a11741e81886efd87787d04ba1d3b0ff9dbbfR78.*

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Are E2E tests passing?
- [ ] Are unit tests passing?
- [ ] Are linting tests passing?
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?