### PR TITLE
K8SPSMDB-845: delete backup finalizer fails with PBM v2 

### DIFF
--- a/e2e-tests/demand-backup-sharded/conf/backup-aws-s3.yml
+++ b/e2e-tests/demand-backup-sharded/conf/backup-aws-s3.yml
@@ -1,8 +1,8 @@
 apiVersion: psmdb.percona.com/v1
 kind: PerconaServerMongoDBBackup
 metadata:
-#  finalizers:
-#    - delete-backup
+  finalizers:
+    - delete-backup
   name: backup-aws-s3
 spec:
   clusterName: some-name

--- a/e2e-tests/demand-backup-sharded/conf/backup-azure-blob.yml
+++ b/e2e-tests/demand-backup-sharded/conf/backup-azure-blob.yml
@@ -1,8 +1,8 @@
 apiVersion: psmdb.percona.com/v1
 kind: PerconaServerMongoDBBackup
 metadata:
-#  finalizers:
-#    - delete-backup
+  finalizers:
+    - delete-backup
   name: backup-azure-blob
 spec:
   clusterName: some-name

--- a/e2e-tests/demand-backup-sharded/conf/backup-gcp-cs.yml
+++ b/e2e-tests/demand-backup-sharded/conf/backup-gcp-cs.yml
@@ -1,8 +1,8 @@
 apiVersion: psmdb.percona.com/v1
 kind: PerconaServerMongoDBBackup
 metadata:
-#  finalizers:
-#    - delete-backup
+  finalizers:
+    - delete-backup
   name: backup-gcp-cs
 spec:
   clusterName: some-name

--- a/e2e-tests/demand-backup-sharded/conf/backup-minio.yml
+++ b/e2e-tests/demand-backup-sharded/conf/backup-minio.yml
@@ -1,8 +1,8 @@
 apiVersion: psmdb.percona.com/v1
 kind: PerconaServerMongoDBBackup
 metadata:
-#  finalizers:
-#    - delete-backup
+  finalizers:
+    - delete-backup
   name: backup-minio
 spec:
   clusterName: some-name

--- a/e2e-tests/demand-backup-sharded/run
+++ b/e2e-tests/demand-backup-sharded/run
@@ -118,23 +118,21 @@ wait_restore $backup_name_minio 3 1 "-mongos"
 sleep 60
 desc 'delete backup and check if it is removed from bucket -- minio'
 kubectl_bin delete psmdb-backup --all
-#
-# TODO: Recheck after fix for: https://jira.percona.com/browse/PBM-1020
-#
-#backup_exists=$(kubectl_bin run -i --rm aws-cli --image=perconalab/awscli --restart=Never -- \
-#	/usr/bin/env AWS_ACCESS_KEY_ID=some-access-key AWS_SECRET_ACCESS_KEY=some-secret-key AWS_DEFAULT_REGION=us-east-1 \
-#	/usr/bin/aws --endpoint-url http://minio-service:9000 s3 ls s3://operator-testing/ \
-#	| grep -c ${backup_dest_minio}_ | cat)
-#if [[ $backup_exists -eq 1 ]]; then
-#	echo "Backup was not removed from bucket -- minio"
-#	exit 1
-#fi
-#
-#if [ -z "$SKIP_BACKUPS_TO_AWS_GCP_AZURE" ]; then
-#	check_backup_deletion "https://s3.amazonaws.com/operator-testing/${backup_dest_aws}" "aws-s3"
-#	#	check_backup_deletion "https://storage.googleapis.com/operator-testing/${backup_dest_gcp}" "gcp-cs"
-#	check_backup_deletion "https://engk8soperators.blob.core.windows.net/operator-testing/${backup_dest_azure}" "azure-blob"
-#fi
+
+backup_exists=$(kubectl_bin run -i --rm aws-cli --image=perconalab/awscli --restart=Never -- \
+	/usr/bin/env AWS_ACCESS_KEY_ID=some-access-key AWS_SECRET_ACCESS_KEY=some-secret-key AWS_DEFAULT_REGION=us-east-1 \
+	/usr/bin/aws --endpoint-url http://minio-service:9000 s3 ls s3://operator-testing/ \
+	| grep -c ${backup_dest_minio}_ | cat)
+if [[ $backup_exists -eq 1 ]]; then
+	echo "Backup was not removed from bucket -- minio"
+	exit 1
+fi
+
+if [ -z "$SKIP_BACKUPS_TO_AWS_GCP_AZURE" ]; then
+	check_backup_deletion "https://s3.amazonaws.com/operator-testing/${backup_dest_aws}" "aws-s3"
+	check_backup_deletion "https://storage.googleapis.com/operator-testing/${backup_dest_gcp}" "gcp-cs"
+	check_backup_deletion "https://engk8soperators.blob.core.windows.net/operator-testing/${backup_dest_azure}" "azure-blob"
+fi
 
 kubectl_bin delete -f "$conf_dir/container-rc.yaml"
 destroy "$namespace"

--- a/e2e-tests/demand-backup/run
+++ b/e2e-tests/demand-backup/run
@@ -118,7 +118,7 @@ fi
 
 if [ -z "$SKIP_BACKUPS_TO_AWS_GCP_AZURE" ]; then
 	check_backup_deletion "https://s3.amazonaws.com/operator-testing/${backup_dest_aws}" "aws-s3"
-	#	check_backup_deletion "https://storage.googleapis.com/operator-testing/${backup_dest_gcp}" "gcp-cs"
+	check_backup_deletion "https://storage.googleapis.com/operator-testing/${backup_dest_gcp}" "gcp-cs"
 	check_backup_deletion "https://engk8soperators.blob.core.windows.net/operator-testing/${backup_dest_azure}" "azure-blob"
 fi
 

--- a/e2e-tests/demand-backup/run
+++ b/e2e-tests/demand-backup/run
@@ -122,4 +122,39 @@ if [ -z "$SKIP_BACKUPS_TO_AWS_GCP_AZURE" ]; then
 	check_backup_deletion "https://engk8soperators.blob.core.windows.net/operator-testing/${backup_dest_azure}" "azure-blob"
 fi
 
+desc 'checking backup deletion without cr'
+run_backup minio
+if [ -z "$SKIP_BACKUPS_TO_AWS_GCP_AZURE" ]; then
+	run_backup aws-s3
+	run_backup gcp-cs
+	run_backup azure-blob
+fi
+
+wait_backup "$backup_name_minio"
+if [ -z "$SKIP_BACKUPS_TO_AWS_GCP_AZURE" ]; then
+	wait_backup "$backup_name_aws"
+	wait_backup "$backup_name_gcp"
+	wait_backup "$backup_name_azure"
+fi
+
+kubectl_bin delete psmdb --all
+sleep 60
+
+desc 'delete backup and check if it is removed from bucket -- minio'
+kubectl_bin delete psmdb-backup --all
+backup_exists=$(kubectl_bin run -i --rm aws-cli --image=perconalab/awscli --restart=Never -- \
+	/usr/bin/env AWS_ACCESS_KEY_ID=some-access-key AWS_SECRET_ACCESS_KEY=some-secret-key AWS_DEFAULT_REGION=us-east-1 \
+	/usr/bin/aws --endpoint-url http://minio-service:9000 s3 ls s3://operator-testing/ \
+	| grep -c ${backup_dest_minio} | cat)
+if [[ $backup_exists -eq 1 ]]; then
+	echo "Backup was not removed from bucket -- minio"
+	exit 1
+fi
+
+if [ -z "$SKIP_BACKUPS_TO_AWS_GCP_AZURE" ]; then
+	check_backup_deletion "https://s3.amazonaws.com/operator-testing/${backup_dest_aws}" "aws-s3"
+	check_backup_deletion "https://storage.googleapis.com/operator-testing/${backup_dest_gcp}" "gcp-cs"
+	check_backup_deletion "https://engk8soperators.blob.core.windows.net/operator-testing/${backup_dest_azure}" "azure-blob"
+fi
+
 destroy $namespace

--- a/pkg/controller/perconaservermongodbbackup/perconaservermongodbbackup_controller.go
+++ b/pkg/controller/perconaservermongodbbackup/perconaservermongodbbackup_controller.go
@@ -341,10 +341,27 @@ func (r *ReconcilePerconaServerMongoDBBackup) checkFinalizers(ctx context.Contex
 						return errors.Wrap(err, "get storage")
 					}
 					if err := dummyPBM.DeleteBackupFiles(getPBMBackupMeta(cr), stg); err != nil {
-						log.Error(err, "failed to run finalizer", "finalizer", f)
+						log.Error(err, "failed to run finalizer with dummy pbm", "finalizer", f)
 						finalizers = append(finalizers, f)
 					}
 				} else {
+					var storage psmdbv1.BackupStorageSpec
+					switch {
+					case cr.Status.S3 != nil:
+						storage.Type = psmdbv1.BackupStorageS3
+						storage.S3 = *cr.Status.S3
+					case cr.Status.Azure != nil:
+						storage.Type = psmdbv1.BackupStorageAzure
+						storage.Azure = *cr.Status.Azure
+					}
+					priorities, err := r.getPrioritiesFromBackup(ctx, cr, b.pbm)
+					if err != nil {
+						return errors.Wrap(err, "get priorities from backup")
+					}
+					err = b.pbm.SetConfig(ctx, storage, b.spec.PITR, priorities)
+					if err != nil {
+						return errors.Wrapf(err, "set backup config with storage %s", cr.Spec.StorageName)
+					}
 					e := b.pbm.C.Logger().NewEvent(string(pbm.CmdDeleteBackup), "", "", primitive.Timestamp{})
 					err = b.pbm.C.DeleteBackup(cr.Status.PBMname, e)
 					if err != nil {
@@ -360,6 +377,23 @@ func (r *ReconcilePerconaServerMongoDBBackup) checkFinalizers(ctx context.Contex
 	err = r.client.Update(ctx, cr)
 
 	return err
+}
+
+func (r *ReconcilePerconaServerMongoDBBackup) getPrioritiesFromBackup(ctx context.Context, cr *psmdbv1.PerconaServerMongoDBBackup, pbm *backup.PBM) (map[string]float64, error) {
+	priorities := make(map[string]float64)
+	cluster := new(psmdbv1.PerconaServerMongoDB)
+	err := r.client.Get(ctx, types.NamespacedName{Name: cr.Spec.GetClusterName(), Namespace: cr.Namespace}, cluster)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return priorities, nil
+		}
+		return nil, errors.Wrapf(err, "get cluster %s", cr.Spec.GetClusterName())
+	}
+	priorities, err = pbm.GetPriorities(ctx, r.client, cluster)
+	if err != nil {
+		return nil, errors.Wrap(err, "get priorities")
+	}
+	return priorities, nil
 }
 
 func (r *ReconcilePerconaServerMongoDBBackup) updateStatus(ctx context.Context, cr *psmdbv1.PerconaServerMongoDBBackup) error {


### PR DESCRIPTION
[![K8SPSMDB-845](https://badgen.net/badge/JIRA/K8SPSMDB-845/green)](https://jira.percona.com/browse/K8SPSMDB-845) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://jira.percona.com/browse/K8SPSMDB-845

**DESCRIPTION**
---
**Problem:**
*When we run backup on different storages and then delete the first one, `delete-backup` finalizer fails*

**Cause:**
*Every time we create a backup we set a new pbm config, which contains info about storage.  `delete-backup` finalizer uses pbm to delete backups. When we delete the backup with other storage, we don't set a new pbm config with info about the needed storage. This way pbm, uses storage of the last created backup and tries to delete backup on the wrong storage*

**Solution:**
*We should set a new pbm config every time the `delete-backup` finalizer used*

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Are E2E tests passing?
- [x] Are unit tests passing?
- [x] Are linting tests passing?
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?