### PR TITLE
K8SPSMDB-754: Use proper logger in controllers

### DIFF
--- a/healthcheck/tools/db/config.go
+++ b/healthcheck/tools/db/config.go
@@ -15,7 +15,6 @@
 package db
 
 import (
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -65,7 +64,7 @@ func NewConfig(app *kingpin.Application, envUser string, envPassword string) (*C
 
 	pwdFile := "/etc/users-secret/MONGODB_CLUSTER_MONITOR_PASSWORD"
 	if _, err := os.Stat(pwdFile); err == nil {
-		pass, err := ioutil.ReadFile(pwdFile)
+		pass, err := os.ReadFile(pwdFile)
 		if err != nil {
 			return nil, errors.Wrapf(err, "read %s", pwdFile)
 		}

--- a/healthcheck/tools/db/ssl.go
+++ b/healthcheck/tools/db/ssl.go
@@ -17,7 +17,6 @@ package db
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
 	"os"
 
 	"github.com/pkg/errors"
@@ -34,7 +33,7 @@ type SSLConfig struct {
 }
 
 func (sc *SSLConfig) loadCaCertificate() (*x509.CertPool, error) {
-	caCert, err := ioutil.ReadFile(sc.CAFile)
+	caCert, err := os.ReadFile(sc.CAFile)
 	if err != nil {
 		return nil, err
 	}

--- a/healthcheck/tools/util.go
+++ b/healthcheck/tools/util.go
@@ -15,7 +15,7 @@
 package tools
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -68,7 +68,7 @@ func StringFromFile(fileName string) *string {
 			return nil
 		}
 		defer file.Close()
-		bytes, err := ioutil.ReadAll(file)
+		bytes, err := io.ReadAll(file)
 		if err == nil {
 			data := strings.TrimSpace(string(bytes))
 			return &data

--- a/pkg/controller/perconaservermongodb/backup.go
+++ b/pkg/controller/perconaservermongodb/backup.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"strconv"
 
 	"github.com/pkg/errors"
@@ -76,7 +76,7 @@ func (r *ReconcilePerconaServerMongoDB) createOrUpdateBackupTask(ctx context.Con
 	}
 
 	if !ok || t.Schedule != task.Schedule || t.StorageName != task.StorageName {
-		log.FromContext(ctx).Info("Creating or updating backup job", "name", task.Name, "namespace", cr.Namespace, "schedule", task.Schedule)
+		logf.FromContext(ctx).Info("Creating or updating backup job", "name", task.Name, "namespace", cr.Namespace, "schedule", task.Schedule)
 		r.deleteBackupTask(cr, t.BackupTaskSpec)
 		jobID, err := r.crons.crons.AddFunc(task.Schedule, r.createBackupTask(ctx, cr, task))
 		if err != nil {
@@ -92,7 +92,7 @@ func (r *ReconcilePerconaServerMongoDB) createOrUpdateBackupTask(ctx context.Con
 }
 
 func (r *ReconcilePerconaServerMongoDB) deleteOldBackupTasks(ctx context.Context, cr *api.PerconaServerMongoDB, ctasks map[string]api.BackupTaskSpec) error {
-	log := log.FromContext(ctx)
+	log := logf.FromContext(ctx)
 
 	if cr.CompareVersion("1.13.0") < 0 {
 		ls := backup.NewBackupCronJobLabels(cr.Name, cr.Spec.Backup.Labels)
@@ -162,7 +162,7 @@ func (r *ReconcilePerconaServerMongoDB) deleteOldBackupTasks(ctx context.Context
 }
 
 func (r *ReconcilePerconaServerMongoDB) createBackupTask(ctx context.Context, cr *api.PerconaServerMongoDB, task api.BackupTaskSpec) func() {
-	log := log.FromContext(ctx)
+	log := logf.FromContext(ctx)
 
 	return func() {
 		localCr := &api.PerconaServerMongoDB{}
@@ -319,7 +319,7 @@ func (r *ReconcilePerconaServerMongoDB) hasFullBackup(ctx context.Context, cr *a
 }
 
 func (r *ReconcilePerconaServerMongoDB) updatePITR(ctx context.Context, cr *api.PerconaServerMongoDB) error {
-	log := log.FromContext(ctx)
+	log := logf.FromContext(ctx)
 
 	if !cr.Spec.Backup.Enabled {
 		return nil

--- a/pkg/controller/perconaservermongodb/backup.go
+++ b/pkg/controller/perconaservermongodb/backup.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"strconv"
 
 	"github.com/pkg/errors"
 

--- a/pkg/controller/perconaservermongodb/backup.go
+++ b/pkg/controller/perconaservermongodb/backup.go
@@ -18,7 +18,6 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"strconv"
 
-
 	"github.com/pkg/errors"
 
 	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"

--- a/pkg/controller/perconaservermongodb/balancer.go
+++ b/pkg/controller/perconaservermongodb/balancer.go
@@ -4,16 +4,20 @@ import (
 	"context"
 	"time"
 
-	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
 	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb"
 	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb/mongo"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
 )
 
 func (r *ReconcilePerconaServerMongoDB) enableBalancerIfNeeded(ctx context.Context, cr *api.PerconaServerMongoDB) error {
+	log := log.FromContext(ctx)
+
 	if !cr.Spec.Sharding.Enabled || cr.Spec.Sharding.Mongos.Size == 0 || cr.Spec.Unmanaged {
 		return nil
 	}
@@ -101,6 +105,8 @@ func (r *ReconcilePerconaServerMongoDB) enableBalancerIfNeeded(ctx context.Conte
 }
 
 func (r *ReconcilePerconaServerMongoDB) disableBalancer(ctx context.Context, cr *api.PerconaServerMongoDB) error {
+	log := log.FromContext(ctx)
+
 	if !cr.Spec.Sharding.Enabled || cr.Spec.Unmanaged {
 		return nil
 	}

--- a/pkg/controller/perconaservermongodb/balancer.go
+++ b/pkg/controller/perconaservermongodb/balancer.go
@@ -10,13 +10,13 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
 )
 
 func (r *ReconcilePerconaServerMongoDB) enableBalancerIfNeeded(ctx context.Context, cr *api.PerconaServerMongoDB) error {
-	log := log.FromContext(ctx)
+	log := logf.FromContext(ctx)
 
 	if !cr.Spec.Sharding.Enabled || cr.Spec.Sharding.Mongos.Size == 0 || cr.Spec.Unmanaged {
 		return nil
@@ -105,7 +105,7 @@ func (r *ReconcilePerconaServerMongoDB) enableBalancerIfNeeded(ctx context.Conte
 }
 
 func (r *ReconcilePerconaServerMongoDB) disableBalancer(ctx context.Context, cr *api.PerconaServerMongoDB) error {
-	log := log.FromContext(ctx)
+	log := logf.FromContext(ctx)
 
 	if !cr.Spec.Sharding.Enabled || cr.Spec.Unmanaged {
 		return nil

--- a/pkg/controller/perconaservermongodb/fcv.go
+++ b/pkg/controller/perconaservermongodb/fcv.go
@@ -6,6 +6,7 @@ import (
 	v "github.com/hashicorp/go-version"
 	"github.com/pkg/errors"
 	mgo "go.mongodb.org/mongo-driver/mongo"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
 	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb/mongo"
@@ -19,7 +20,7 @@ func (r *ReconcilePerconaServerMongoDB) getFCV(ctx context.Context, cr *api.Perc
 
 	defer func() {
 		if err := c.Disconnect(ctx); err != nil {
-			log.Error(err, "close client connection")
+			log.FromContext(ctx).Error(err, "close client connection")
 		}
 	}()
 
@@ -51,7 +52,7 @@ func (r *ReconcilePerconaServerMongoDB) setFCV(ctx context.Context, cr *api.Perc
 
 	defer func() {
 		if err := cli.Disconnect(ctx); err != nil {
-			log.Error(err, "close client connection")
+			log.FromContext(ctx).Error(err, "close client connection")
 		}
 	}()
 

--- a/pkg/controller/perconaservermongodb/fcv.go
+++ b/pkg/controller/perconaservermongodb/fcv.go
@@ -6,7 +6,7 @@ import (
 	v "github.com/hashicorp/go-version"
 	"github.com/pkg/errors"
 	mgo "go.mongodb.org/mongo-driver/mongo"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
 	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb/mongo"
@@ -20,7 +20,7 @@ func (r *ReconcilePerconaServerMongoDB) getFCV(ctx context.Context, cr *api.Perc
 
 	defer func() {
 		if err := c.Disconnect(ctx); err != nil {
-			log.FromContext(ctx).Error(err, "close client connection")
+			logf.FromContext(ctx).Error(err, "close client connection")
 		}
 	}()
 
@@ -52,7 +52,7 @@ func (r *ReconcilePerconaServerMongoDB) setFCV(ctx context.Context, cr *api.Perc
 
 	defer func() {
 		if err := cli.Disconnect(ctx); err != nil {
-			log.FromContext(ctx).Error(err, "close client connection")
+			logf.FromContext(ctx).Error(err, "close client connection")
 		}
 	}()
 

--- a/pkg/controller/perconaservermongodb/finalizers.go
+++ b/pkg/controller/perconaservermongodb/finalizers.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
 )
@@ -17,7 +17,7 @@ import (
 var errWaitingTermination = errors.New("waiting pods to be deleted")
 
 func (r *ReconcilePerconaServerMongoDB) checkFinalizers(ctx context.Context, cr *api.PerconaServerMongoDB) (shouldReconcile bool, err error) {
-	log := log.FromContext(ctx)
+	log := logf.FromContext(ctx)
 
 	shouldReconcile = false
 	orderedFinalizers := cr.GetOrderedFinalizers()
@@ -119,7 +119,7 @@ func (r *ReconcilePerconaServerMongoDB) deleteAllStatefulsets(ctx context.Contex
 	}
 
 	for _, sts := range stsList.Items {
-		log.FromContext(ctx).Info("deleting StatefulSet", "name", sts.Name)
+		logf.FromContext(ctx).Info("deleting StatefulSet", "name", sts.Name)
 		err := r.client.Delete(ctx, &sts)
 		if err != nil {
 			return errors.Wrapf(err, "failed to delete StatefulSet %s", sts.Name)
@@ -136,7 +136,7 @@ func (r *ReconcilePerconaServerMongoDB) deleteAllPVC(ctx context.Context, cr *ap
 	}
 
 	for _, pvc := range pvcList.Items {
-		log.FromContext(ctx).Info("deleting PVC", "name", pvc.Name)
+		logf.FromContext(ctx).Info("deleting PVC", "name", pvc.Name)
 		err := r.client.Delete(ctx, &pvc)
 		if err != nil {
 			return errors.Wrapf(err, "failed to delete PVC %s", pvc.Name)
@@ -169,7 +169,7 @@ func (r *ReconcilePerconaServerMongoDB) deleteSecrets(ctx context.Context, cr *a
 			continue
 		}
 
-		log.FromContext(ctx).Info("deleting secret", "name", secret.Name)
+		logf.FromContext(ctx).Info("deleting secret", "name", secret.Name)
 		err = r.client.Delete(ctx, secret)
 		if err != nil {
 			return errors.Wrapf(err, "delete secret %s", secretName)

--- a/pkg/controller/perconaservermongodb/finalizers.go
+++ b/pkg/controller/perconaservermongodb/finalizers.go
@@ -3,18 +3,22 @@ package perconaservermongodb
 import (
 	"context"
 
-	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
 )
 
 var errWaitingTermination = errors.New("waiting pods to be deleted")
 
 func (r *ReconcilePerconaServerMongoDB) checkFinalizers(ctx context.Context, cr *api.PerconaServerMongoDB) (shouldReconcile bool, err error) {
+	log := log.FromContext(ctx)
+
 	shouldReconcile = false
 	orderedFinalizers := cr.GetOrderedFinalizers()
 	var finalizers []string
@@ -115,7 +119,7 @@ func (r *ReconcilePerconaServerMongoDB) deleteAllStatefulsets(ctx context.Contex
 	}
 
 	for _, sts := range stsList.Items {
-		log.Info("deleting StatefulSet", "name", sts.Name)
+		log.FromContext(ctx).Info("deleting StatefulSet", "name", sts.Name)
 		err := r.client.Delete(ctx, &sts)
 		if err != nil {
 			return errors.Wrapf(err, "failed to delete StatefulSet %s", sts.Name)
@@ -132,7 +136,7 @@ func (r *ReconcilePerconaServerMongoDB) deleteAllPVC(ctx context.Context, cr *ap
 	}
 
 	for _, pvc := range pvcList.Items {
-		log.Info("deleting PVC", "name", pvc.Name)
+		log.FromContext(ctx).Info("deleting PVC", "name", pvc.Name)
 		err := r.client.Delete(ctx, &pvc)
 		if err != nil {
 			return errors.Wrapf(err, "failed to delete PVC %s", pvc.Name)
@@ -165,7 +169,7 @@ func (r *ReconcilePerconaServerMongoDB) deleteSecrets(ctx context.Context, cr *a
 			continue
 		}
 
-		log.Info("deleting secret", "name", secret.Name)
+		log.FromContext(ctx).Info("deleting secret", "name", secret.Name)
 		err = r.client.Delete(ctx, secret)
 		if err != nil {
 			return errors.Wrapf(err, "delete secret %s", secretName)

--- a/pkg/controller/perconaservermongodb/mgo.go
+++ b/pkg/controller/perconaservermongodb/mgo.go
@@ -15,7 +15,7 @@ import (
 	"go.mongodb.org/mongo-driver/x/mongo/driver/topology"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
 	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb"
@@ -25,9 +25,8 @@ import (
 var errReplsetLimit = fmt.Errorf("maximum replset member (%d) count reached", mongo.MaxMembers)
 
 func (r *ReconcilePerconaServerMongoDB) reconcileCluster(ctx context.Context, cr *api.PerconaServerMongoDB, replset *api.ReplsetSpec,
-	pods corev1.PodList, mongosPods []corev1.Pod) (api.AppState, error,
-) {
-	log := log.FromContext(ctx)
+	pods corev1.PodList, mongosPods []corev1.Pod) (api.AppState, error) {
+	log := logf.FromContext(ctx)
 
 	replsetSize := replset.Size
 
@@ -428,7 +427,7 @@ func mongoInitAdminUser(user, pwd string) string {
 }
 
 func (r *ReconcilePerconaServerMongoDB) removeRSFromShard(ctx context.Context, cr *api.PerconaServerMongoDB, rsName string) error {
-	log := log.FromContext(ctx)
+	log := logf.FromContext(ctx)
 
 	if !cr.Spec.Sharding.Enabled {
 		return nil
@@ -486,7 +485,7 @@ func (r *ReconcilePerconaServerMongoDB) handleRsAddToShard(ctx context.Context, 
 	defer func() {
 		err := cli.Disconnect(ctx)
 		if err != nil {
-			log.FromContext(ctx).Error(err, "failed to close mongos connection")
+			logf.FromContext(ctx).Error(err, "failed to close mongos connection")
 		}
 	}()
 
@@ -503,7 +502,7 @@ func (r *ReconcilePerconaServerMongoDB) handleRsAddToShard(ctx context.Context, 
 //
 // See: https://www.mongodb.com/docs/manual/core/localhost-exception/
 func (r *ReconcilePerconaServerMongoDB) handleReplsetInit(ctx context.Context, m *api.PerconaServerMongoDB, replset *api.ReplsetSpec, pods []corev1.Pod) error {
-	log := log.FromContext(ctx)
+	log := logf.FromContext(ctx)
 
 	for _, pod := range pods {
 		if !isMongodPod(pod) || !isContainerAndPodRunning(pod, "mongod") || !isPodReady(pod) {
@@ -675,7 +674,7 @@ func compareRoles(x []map[string]interface{}, y []map[string]interface{}) bool {
 }
 
 func (r *ReconcilePerconaServerMongoDB) createOrUpdateSystemUsers(ctx context.Context, cr *api.PerconaServerMongoDB, replset *api.ReplsetSpec) error {
-	log := log.FromContext(ctx)
+	log := logf.FromContext(ctx)
 
 	cli, err := r.mongoClientWithRole(ctx, cr, *replset, roleUserAdmin)
 	if err != nil {
@@ -778,7 +777,7 @@ func (r *ReconcilePerconaServerMongoDB) recoverReplsetNoPrimary(ctx context.Cont
 	}
 
 	cnf.Version++
-	log.FromContext(ctx).Info("Writing replicaset config", "config", cnf)
+	logf.FromContext(ctx).Info("Writing replicaset config", "config", cnf)
 
 	if err := mongo.WriteConfig(ctx, cli, cnf); err != nil {
 		return errors.Wrap(err, "write mongo config")

--- a/pkg/controller/perconaservermongodb/psmdb_controller.go
+++ b/pkg/controller/perconaservermongodb/psmdb_controller.go
@@ -30,7 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -212,7 +212,7 @@ const (
 // The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcilePerconaServerMongoDB) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := log.FromContext(ctx).WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	log := logf.FromContext(ctx).WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
 
 	rr := reconcile.Result{
 		RequeueAfter: r.reconcileIn,
@@ -560,7 +560,7 @@ func (r *ReconcilePerconaServerMongoDB) setCRVersion(ctx context.Context, cr *ap
 		return errors.Wrap(err, "patch CR")
 	}
 
-	log.FromContext(ctx).Info("Set CR version", "version", cr.Spec.CRVersion)
+	logf.FromContext(ctx).Info("Set CR version", "version", cr.Spec.CRVersion)
 
 	return nil
 }
@@ -654,7 +654,7 @@ func (r *ReconcilePerconaServerMongoDB) getRemovedSfs(ctx context.Context, cr *a
 }
 
 func (r *ReconcilePerconaServerMongoDB) checkIfPossibleToRemove(ctx context.Context, cr *api.PerconaServerMongoDB, rsName string) error {
-	log := log.FromContext(ctx)
+	log := logf.FromContext(ctx)
 
 	systemDBs := map[string]struct{}{
 		"local":  {},
@@ -750,7 +750,7 @@ func (r *ReconcilePerconaServerMongoDB) deleteOrphanPVCs(ctx context.Context, cr
 					podName := strings.TrimPrefix(pvc.Name, psmdb.MongodDataVolClaimName+"-")
 					if _, ok := mongodPodsMap[podName]; !ok {
 						// remove the orphan pvc
-						log.FromContext(ctx).Info("remove orphan pvc", "pvc", pvc.Name)
+						logf.FromContext(ctx).Info("remove orphan pvc", "pvc", pvc.Name)
 						err := r.client.Delete(ctx, &pvc)
 						if err != nil {
 							return errors.Wrapf(err, "failed to delete PVC %s", pvc.Name)
@@ -1043,7 +1043,7 @@ func (r *ReconcilePerconaServerMongoDB) createOrUpdateConfigMap(ctx context.Cont
 }
 
 func (r *ReconcilePerconaServerMongoDB) reconcileMongos(ctx context.Context, cr *api.PerconaServerMongoDB) error {
-	log := log.FromContext(ctx)
+	log := logf.FromContext(ctx)
 
 	if !cr.Spec.Sharding.Enabled {
 		return nil
@@ -1404,7 +1404,7 @@ func (r *ReconcilePerconaServerMongoDB) reconcileStatefulSet(
 	}
 
 	sfsSpec, err := psmdb.StatefulSpec(cr, replset, containerName, matchLabels, customLabels,
-		multiAZ, size, internalKeyName, inits, log.FromContext(ctx), customConfig, resources,
+		multiAZ, size, internalKeyName, inits, logf.FromContext(ctx), customConfig, resources,
 		podSecurityContext, containerSecurityContext, livenessProbe, readinessProbe,
 		configName)
 	if err != nil {
@@ -1505,8 +1505,8 @@ func (r *ReconcilePerconaServerMongoDB) reconcileStatefulSet(
 		}
 	}
 
-	sfsSpec.Template.Spec.Volumes = multiAZ.WithSidecarVolumes(log.FromContext(ctx), sfsSpec.Template.Spec.Volumes)
-	sfsSpec.VolumeClaimTemplates = multiAZ.WithSidecarPVCs(log.FromContext(ctx), sfsSpec.VolumeClaimTemplates)
+	sfsSpec.Template.Spec.Volumes = multiAZ.WithSidecarVolumes(logf.FromContext(ctx), sfsSpec.Template.Spec.Volumes)
+	sfsSpec.VolumeClaimTemplates = multiAZ.WithSidecarPVCs(logf.FromContext(ctx), sfsSpec.VolumeClaimTemplates)
 
 	switch cr.Spec.UpdateStrategy {
 	case appsv1.OnDeleteStatefulSetStrategyType:
@@ -1588,7 +1588,7 @@ func (r *ReconcilePerconaServerMongoDB) reconcilePVCs(ctx context.Context, sts *
 		patch := client.MergeFrom(orig)
 
 		if err := r.client.Patch(ctx, &pvc, patch); err != nil {
-			log.FromContext(ctx).Error(err, "patch PVC", "PVC", pvc.Name)
+			logf.FromContext(ctx).Error(err, "patch PVC", "PVC", pvc.Name)
 		}
 	}
 

--- a/pkg/controller/perconaservermongodb/psmdb_controller.go
+++ b/pkg/controller/perconaservermongodb/psmdb_controller.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	logi "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -222,7 +223,12 @@ func (r *ReconcilePerconaServerMongoDB) Reconcile(ctx context.Context, request r
 		RequeueAfter: r.reconcileIn,
 	}
 
-	logger.Error(errors.New("New ERROR"), "AAAAAAAAAA EEERRROOOORRR")
+
+	loooog := logi.FromContext(ctx).WithName("Finalizer")
+
+	loooog.Info("AAAAAAAAAAAAA INFOOOOOOOOOOOOOOOOOOOOOOO")
+
+	loooog.Error(errors.New("New ERROR"), "AAAAAAAAAA EEERRROOOORRR")
 
 	// As operator can handle a few clusters
 	// lock should be created per cluster to not lock cron jobs of other clusters

--- a/pkg/controller/perconaservermongodb/psmdb_controller.go
+++ b/pkg/controller/perconaservermongodb/psmdb_controller.go
@@ -212,7 +212,7 @@ const (
 // The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcilePerconaServerMongoDB) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := logf.FromContext(ctx).WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	log := logf.FromContext(ctx)
 
 	rr := reconcile.Result{
 		RequeueAfter: r.reconcileIn,

--- a/pkg/controller/perconaservermongodb/psmdb_controller.go
+++ b/pkg/controller/perconaservermongodb/psmdb_controller.go
@@ -45,10 +45,7 @@ import (
 	"github.com/percona/percona-server-mongodb-operator/version"
 )
 
-var (
-	secretFileMode int32 = 288
-	// log                  = logf.Log.WithName("controller_psmdb")
-)
+var secretFileMode int32 = 288
 
 // Add creates a new PerconaServerMongoDB Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.

--- a/pkg/controller/perconaservermongodb/psmdb_controller.go
+++ b/pkg/controller/perconaservermongodb/psmdb_controller.go
@@ -222,6 +222,8 @@ func (r *ReconcilePerconaServerMongoDB) Reconcile(ctx context.Context, request r
 		RequeueAfter: r.reconcileIn,
 	}
 
+	logger.Error(errors.New("New ERROR"), "AAAAAAAAAA EEERRROOOORRR")
+
 	// As operator can handle a few clusters
 	// lock should be created per cluster to not lock cron jobs of other clusters
 	l := r.lockers.LoadOrCreate(request.NamespacedName.String())

--- a/pkg/controller/perconaservermongodb/smart.go
+++ b/pkg/controller/perconaservermongodb/smart.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
 	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb"
@@ -25,7 +25,7 @@ import (
 func (r *ReconcilePerconaServerMongoDB) smartUpdate(ctx context.Context, cr *api.PerconaServerMongoDB, sfs *appsv1.StatefulSet,
 	replset *api.ReplsetSpec) error {
 
-	log := log.FromContext(ctx)
+	log := logf.FromContext(ctx)
 	if replset.Size == 0 {
 		return nil
 	}
@@ -197,7 +197,7 @@ func (r *ReconcilePerconaServerMongoDB) smartUpdate(ctx context.Context, cr *api
 }
 
 func (r *ReconcilePerconaServerMongoDB) smartMongosUpdate(ctx context.Context, cr *api.PerconaServerMongoDB, sts *appsv1.StatefulSet) error {
-	log := log.FromContext(ctx)
+	log := logf.FromContext(ctx)
 
 	if cr.Spec.Sharding.Mongos.Size == 0 || cr.Spec.UpdateStrategy != api.SmartUpdateStatefulSetStrategyType {
 		return nil
@@ -265,7 +265,7 @@ func (r *ReconcilePerconaServerMongoDB) isStsListUpToDate(ctx context.Context, c
 			return false, errors.Errorf("failed to get statefulset %s pods: %v", s.Name, err)
 		}
 		if s.Status.UpdatedReplicas < s.Status.Replicas || isSfsChanged(&s, podList) {
-			log.FromContext(ctx).Info("StatefulSet is not up to date", "sts", s.Name)
+			logf.FromContext(ctx).Info("StatefulSet is not up to date", "sts", s.Name)
 			return false, nil
 		}
 	}
@@ -290,7 +290,7 @@ func (r *ReconcilePerconaServerMongoDB) isAllSfsUpToDate(ctx context.Context, cr
 
 func (r *ReconcilePerconaServerMongoDB) applyNWait(ctx context.Context, cr *api.PerconaServerMongoDB, updateRevision string, pod *corev1.Pod, waitLimit int) error {
 	if pod.ObjectMeta.Labels["controller-revision-hash"] == updateRevision {
-		log.FromContext(ctx).Info("Pod already updated", "pod", pod.Name)
+		logf.FromContext(ctx).Info("Pod already updated", "pod", pod.Name)
 	} else {
 		if err := r.client.Delete(ctx, pod); err != nil {
 			return errors.Wrap(err, "delete pod")
@@ -327,7 +327,7 @@ func (r *ReconcilePerconaServerMongoDB) waitPodRestart(ctx context.Context, cr *
 		}
 
 		if pod.Status.Phase == corev1.PodRunning && pod.ObjectMeta.Labels["controller-revision-hash"] == updateRevision && ready {
-			log.FromContext(ctx).Info("Pod started", "pod", pod.Name)
+			logf.FromContext(ctx).Info("Pod started", "pod", pod.Name)
 			return nil
 		}
 	}

--- a/pkg/controller/perconaservermongodb/smart.go
+++ b/pkg/controller/perconaservermongodb/smart.go
@@ -7,10 +7,6 @@ import (
 	"strings"
 	"time"
 
-	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
-	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb"
-	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb/backup"
-	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb/mongo"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -18,11 +14,18 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
+	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb"
+	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb/backup"
+	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb/mongo"
 )
 
 func (r *ReconcilePerconaServerMongoDB) smartUpdate(ctx context.Context, cr *api.PerconaServerMongoDB, sfs *appsv1.StatefulSet,
 	replset *api.ReplsetSpec) error {
 
+	log := log.FromContext(ctx)
 	if replset.Size == 0 {
 		return nil
 	}
@@ -194,6 +197,8 @@ func (r *ReconcilePerconaServerMongoDB) smartUpdate(ctx context.Context, cr *api
 }
 
 func (r *ReconcilePerconaServerMongoDB) smartMongosUpdate(ctx context.Context, cr *api.PerconaServerMongoDB, sts *appsv1.StatefulSet) error {
+	log := log.FromContext(ctx)
+
 	if cr.Spec.Sharding.Mongos.Size == 0 || cr.Spec.UpdateStrategy != api.SmartUpdateStatefulSetStrategyType {
 		return nil
 	}
@@ -260,7 +265,7 @@ func (r *ReconcilePerconaServerMongoDB) isStsListUpToDate(ctx context.Context, c
 			return false, errors.Errorf("failed to get statefulset %s pods: %v", s.Name, err)
 		}
 		if s.Status.UpdatedReplicas < s.Status.Replicas || isSfsChanged(&s, podList) {
-			log.Info("StatefulSet is not up to date", "sts", s.Name)
+			log.FromContext(ctx).Info("StatefulSet is not up to date", "sts", s.Name)
 			return false, nil
 		}
 	}
@@ -285,7 +290,7 @@ func (r *ReconcilePerconaServerMongoDB) isAllSfsUpToDate(ctx context.Context, cr
 
 func (r *ReconcilePerconaServerMongoDB) applyNWait(ctx context.Context, cr *api.PerconaServerMongoDB, updateRevision string, pod *corev1.Pod, waitLimit int) error {
 	if pod.ObjectMeta.Labels["controller-revision-hash"] == updateRevision {
-		log.Info("Pod already updated", "pod", pod.Name)
+		log.FromContext(ctx).Info("Pod already updated", "pod", pod.Name)
 	} else {
 		if err := r.client.Delete(ctx, pod); err != nil {
 			return errors.Wrap(err, "delete pod")
@@ -322,7 +327,7 @@ func (r *ReconcilePerconaServerMongoDB) waitPodRestart(ctx context.Context, cr *
 		}
 
 		if pod.Status.Phase == corev1.PodRunning && pod.ObjectMeta.Labels["controller-revision-hash"] == updateRevision && ready {
-			log.Info("Pod started", "pod", pod.Name)
+			log.FromContext(ctx).Info("Pod started", "pod", pod.Name)
 			return nil
 		}
 	}

--- a/pkg/controller/perconaservermongodb/ssl.go
+++ b/pkg/controller/perconaservermongodb/ssl.go
@@ -11,7 +11,7 @@ import (
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
 	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb/tls"
@@ -47,7 +47,7 @@ func (r *ReconcilePerconaServerMongoDB) reconsileSSL(ctx context.Context, cr *ap
 
 	err := r.createSSLByCertManager(ctx, cr)
 	if err != nil {
-		log.FromContext(ctx).Error(err, "issue cert with cert-manager")
+		logf.FromContext(ctx).Error(err, "issue cert with cert-manager")
 		err = r.createSSLManually(ctx, cr)
 		if err != nil {
 			return errors.Wrap(err, "create ssl manually")

--- a/pkg/controller/perconaservermongodb/ssl.go
+++ b/pkg/controller/perconaservermongodb/ssl.go
@@ -11,6 +11,7 @@ import (
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
 	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb/tls"
@@ -46,7 +47,7 @@ func (r *ReconcilePerconaServerMongoDB) reconsileSSL(ctx context.Context, cr *ap
 
 	err := r.createSSLByCertManager(ctx, cr)
 	if err != nil {
-		log.Error(err, "issue cert with cert-manager")
+		log.FromContext(ctx).Error(err, "issue cert with cert-manager")
 		err = r.createSSLManually(ctx, cr)
 		if err != nil {
 			return errors.Wrap(err, "create ssl manually")

--- a/pkg/controller/perconaservermongodb/status.go
+++ b/pkg/controller/perconaservermongodb/status.go
@@ -15,14 +15,14 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
 	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb"
 )
 
 func (r *ReconcilePerconaServerMongoDB) updateStatus(ctx context.Context, cr *api.PerconaServerMongoDB, reconcileErr error, clusterState api.AppState) error {
-	log := log.FromContext(ctx)
+	log := logf.FromContext(ctx)
 
 	clusterCondition := api.ClusterCondition{
 		Status:             api.ConditionTrue,

--- a/pkg/controller/perconaservermongodb/status.go
+++ b/pkg/controller/perconaservermongodb/status.go
@@ -15,12 +15,15 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
 	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb"
 )
 
 func (r *ReconcilePerconaServerMongoDB) updateStatus(ctx context.Context, cr *api.PerconaServerMongoDB, reconcileErr error, clusterState api.AppState) error {
+	log := log.FromContext(ctx)
+
 	clusterCondition := api.ClusterCondition{
 		Status:             api.ConditionTrue,
 		Type:               api.AppStateInit,

--- a/pkg/controller/perconaservermongodb/users.go
+++ b/pkg/controller/perconaservermongodb/users.go
@@ -15,7 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
 	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb"
@@ -84,7 +84,7 @@ func (r *ReconcilePerconaServerMongoDB) reconcileUsers(ctx context.Context, cr *
 		return nil
 	}
 
-	log.FromContext(ctx).Info("Secret data changed. Updating users...")
+	logf.FromContext(ctx).Info("Secret data changed. Updating users...")
 
 	containers, err := r.updateSysUsers(ctx, cr, &sysUsersSecretObj, &internalSysSecretObj, repls)
 	if err != nil {
@@ -136,7 +136,7 @@ func (r *ReconcilePerconaServerMongoDB) killcontainer(ctx context.Context, pods 
 	for _, pod := range pods {
 		for _, c := range pod.Spec.Containers {
 			if c.Name == containerName {
-				log.FromContext(ctx).Info("Restarting container", "pod", pod.Name, "container", c.Name)
+				logf.FromContext(ctx).Info("Restarting container", "pod", pod.Name, "container", c.Name)
 
 				err := retry.OnError(retry.DefaultBackoff, func(_ error) bool { return true }, func() error {
 					stderrBuf := &bytes.Buffer{}
@@ -304,7 +304,7 @@ func (r *ReconcilePerconaServerMongoDB) updateUsers(ctx context.Context, cr *api
 
 			defer func() {
 				if err := client.Disconnect(gCtx); err != nil {
-					log.FromContext(ctx).Error(err, "failed to close connection")
+					logf.FromContext(ctx).Error(err, "failed to close connection")
 				}
 			}()
 

--- a/pkg/controller/perconaservermongodb/users.go
+++ b/pkg/controller/perconaservermongodb/users.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
 	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb"
@@ -83,7 +84,7 @@ func (r *ReconcilePerconaServerMongoDB) reconcileUsers(ctx context.Context, cr *
 		return nil
 	}
 
-	log.Info("Secret data changed. Updating users...")
+	log.FromContext(ctx).Info("Secret data changed. Updating users...")
 
 	containers, err := r.updateSysUsers(ctx, cr, &sysUsersSecretObj, &internalSysSecretObj, repls)
 	if err != nil {
@@ -115,7 +116,7 @@ func (r *ReconcilePerconaServerMongoDB) reconcileUsers(ctx context.Context, cr *
 		}
 
 		for _, name := range containers {
-			err = r.killcontainer(pods, name)
+			err = r.killcontainer(ctx, pods, name)
 			if err != nil {
 				return errors.Wrapf(err, "failed to kill %s container", name)
 			}
@@ -131,11 +132,11 @@ func (r *ReconcilePerconaServerMongoDB) reconcileUsers(ctx context.Context, cr *
 	return nil
 }
 
-func (r *ReconcilePerconaServerMongoDB) killcontainer(pods []corev1.Pod, containerName string) error {
+func (r *ReconcilePerconaServerMongoDB) killcontainer(ctx context.Context, pods []corev1.Pod, containerName string) error {
 	for _, pod := range pods {
 		for _, c := range pod.Spec.Containers {
 			if c.Name == containerName {
-				log.Info("Restarting container", "pod", pod.Name, "container", c.Name)
+				log.FromContext(ctx).Info("Restarting container", "pod", pod.Name, "container", c.Name)
 
 				err := retry.OnError(retry.DefaultBackoff, func(_ error) bool { return true }, func() error {
 					stderrBuf := &bytes.Buffer{}
@@ -303,7 +304,7 @@ func (r *ReconcilePerconaServerMongoDB) updateUsers(ctx context.Context, cr *api
 
 			defer func() {
 				if err := client.Disconnect(gCtx); err != nil {
-					log.Error(err, "failed to close connection")
+					log.FromContext(ctx).Error(err, "failed to close connection")
 				}
 			}()
 

--- a/pkg/controller/perconaservermongodb/version.go
+++ b/pkg/controller/perconaservermongodb/version.go
@@ -8,15 +8,17 @@ import (
 	"sync/atomic"
 
 	v "github.com/hashicorp/go-version"
-	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
-	v1 "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
-	"github.com/percona/percona-server-mongodb-operator/pkg/k8s"
-	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb/mongo"
 	"github.com/pkg/errors"
 	"github.com/robfig/cron/v3"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
+	v1 "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
+	"github.com/percona/percona-server-mongodb-operator/pkg/k8s"
+	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb/mongo"
 )
 
 func (r *ReconcilePerconaServerMongoDB) deleteEnsureVersion(cr *api.PerconaServerMongoDB, id int) {
@@ -25,6 +27,7 @@ func (r *ReconcilePerconaServerMongoDB) deleteEnsureVersion(cr *api.PerconaServe
 }
 
 func (r *ReconcilePerconaServerMongoDB) scheduleEnsureVersion(ctx context.Context, cr *api.PerconaServerMongoDB, vs VersionService) error {
+	log := log.FromContext(ctx)
 	schedule, ok := r.crons.jobs[jobName(cr)]
 	if cr.Spec.UpgradeOptions.Schedule == "" || !(versionUpgradeEnabled(cr) || telemetryEnabled()) {
 		if ok {
@@ -210,6 +213,8 @@ func versionUpgradeEnabled(cr *api.PerconaServerMongoDB) bool {
 }
 
 func (r *ReconcilePerconaServerMongoDB) ensureVersion(ctx context.Context, cr *api.PerconaServerMongoDB, vs VersionService) error {
+	log := log.FromContext(ctx)
+
 	if !(versionUpgradeEnabled(cr) || telemetryEnabled()) {
 		return nil
 	}
@@ -335,6 +340,8 @@ func (r *ReconcilePerconaServerMongoDB) ensureVersion(ctx context.Context, cr *a
 }
 
 func (r *ReconcilePerconaServerMongoDB) fetchVersionFromMongo(ctx context.Context, cr *api.PerconaServerMongoDB, replset *api.ReplsetSpec) error {
+	log := log.FromContext(ctx)
+
 	if cr.Status.ObservedGeneration != cr.ObjectMeta.Generation ||
 		cr.Status.State != api.AppStateReady ||
 		cr.Status.MongoImage == cr.Spec.Image {

--- a/pkg/controller/perconaservermongodb/version.go
+++ b/pkg/controller/perconaservermongodb/version.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
 	v1 "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
@@ -27,7 +27,7 @@ func (r *ReconcilePerconaServerMongoDB) deleteEnsureVersion(cr *api.PerconaServe
 }
 
 func (r *ReconcilePerconaServerMongoDB) scheduleEnsureVersion(ctx context.Context, cr *api.PerconaServerMongoDB, vs VersionService) error {
-	log := log.FromContext(ctx)
+	log := logf.FromContext(ctx)
 	schedule, ok := r.crons.jobs[jobName(cr)]
 	if cr.Spec.UpgradeOptions.Schedule == "" || !(versionUpgradeEnabled(cr) || telemetryEnabled()) {
 		if ok {
@@ -213,7 +213,7 @@ func versionUpgradeEnabled(cr *api.PerconaServerMongoDB) bool {
 }
 
 func (r *ReconcilePerconaServerMongoDB) ensureVersion(ctx context.Context, cr *api.PerconaServerMongoDB, vs VersionService) error {
-	log := log.FromContext(ctx)
+	log := logf.FromContext(ctx)
 
 	if !(versionUpgradeEnabled(cr) || telemetryEnabled()) {
 		return nil
@@ -340,7 +340,7 @@ func (r *ReconcilePerconaServerMongoDB) ensureVersion(ctx context.Context, cr *a
 }
 
 func (r *ReconcilePerconaServerMongoDB) fetchVersionFromMongo(ctx context.Context, cr *api.PerconaServerMongoDB, replset *api.ReplsetSpec) error {
-	log := log.FromContext(ctx)
+	log := logf.FromContext(ctx)
 
 	if cr.Status.ObservedGeneration != cr.ObjectMeta.Generation ||
 		cr.Status.State != api.AppStateReady ||

--- a/pkg/controller/perconaservermongodbbackup/backup.go
+++ b/pkg/controller/perconaservermongodbbackup/backup.go
@@ -10,6 +10,7 @@ import (
 	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb/backup"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
@@ -102,7 +103,7 @@ func (b *Backup) Start(ctx context.Context, cluster *api.PerconaServerMongoDB, c
 }
 
 // Status return backup status
-func (b *Backup) Status(cr *api.PerconaServerMongoDBBackup) (api.PerconaServerMongoDBBackupStatus, error) {
+func (b *Backup) Status(ctx context.Context, cr *api.PerconaServerMongoDBBackup) (api.PerconaServerMongoDBBackupStatus, error) {
 	status := cr.Status
 
 	meta, err := b.pbm.C.GetBackupMeta(cr.Status.PBMname)
@@ -111,7 +112,7 @@ func (b *Backup) Status(cr *api.PerconaServerMongoDBBackup) (api.PerconaServerMo
 	}
 
 	if meta == nil || meta.Name == "" || errors.Is(err, pbm.ErrNotFound) {
-		log.Info("Waiting for backup metadata", "PBM name", cr.Status.PBMname, "backup", cr.Name)
+		log.FromContext(ctx).Info("Waiting for backup metadata", "PBM name", cr.Status.PBMname, "backup", cr.Name)
 		return status, nil
 	}
 

--- a/pkg/controller/perconaservermongodbbackup/backup.go
+++ b/pkg/controller/perconaservermongodbbackup/backup.go
@@ -10,7 +10,7 @@ import (
 	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb/backup"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
@@ -112,7 +112,7 @@ func (b *Backup) Status(ctx context.Context, cr *api.PerconaServerMongoDBBackup)
 	}
 
 	if meta == nil || meta.Name == "" || errors.Is(err, pbm.ErrNotFound) {
-		log.FromContext(ctx).Info("Waiting for backup metadata", "PBM name", cr.Status.PBMname, "backup", cr.Name)
+		logf.FromContext(ctx).Info("Waiting for backup metadata", "PBM name", cr.Status.PBMname, "backup", cr.Name)
 		return status, nil
 	}
 

--- a/pkg/controller/perconaservermongodbbackup/perconaservermongodbbackup_controller.go
+++ b/pkg/controller/perconaservermongodbbackup/perconaservermongodbbackup_controller.go
@@ -21,7 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -90,7 +90,7 @@ type ReconcilePerconaServerMongoDBBackup struct {
 // The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcilePerconaServerMongoDBBackup) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := log.FromContext(ctx).WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	log := logf.FromContext(ctx).WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
 
 	rr := reconcile.Result{
 		RequeueAfter: time.Second * 5,
@@ -197,7 +197,7 @@ func (r *ReconcilePerconaServerMongoDBBackup) reconcile(
 	cr *psmdbv1.PerconaServerMongoDBBackup,
 	bcp *Backup,
 ) (psmdbv1.PerconaServerMongoDBBackupStatus, error) {
-	log := log.FromContext(ctx)
+	log := logf.FromContext(ctx)
 	status := cr.Status
 	if cluster == nil {
 		return status, errors.New("cluster not found")
@@ -308,7 +308,7 @@ func getPBMBackupMeta(cr *psmdbv1.PerconaServerMongoDBBackup) *pbm.BackupMeta {
 }
 
 func (r *ReconcilePerconaServerMongoDBBackup) checkFinalizers(ctx context.Context, cr *psmdbv1.PerconaServerMongoDBBackup, b *Backup) error {
-	log := log.FromContext(ctx)
+	log := logf.FromContext(ctx)
 
 	var err error
 	if cr.ObjectMeta.DeletionTimestamp == nil {

--- a/pkg/controller/perconaservermongodbbackup/perconaservermongodbbackup_controller.go
+++ b/pkg/controller/perconaservermongodbbackup/perconaservermongodbbackup_controller.go
@@ -21,7 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -30,8 +30,6 @@ import (
 	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb/backup"
 	"github.com/percona/percona-server-mongodb-operator/version"
 )
-
-var log = logf.Log.WithName("controller_perconaservermongodbbackup")
 
 /**
 * USER ACTION REQUIRED: This is a scaffold file intended for the user to modify with their own Controller
@@ -92,6 +90,8 @@ type ReconcilePerconaServerMongoDBBackup struct {
 // The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcilePerconaServerMongoDBBackup) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	log := log.FromContext(ctx).WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+
 	rr := reconcile.Result{
 		RequeueAfter: time.Second * 5,
 	}
@@ -197,6 +197,7 @@ func (r *ReconcilePerconaServerMongoDBBackup) reconcile(
 	cr *psmdbv1.PerconaServerMongoDBBackup,
 	bcp *Backup,
 ) (psmdbv1.PerconaServerMongoDBBackupStatus, error) {
+	log := log.FromContext(ctx)
 	status := cr.Status
 	if cluster == nil {
 		return status, errors.New("cluster not found")
@@ -229,7 +230,7 @@ func (r *ReconcilePerconaServerMongoDBBackup) reconcile(
 	}
 
 	time.Sleep(5 * time.Second)
-	return bcp.Status(cr)
+	return bcp.Status(ctx, cr)
 }
 
 func (r *ReconcilePerconaServerMongoDBBackup) getPBMStorage(ctx context.Context, cr *psmdbv1.PerconaServerMongoDBBackup) (storage.Storage, error) {
@@ -307,6 +308,8 @@ func getPBMBackupMeta(cr *psmdbv1.PerconaServerMongoDBBackup) *pbm.BackupMeta {
 }
 
 func (r *ReconcilePerconaServerMongoDBBackup) checkFinalizers(ctx context.Context, cr *psmdbv1.PerconaServerMongoDBBackup, b *Backup) error {
+	log := log.FromContext(ctx)
+
 	var err error
 	if cr.ObjectMeta.DeletionTimestamp == nil {
 		return nil

--- a/pkg/controller/perconaservermongodbbackup/perconaservermongodbbackup_controller.go
+++ b/pkg/controller/perconaservermongodbbackup/perconaservermongodbbackup_controller.go
@@ -90,7 +90,7 @@ type ReconcilePerconaServerMongoDBBackup struct {
 // The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcilePerconaServerMongoDBBackup) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := logf.FromContext(ctx).WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	log := logf.FromContext(ctx)
 
 	rr := reconcile.Result{
 		RequeueAfter: time.Second * 5,

--- a/pkg/controller/perconaservermongodbrestore/perconaservermongodbrestore_controller.go
+++ b/pkg/controller/perconaservermongodbrestore/perconaservermongodbrestore_controller.go
@@ -19,7 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -28,8 +28,6 @@ import (
 	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb/backup"
 	"github.com/percona/percona-server-mongodb-operator/version"
 )
-
-var log = logf.Log.WithName("controller_perconaservermongodbrestore")
 
 // Add creates a new PerconaServerMongoDBRestore Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
@@ -84,6 +82,8 @@ type ReconcilePerconaServerMongoDBRestore struct {
 // The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcilePerconaServerMongoDBRestore) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	log := log.FromContext(ctx).WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+
 	rr := reconcile.Result{
 		RequeueAfter: time.Second * 5,
 	}
@@ -138,6 +138,8 @@ func (r *ReconcilePerconaServerMongoDBRestore) Reconcile(ctx context.Context, re
 }
 
 func (r *ReconcilePerconaServerMongoDBRestore) reconcileRestore(ctx context.Context, cr *psmdbv1.PerconaServerMongoDBRestore) (psmdbv1.PerconaServerMongoDBRestoreStatus, error) {
+	log := log.FromContext(ctx)
+
 	status := cr.Status
 
 	cluster := &psmdbv1.PerconaServerMongoDB{}

--- a/pkg/controller/perconaservermongodbrestore/perconaservermongodbrestore_controller.go
+++ b/pkg/controller/perconaservermongodbrestore/perconaservermongodbrestore_controller.go
@@ -19,7 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -82,7 +82,7 @@ type ReconcilePerconaServerMongoDBRestore struct {
 // The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcilePerconaServerMongoDBRestore) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := log.FromContext(ctx).WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	log := logf.FromContext(ctx).WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
 
 	rr := reconcile.Result{
 		RequeueAfter: time.Second * 5,
@@ -138,7 +138,7 @@ func (r *ReconcilePerconaServerMongoDBRestore) Reconcile(ctx context.Context, re
 }
 
 func (r *ReconcilePerconaServerMongoDBRestore) reconcileRestore(ctx context.Context, cr *psmdbv1.PerconaServerMongoDBRestore) (psmdbv1.PerconaServerMongoDBRestoreStatus, error) {
-	log := log.FromContext(ctx)
+	log := logf.FromContext(ctx)
 
 	status := cr.Status
 

--- a/pkg/controller/perconaservermongodbrestore/perconaservermongodbrestore_controller.go
+++ b/pkg/controller/perconaservermongodbrestore/perconaservermongodbrestore_controller.go
@@ -82,7 +82,7 @@ type ReconcilePerconaServerMongoDBRestore struct {
 // The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcilePerconaServerMongoDBRestore) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := logf.FromContext(ctx).WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	log := logf.FromContext(ctx)
 
 	rr := reconcile.Result{
 		RequeueAfter: time.Second * 5,

--- a/pkg/k8s/utils.go
+++ b/pkg/k8s/utils.go
@@ -2,7 +2,6 @@ package k8s
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 )
@@ -20,7 +19,7 @@ func GetWatchNamespace() (string, error) {
 
 // GetOperatorNamespace returns the namespace of the operator pod
 func GetOperatorNamespace() (string, error) {
-	nsBytes, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	nsBytes, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
[![K8SPSMDB-754](https://badgen.net/badge/JIRA/K8SPSMDB-754/green)](https://jira.percona.com/browse/K8SPSMDB-754) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
The log level that is set in the operator is not respected.


**Cause:**
The logger is instantiated in the manager and passed down to our controllers, but then there is a new global logger that is used throughout the controller.

**Solution:**
Use the logger we instantiate and pass to the controller.

*Note*: This PR also fixes [K8SPSMDB-770](https://jira.percona.com/browse/K8SPSMDB-770) 
  - Also removed usage of deprecated `"io/ioutil"` functions.


**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Are E2E tests passing?
- [ ] Are unit tests passing?
- [ ] Are linting tests passing?
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?