### PR TITLE
K8SPSMDB-658: Improve cluster pausing logs

### DIFF
--- a/pkg/apis/psmdb/v1/psmdb_defaults.go
+++ b/pkg/apis/psmdb/v1/psmdb_defaults.go
@@ -449,6 +449,9 @@ func (cr *PerconaServerMongoDB) CheckNSetDefaults(platform version.Platform, log
 		}
 
 		if cr.Spec.Pause {
+			if cr.Status.State == AppStateStopping {
+				log.Info("Pausing cluster", "replset", replset.Name, "oldSize", replset.Size, "newSize", 0)
+			}
 			replset.Size = 0
 			replset.Arbiter.Enabled = false
 			replset.NonVoting.Enabled = false


### PR DESCRIPTION
[![K8SPSMDB-658](https://badgen.net/badge/JIRA/K8SPSMDB-658/green)](https://jira.percona.com/browse/K8SPSMDB-658) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
Pausing the cluster is not clearly visible in the operator logs

**Cause:**


**Solution:**
Add a logline that says that the cluster is being paused.

For a non-sharded cluster, logs look like this:
```
2023-02-03T08:43:57.333Z	INFO	controller_psmdb	StatefulSet is not up to date	{"sts": "my-cluster-name-rs0"}
2023-02-03T08:43:57.333Z	INFO	controller_psmdb	Cluster state changed	{"previous": "ready", "current": "stopping"}
2023-02-03T08:45:04.426Z	INFO	controller_psmdb	Pausing cluster	{"replset": "rs0", "oldSize": 3, "newSize": 0}
2023-02-03T08:45:04.437Z	INFO	controller_psmdb	StatefulSet is not up to date	{"sts": "my-cluster-name-rs0"}
2023-02-03T08:45:04.437Z	INFO	controller_psmdb	StatefulSet is not up to date	{"sts": "my-cluster-name-rs0"}
2023-02-03T08:45:09.453Z	INFO	controller_psmdb	Pausing cluster	{"replset": "rs0", "oldSize": 3, "newSize": 0}
2023-02-03T08:45:09.465Z	INFO	controller_psmdb	StatefulSet is not up to date	{"sts": "my-cluster-name-rs0"}
2023-02-03T08:45:09.465Z	INFO	controller_psmdb	StatefulSet is not up to date	{"sts": "my-cluster-name-rs0"}
2023-02-03T08:45:14.483Z	INFO	controller_psmdb	Pausing cluster	{"replset": "rs0", "oldSize": 3, "newSize": 0}
2023-02-03T08:45:14.493Z	INFO	controller_psmdb	StatefulSet is not up to date	{"sts": "my-cluster-name-rs0"}
2023-02-03T08:45:14.494Z	INFO	controller_psmdb	StatefulSet is not up to date	{"sts": "my-cluster-name-rs0"}
2023-02-03T08:45:19.549Z	INFO	controller_psmdb	Pausing cluster	{"replset": "rs0", "oldSize": 3, "newSize": 0}
2023-02-03T08:45:19.567Z	INFO	controller_psmdb	Cluster state changed	{"previous": "stopping", "current": "paused"}
```

For a sharded cluster, they look like this:
```
2023-02-03T08:43:57.333Z	INFO	controller_psmdb	StatefulSet is not up to date	{"sts": "my-cluster-name-rs0"}
2023-02-03T08:43:57.333Z	INFO	controller_psmdb	Cluster state changed	{"previous": "ready", "current": "stopping"}
2023-02-03T08:45:04.426Z	INFO	controller_psmdb	Pausing cluster	{"replset": "rs0", "oldSize": 3, "newSize": 0}
2023-02-03T08:45:04.437Z	INFO	controller_psmdb	StatefulSet is not up to date	{"sts": "my-cluster-name-rs0"}
2023-02-03T08:45:04.437Z	INFO	controller_psmdb	StatefulSet is not up to date	{"sts": "my-cluster-name-rs0"}
2023-02-03T08:45:09.453Z	INFO	controller_psmdb	Pausing cluster	{"replset": "rs0", "oldSize": 3, "newSize": 0}
2023-02-03T08:45:09.465Z	INFO	controller_psmdb	StatefulSet is not up to date	{"sts": "my-cluster-name-rs0"}
2023-02-03T08:45:09.465Z	INFO	controller_psmdb	StatefulSet is not up to date	{"sts": "my-cluster-name-rs0"}
2023-02-03T08:45:14.483Z	INFO	controller_psmdb	Pausing cluster	{"replset": "rs0", "oldSize": 3, "newSize": 0}
2023-02-03T08:45:14.493Z	INFO	controller_psmdb	StatefulSet is not up to date	{"sts": "my-cluster-name-rs0"}
2023-02-03T08:45:14.494Z	INFO	controller_psmdb	StatefulSet is not up to date	{"sts": "my-cluster-name-rs0"}
2023-02-03T08:45:19.549Z	INFO	controller_psmdb	Pausing cluster	{"replset": "rs0", "oldSize": 3, "newSize": 0}
2023-02-03T08:45:19.567Z	INFO	controller_psmdb	Cluster state changed	{"previous": "stopping", "current": "paused"}
```

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Are E2E tests passing?
- [x] Are unit tests passing?
- [ ] Are linting tests passing?
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are the manifests (crd/bundle) regenerated if needed?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported MongoDB version?
- [x] Does the change support oldest and newest supported Kubernetes version?