### PR TITLE
K8SPSMDB-856 Sync crVersion and compare files

### DIFF
--- a/e2e-tests/upgrade-consistency/compare/service_some-name-rs0-1120.yml
+++ b/e2e-tests/upgrade-consistency/compare/service_some-name-rs0-1120.yml
@@ -2,6 +2,12 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations: {}
+  labels:
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/managed-by: percona-server-mongodb-operator
+    app.kubernetes.io/name: percona-server-mongodb
+    app.kubernetes.io/part-of: percona-server-mongodb
+    app.kubernetes.io/replset: rs0
   name: some-name-rs0
   ownerReferences:
     - controller: true

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1120-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1120-oc.yml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations: {}
-  generation: 1
+  generation: 2
   labels:
     app.kubernetes.io/component: mongod
     app.kubernetes.io/instance: some-name
@@ -51,21 +51,10 @@ spec:
             - --sslAllowInvalidCertificates
             - --sslMode=preferSSL
             - --clusterAuthMode=x509
-            - --slowms=100
-            - --profile=1
-            - --rateLimit=1
             - --enableEncryption
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerCacheSizeGB=0.25
-            - --wiredTigerCollectionBlockCompressor=snappy
-            - --wiredTigerJournalCompressor=snappy
             - --wiredTigerIndexPrefixCompression=true
-            - --setParameter
-            - ttlMonitorSleepSecs=60
-            - --setParameter
-            - wiredTigerConcurrentReadTransactions=128
-            - --setParameter
-            - wiredTigerConcurrentWriteTransactions=128
             - --config=/etc/mongodb-config/mongod.conf
           command:
             - /data/db/ps-entry.sh

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1120.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1120.yml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations: {}
-  generation: 1
+  generation: 2
   labels:
     app.kubernetes.io/component: mongod
     app.kubernetes.io/instance: some-name
@@ -51,21 +51,10 @@ spec:
             - --sslAllowInvalidCertificates
             - --sslMode=preferSSL
             - --clusterAuthMode=x509
-            - --slowms=100
-            - --profile=1
-            - --rateLimit=1
             - --enableEncryption
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerCacheSizeGB=0.25
-            - --wiredTigerCollectionBlockCompressor=snappy
-            - --wiredTigerJournalCompressor=snappy
             - --wiredTigerIndexPrefixCompression=true
-            - --setParameter
-            - ttlMonitorSleepSecs=60
-            - --setParameter
-            - wiredTigerConcurrentReadTransactions=128
-            - --setParameter
-            - wiredTigerConcurrentWriteTransactions=128
             - --config=/etc/mongodb-config/mongod.conf
           command:
             - /data/db/ps-entry.sh

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1130-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1130-oc.yml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations: {}
-  generation: 2
+  generation: 3
   labels:
     app.kubernetes.io/component: mongod
     app.kubernetes.io/instance: some-name
@@ -49,7 +49,6 @@ spec:
             - --storageEngine=wiredTiger
             - --relaxPermChecks
             - --sslAllowInvalidCertificates
-            - --sslMode=preferSSL
             - --clusterAuthMode=x509
             - --enableEncryption
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
@@ -116,6 +115,8 @@ spec:
           volumeMounts:
             - mountPath: /data/db
               name: mongod-data
+            - mountPath: /opt/percona
+              name: bin
             - mountPath: /etc/mongodb-secrets
               name: some-name-mongodb-keyfile
               readOnly: true
@@ -163,6 +164,8 @@ spec:
             defaultMode: 288
             optional: false
             secretName: some-name-mongodb-keyfile
+        - emptyDir: {}
+          name: bin
         - configMap:
             defaultMode: 420
             name: some-name-rs0-mongod

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1130.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1130.yml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations: {}
-  generation: 2
+  generation: 3
   labels:
     app.kubernetes.io/component: mongod
     app.kubernetes.io/instance: some-name
@@ -49,7 +49,6 @@ spec:
             - --storageEngine=wiredTiger
             - --relaxPermChecks
             - --sslAllowInvalidCertificates
-            - --sslMode=preferSSL
             - --clusterAuthMode=x509
             - --enableEncryption
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
@@ -152,6 +151,8 @@ spec:
           volumeMounts:
             - mountPath: /data/db
               name: mongod-data
+            - mountPath: /opt/percona
+              name: bin
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext:
@@ -165,6 +166,8 @@ spec:
             defaultMode: 288
             optional: false
             secretName: some-name-mongodb-keyfile
+        - emptyDir: {}
+          name: bin
         - configMap:
             defaultMode: 420
             name: some-name-rs0-mongod

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1140-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1140-oc.yml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations: {}
-  generation: 3
+  generation: 4
   labels:
     app.kubernetes.io/component: mongod
     app.kubernetes.io/instance: some-name

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1140.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1140.yml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations: {}
-  generation: 3
+  generation: 4
   labels:
     app.kubernetes.io/component: mongod
     app.kubernetes.io/instance: some-name

--- a/e2e-tests/upgrade-consistency/run
+++ b/e2e-tests/upgrade-consistency/run
@@ -14,21 +14,12 @@ main() {
 	kubectl_bin apply -f "${conf_dir}/client.yml" \
 		-f "${conf_dir}/secrets.yml"
 
-	# test 1.10.0
+	# test 1.11.0
 	apply_cluster "$test_dir/conf/${CLUSTER}-rs0.yml"
 	wait_for_running "${CLUSTER}-rs0" "1" "false"
 
 	compare_kubectl service/${CLUSTER}-rs0 "-1110"
 	compare_kubectl statefulset/${CLUSTER}-rs0 "-1110"
-
-	# test 1.11.0
-	kubectl_bin patch psmdb "${CLUSTER}" --type=merge --patch '{
-        "spec": {"crVersion":"1.11.0"}
-    }'
-	wait_for_running "${CLUSTER}-rs0" "1" "false"
-
-	compare_kubectl service/${CLUSTER}-rs0 "-1120"
-	compare_kubectl statefulset/${CLUSTER}-rs0 "-1120"
 
 	# test 1.12.0
 	kubectl_bin patch psmdb "${CLUSTER}" --type=merge --patch '{
@@ -36,12 +27,21 @@ main() {
     }'
 	wait_for_running "${CLUSTER}-rs0" "1" "false"
 
-	compare_kubectl service/${CLUSTER}-rs0 "-1130"
-	compare_kubectl statefulset/${CLUSTER}-rs0 "-1130"
+	compare_kubectl service/${CLUSTER}-rs0 "-1120"
+	compare_kubectl statefulset/${CLUSTER}-rs0 "-1120"
 
 	# test 1.13.0
 	kubectl_bin patch psmdb "${CLUSTER}" --type=merge --patch '{
         "spec": {"crVersion":"1.13.0"}
+    }'
+	wait_for_running "${CLUSTER}-rs0" "1" "false"
+
+	compare_kubectl service/${CLUSTER}-rs0 "-1130"
+	compare_kubectl statefulset/${CLUSTER}-rs0 "-1130"
+
+	# test 1.14.0
+	kubectl_bin patch psmdb "${CLUSTER}" --type=merge --patch '{
+        "spec": {"crVersion":"1.14.0"}
     }'
 	wait_for_running "${CLUSTER}-rs0" "1" "false"
 


### PR DESCRIPTION
[![K8SPSMDB-856](https://badgen.net/badge/JIRA/K8SPSMDB-856/green)](https://jira.percona.com/browse/K8SPSMDB-856) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
*Previously there was some inconsistency between updating crVersion and target files to compare with.*

**Cause:**
*Human factor.*

**Solution:**
*Updating all corresponding files.*

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Are E2E tests passing?
- [ ] Are unit tests passing?
- [ ] Are linting tests passing?
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?