### PR TITLE
K8SPSMDB- 770: Enrich the rest of the logs with namespace and cluster name keys

### DIFF
--- a/pkg/controller/perconaservermongodb/backup.go
+++ b/pkg/controller/perconaservermongodb/backup.go
@@ -140,7 +140,7 @@ func (r *ReconcilePerconaServerMongoDB) deleteOldBackupTasks(ctx context.Context
 			if spec.Keep > 0 {
 				oldjobs, err := r.oldScheduledBackups(ctx, cr, item.Name, spec.Keep)
 				if err != nil {
-					log.Error(err, "failed to list old backups", "job name", item.Name)
+					log.Error(err, "failed to list old backups", "job", item.Name)
 					return true
 				}
 
@@ -154,7 +154,7 @@ func (r *ReconcilePerconaServerMongoDB) deleteOldBackupTasks(ctx context.Context
 
 			}
 		} else {
-			log.Info("deleting outdated backup job", "name", item.Name)
+			log.Info("deleting outdated backup job", "job", item.Name)
 			r.deleteBackupTask(cr, item.BackupTaskSpec)
 		}
 
@@ -170,8 +170,7 @@ func (r *ReconcilePerconaServerMongoDB) createBackupTask(ctx context.Context, cr
 		localCr := &api.PerconaServerMongoDB{}
 		err := r.client.Get(ctx, types.NamespacedName{Name: cr.Name, Namespace: cr.Namespace}, localCr)
 		if k8sErrors.IsNotFound(err) {
-			log.Info("cluster is not found, deleting the job",
-				"job name", task.Name)
+			log.Info("cluster is not found, deleting the job", "job", task.Name)
 			r.deleteBackupTask(cr, task)
 			return
 		}

--- a/pkg/controller/perconaservermongodb/backup.go
+++ b/pkg/controller/perconaservermongodb/backup.go
@@ -154,7 +154,7 @@ func (r *ReconcilePerconaServerMongoDB) deleteOldBackupTasks(ctx context.Context
 
 			}
 		} else {
-			log.Info("deleting outdated backup job", "cluster", cr.Name, "name", item.Name, "namespace", cr.Namespace)
+			log.Info("deleting outdated backup job", "name", item.Name, )
 			r.deleteBackupTask(cr, item.BackupTaskSpec)
 		}
 
@@ -171,7 +171,7 @@ func (r *ReconcilePerconaServerMongoDB) createBackupTask(ctx context.Context, cr
 		err := r.client.Get(ctx, types.NamespacedName{Name: cr.Name, Namespace: cr.Namespace}, localCr)
 		if k8sErrors.IsNotFound(err) {
 			log.Info("cluster is not found, deleting the job",
-				"job name", task.Name, "cluster", cr.Name, "namespace", cr.Namespace)
+				"job name", task.Name)
 			r.deleteBackupTask(cr, task)
 			return
 		}

--- a/pkg/controller/perconaservermongodb/backup.go
+++ b/pkg/controller/perconaservermongodb/backup.go
@@ -154,7 +154,7 @@ func (r *ReconcilePerconaServerMongoDB) deleteOldBackupTasks(ctx context.Context
 
 			}
 		} else {
-			log.Info("deleting outdated backup job", "name", item.Name, )
+			log.Info("deleting outdated backup job", "name", item.Name)
 			r.deleteBackupTask(cr, item.BackupTaskSpec)
 		}
 

--- a/pkg/controller/perconaservermongodb/mgo.go
+++ b/pkg/controller/perconaservermongodb/mgo.go
@@ -463,7 +463,7 @@ func (r *ReconcilePerconaServerMongoDB) removeRSFromShard(ctx context.Context, c
 	}
 }
 
-func (r *ReconcilePerconaServerMongoDB) handleRsAddToShard(ctx context.Context, m *api.PerconaServerMongoDB, replset *api.ReplsetSpec, rspod corev1.Pod,
+func (r *ReconcilePerconaServerMongoDB) handleRsAddToShard(ctx context.Context, cr *api.PerconaServerMongoDB, replset *api.ReplsetSpec, rspod corev1.Pod,
 	mongosPod corev1.Pod) error {
 	if !isContainerAndPodRunning(rspod, "mongod") || !isPodReady(rspod) {
 		return errors.Errorf("rsPod %s is not ready", rspod.Name)
@@ -472,12 +472,12 @@ func (r *ReconcilePerconaServerMongoDB) handleRsAddToShard(ctx context.Context, 
 		return errors.New("mongos pod is not ready")
 	}
 
-	host, err := psmdb.MongoHost(ctx, r.client, m, replset.Name, replset.Expose.Enabled, rspod)
+	host, err := psmdb.MongoHost(ctx, r.client, cr, replset.Name, replset.Expose.Enabled, rspod)
 	if err != nil {
 		return errors.Wrapf(err, "get rsPod %s host", rspod.Name)
 	}
 
-	cli, err := r.mongosClientWithRole(ctx, m, roleClusterAdmin)
+	cli, err := r.mongosClientWithRole(ctx, cr, roleClusterAdmin)
 	if err != nil {
 		return errors.Wrap(err, "failed to get mongos client")
 	}

--- a/pkg/controller/perconaservermongodb/psmdb_controller.go
+++ b/pkg/controller/perconaservermongodb/psmdb_controller.go
@@ -1171,7 +1171,7 @@ func (r *ReconcilePerconaServerMongoDB) reconcileMongos(ctx context.Context, cr 
 	if client.IgnoreNotFound(err) != nil {
 		return errors.Wrapf(err, "check pmm secrets: %s", api.UserSecretName(cr))
 	}
-	pmmC := psmdb.AddPMMContainer(cr, secret, cr.Spec.PMM.MongosParams)
+	pmmC := psmdb.AddPMMContainer(ctx, cr, secret, cr.Spec.PMM.MongosParams)
 	if pmmC != nil {
 		templateSpec.Spec.Containers = append(
 			templateSpec.Spec.Containers,
@@ -1403,7 +1403,7 @@ func (r *ReconcilePerconaServerMongoDB) reconcileStatefulSet(
 		return nil, errors.Wrap(err, "check if mongod custom configuration exists")
 	}
 
-	sfsSpec, err := psmdb.StatefulSpec(cr, replset, containerName, matchLabels, customLabels,
+	sfsSpec, err := psmdb.StatefulSpec(ctx, cr, replset, containerName, matchLabels, customLabels,
 		multiAZ, size, internalKeyName, inits, logf.FromContext(ctx), customConfig, resources,
 		podSecurityContext, containerSecurityContext, livenessProbe, readinessProbe,
 		configName)
@@ -1499,7 +1499,7 @@ func (r *ReconcilePerconaServerMongoDB) reconcileStatefulSet(
 			sfsSpec.Template.Spec.Containers = append(sfsSpec.Template.Spec.Containers, agentC)
 		}
 
-		pmmC := psmdb.AddPMMContainer(cr, secret, cr.Spec.PMM.MongodParams)
+		pmmC := psmdb.AddPMMContainer(ctx, cr, secret, cr.Spec.PMM.MongodParams)
 		if pmmC != nil {
 			sfsSpec.Template.Spec.Containers = append(sfsSpec.Template.Spec.Containers, *pmmC)
 		}

--- a/pkg/psmdb/container.go
+++ b/pkg/psmdb/container.go
@@ -1,16 +1,18 @@
 package psmdb
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
 )
 
-func container(cr *api.PerconaServerMongoDB, replset *api.ReplsetSpec, name string, resources corev1.ResourceRequirements,
+func container(ctx context.Context, cr *api.PerconaServerMongoDB, replset *api.ReplsetSpec, name string, resources corev1.ResourceRequirements,
 	ikeyName string, useConfigFile bool, livenessProbe *api.LivenessProbeExtended, readinessProbe *corev1.Probe,
 	containerSecurityContext *corev1.SecurityContext) (corev1.Container, error) {
 	fvar := false
@@ -82,7 +84,7 @@ func container(cr *api.PerconaServerMongoDB, replset *api.ReplsetSpec, name stri
 		Name:            name,
 		Image:           cr.Spec.Image,
 		ImagePullPolicy: cr.Spec.ImagePullPolicy,
-		Args:            containerArgs(cr, replset, resources, useConfigFile),
+		Args:            containerArgs(ctx, cr, replset, resources, useConfigFile),
 		Ports: []corev1.ContainerPort{
 			{
 				Name:          mongodPortName,
@@ -144,27 +146,27 @@ func container(cr *api.PerconaServerMongoDB, replset *api.ReplsetSpec, name stri
 }
 
 // containerArgs returns the args to pass to the mSpec container
-func containerArgs(m *api.PerconaServerMongoDB, replset *api.ReplsetSpec, resources corev1.ResourceRequirements,
+func containerArgs(ctx context.Context, cr *api.PerconaServerMongoDB, replset *api.ReplsetSpec, resources corev1.ResourceRequirements,
 	useConfigFile bool) []string {
 	// TODO(andrew): in the safe mode `sslAllowInvalidCertificates` should be set only with the external services
 	args := []string{
 		"--bind_ip_all",
 		"--auth",
 		"--dbpath=" + MongodContainerDataDir,
-		"--port=" + strconv.Itoa(int(api.MongodPort(m))),
+		"--port=" + strconv.Itoa(int(api.MongodPort(cr))),
 		"--replSet=" + replset.Name,
 		"--storageEngine=" + string(replset.Storage.Engine),
 		"--relaxPermChecks",
 		"--sslAllowInvalidCertificates",
 	}
 
-	if m.Spec.UnsafeConf {
+	if cr.Spec.UnsafeConf {
 		args = append(args,
 			"--clusterAuthMode=keyFile",
 			"--keyFile="+mongodSecretsDir+"/mongodb-key",
 		)
 	} else {
-		if m.CompareVersion("1.12.0") <= 0 {
+		if cr.CompareVersion("1.12.0") <= 0 {
 			args = append(args, "--sslMode=preferSSL")
 		}
 		args = append(args, "--clusterAuthMode=x509")
@@ -179,7 +181,7 @@ func containerArgs(m *api.PerconaServerMongoDB, replset *api.ReplsetSpec, resour
 	}
 
 	// operationProfiling
-	if mSpec := m.Spec.Mongod; m.CompareVersion("1.12.0") < 0 && mSpec.OperationProfiling != nil {
+	if mSpec := cr.Spec.Mongod; cr.CompareVersion("1.12.0") < 0 && mSpec.OperationProfiling != nil {
 		switch mSpec.OperationProfiling.Mode {
 		case api.OperationProfilingModeAll:
 			args = append(args, "--profile=2")
@@ -194,12 +196,12 @@ func containerArgs(m *api.PerconaServerMongoDB, replset *api.ReplsetSpec, resour
 		}
 	}
 
-	encryptionEnabled, err := isEncryptionEnabled(m, replset)
+	encryptionEnabled, err := isEncryptionEnabled(cr, replset)
 	if err != nil {
-		log.Error(err, "failed to check if mongo encryption enabled")
+		logf.FromContext(ctx).Error(err, "failed to check if mongo encryption enabled")
 	}
 
-	if m.CompareVersion("1.12.0") >= 0 && encryptionEnabled && !replset.Configuration.VaultEnabled() {
+	if cr.CompareVersion("1.12.0") >= 0 && encryptionEnabled && !replset.Configuration.VaultEnabled() {
 		args = append(args, "--enableEncryption",
 			"--encryptionKeyFile="+api.MongodRESTencryptDir+"/"+api.EncryptionKeyName,
 		)
@@ -209,12 +211,12 @@ func containerArgs(m *api.PerconaServerMongoDB, replset *api.ReplsetSpec, resour
 	if replset.Storage != nil {
 		switch replset.Storage.Engine {
 		case api.StorageEngineWiredTiger:
-			if m.CompareVersion("1.12.0") < 0 && *m.Spec.Mongod.Security.EnableEncryption {
+			if cr.CompareVersion("1.12.0") < 0 && *cr.Spec.Mongod.Security.EnableEncryption {
 				args = append(args, "--enableEncryption",
 					"--encryptionKeyFile="+api.MongodRESTencryptDir+"/"+api.EncryptionKeyName)
-				if m.Spec.Mongod.Security.EncryptionCipherMode != api.MongodChiperModeUnset {
+				if cr.Spec.Mongod.Security.EncryptionCipherMode != api.MongodChiperModeUnset {
 					args = append(args,
-						"--encryptionCipherMode="+string(m.Spec.Mongod.Security.EncryptionCipherMode),
+						"--encryptionCipherMode="+string(cr.Spec.Mongod.Security.EncryptionCipherMode),
 					)
 				}
 			}
@@ -258,8 +260,8 @@ func containerArgs(m *api.PerconaServerMongoDB, replset *api.ReplsetSpec, resour
 		}
 	}
 
-	if m.CompareVersion("1.12.0") < 0 {
-		mSpec := m.Spec.Mongod
+	if cr.CompareVersion("1.12.0") < 0 {
+		mSpec := cr.Spec.Mongod
 
 		// security
 		if mSpec.Security != nil && mSpec.Security.RedactClientLogData {
@@ -318,7 +320,7 @@ func containerArgs(m *api.PerconaServerMongoDB, replset *api.ReplsetSpec, resour
 		}
 	}
 
-	if m.CompareVersion("1.9.0") >= 0 && useConfigFile {
+	if cr.CompareVersion("1.9.0") >= 0 && useConfigFile {
 		args = append(args, fmt.Sprintf("--config=%s/mongod.conf", mongodConfigDir))
 	}
 
@@ -334,7 +336,6 @@ func containerArgs(m *api.PerconaServerMongoDB, replset *api.ReplsetSpec, resour
 // explicitly set the WiredTiger cache size to fix this.
 //
 // https://docs.mongodb.com/manual/reference/configuration-options/#storage.wiredTiger.engineConfig.cacheSizeGB
-//
 func getWiredTigerCacheSizeGB(resourceList corev1.ResourceList, cacheRatio float64, subtract1GB bool) float64 {
 	maxMemory := resourceList[corev1.ResourceMemory]
 	var size float64

--- a/pkg/psmdb/init.go
+++ b/pkg/psmdb/init.go
@@ -2,10 +2,7 @@ package psmdb
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
-
-var log = logf.Log.WithName("psmdb")
 
 func EntrypointInitContainer(initImageName string, pullPolicy corev1.PullPolicy) corev1.Container {
 	return corev1.Container{

--- a/pkg/psmdb/pmm.go
+++ b/pkg/psmdb/pmm.go
@@ -1,11 +1,13 @@
 package psmdb
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
 )
@@ -326,13 +328,13 @@ func PMMAgentScript(cr *api.PerconaServerMongoDB) []corev1.EnvVar {
 }
 
 // AddPMMContainer creates the container object for a pmm-client
-func AddPMMContainer(cr *api.PerconaServerMongoDB, secret *corev1.Secret, customAdminParams string) *corev1.Container {
+func AddPMMContainer(ctx context.Context, cr *api.PerconaServerMongoDB, secret *corev1.Secret, customAdminParams string) *corev1.Container {
 	if !cr.Spec.PMM.Enabled {
 		return nil
 	}
 
 	if !cr.Spec.PMM.HasSecret(secret) {
-		log.Info(fmt.Sprintf(`Can't enable PMM: "%s" or "%s" with "%s" keys don't exist in the secrets, or secrets and internal secrets are out of sync`,
+		logf.FromContext(ctx).Info(fmt.Sprintf(`Can't enable PMM: "%s" or "%s" with "%s" keys don't exist in the secrets, or secrets and internal secrets are out of sync`,
 			api.PMMAPIKey, api.PMMUserKey, api.PMMPasswordKey), "secrets", cr.Spec.Secrets.Users, "internalSecrets", api.InternalUserSecretName(cr))
 		return nil
 	}

--- a/pkg/psmdb/service.go
+++ b/pkg/psmdb/service.go
@@ -20,10 +20,10 @@ import (
 )
 
 // Service returns a core/v1 API Service
-func Service(m *api.PerconaServerMongoDB, replset *api.ReplsetSpec) *corev1.Service {
+func Service(cr *api.PerconaServerMongoDB, replset *api.ReplsetSpec) *corev1.Service {
 	ls := map[string]string{
 		"app.kubernetes.io/name":       "percona-server-mongodb",
-		"app.kubernetes.io/instance":   m.Name,
+		"app.kubernetes.io/instance":   cr.Name,
 		"app.kubernetes.io/replset":    replset.Name,
 		"app.kubernetes.io/managed-by": "percona-server-mongodb-operator",
 		"app.kubernetes.io/part-of":    "percona-server-mongodb",
@@ -35,16 +35,16 @@ func Service(m *api.PerconaServerMongoDB, replset *api.ReplsetSpec) *corev1.Serv
 			Kind:       "Service",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        m.Name + "-" + replset.Name,
-			Namespace:   m.Namespace,
+			Name:        cr.Name + "-" + replset.Name,
+			Namespace:   cr.Namespace,
 			Annotations: replset.Expose.ServiceAnnotations,
 		},
 		Spec: corev1.ServiceSpec{
 			Ports: []corev1.ServicePort{
 				{
 					Name:       mongodPortName,
-					Port:       api.MongodPort(m),
-					TargetPort: intstr.FromInt(int(api.MongodPort(m))),
+					Port:       api.MongodPort(cr),
+					TargetPort: intstr.FromInt(int(api.MongodPort(cr))),
 				},
 			},
 			ClusterIP:                "None",
@@ -53,7 +53,7 @@ func Service(m *api.PerconaServerMongoDB, replset *api.ReplsetSpec) *corev1.Serv
 		},
 	}
 
-	if m.CompareVersion("1.12.0") >= 0 {
+	if cr.CompareVersion("1.12.0") >= 0 {
 		svc.Labels = make(map[string]string)
 		for k, v := range ls {
 			svc.Labels[k] = v
@@ -69,7 +69,7 @@ func Service(m *api.PerconaServerMongoDB, replset *api.ReplsetSpec) *corev1.Serv
 }
 
 // ExternalService returns a Service object needs to serve external connections
-func ExternalService(m *api.PerconaServerMongoDB, replset *api.ReplsetSpec, podName string) *corev1.Service {
+func ExternalService(cr *api.PerconaServerMongoDB, replset *api.ReplsetSpec, podName string) *corev1.Service {
 	svc := &corev1.Service{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Service",
@@ -77,14 +77,14 @@ func ExternalService(m *api.PerconaServerMongoDB, replset *api.ReplsetSpec, podN
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        podName,
-			Namespace:   m.Namespace,
+			Namespace:   cr.Namespace,
 			Annotations: replset.Expose.ServiceAnnotations,
 		},
 	}
 
 	svc.Labels = map[string]string{
 		"app.kubernetes.io/name":       "percona-server-mongodb",
-		"app.kubernetes.io/instance":   m.Name,
+		"app.kubernetes.io/instance":   cr.Name,
 		"app.kubernetes.io/replset":    replset.Name,
 		"app.kubernetes.io/managed-by": "percona-server-mongodb-operator",
 		"app.kubernetes.io/part-of":    "percona-server-mongodb",
@@ -101,8 +101,8 @@ func ExternalService(m *api.PerconaServerMongoDB, replset *api.ReplsetSpec, podN
 		Ports: []corev1.ServicePort{
 			{
 				Name:       mongodPortName,
-				Port:       api.MongodPort(m),
-				TargetPort: intstr.FromInt(int(api.MongodPort(m))),
+				Port:       api.MongodPort(cr),
+				TargetPort: intstr.FromInt(int(api.MongodPort(cr))),
 			},
 		},
 		Selector: map[string]string{"statefulset.kubernetes.io/pod-name": podName},
@@ -213,11 +213,11 @@ func getIngressPoint(ctx context.Context, pod corev1.Pod, cl client.Client) (str
 }
 
 // GetReplsetAddrs returns a slice of replset host:port addresses
-func GetReplsetAddrs(ctx context.Context, cl client.Client, m *api.PerconaServerMongoDB, rsName string, rsExposed bool, pods []corev1.Pod) ([]string, error) {
+func GetReplsetAddrs(ctx context.Context, cl client.Client, cr *api.PerconaServerMongoDB, rsName string, rsExposed bool, pods []corev1.Pod) ([]string, error) {
 	addrs := make([]string, 0)
 
 	for _, pod := range pods {
-		host, err := MongoHost(ctx, cl, m, rsName, rsExposed, pod)
+		host, err := MongoHost(ctx, cl, cr, rsName, rsExposed, pod)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to get external hostname for pod %s", pod.Name)
 		}
@@ -254,29 +254,29 @@ func GetMongosAddrs(ctx context.Context, cl client.Client, cr *api.PerconaServer
 }
 
 // MongoHost returns the mongo host for given pod
-func MongoHost(ctx context.Context, cl client.Client, m *api.PerconaServerMongoDB, rsName string, rsExposed bool, pod corev1.Pod) (string, error) {
-	if m.Spec.ClusterServiceDNSMode == api.DnsModeServiceMesh {
-		return GetServiceMeshAddr(m, pod.Name, m.Namespace), nil
+func MongoHost(ctx context.Context, cl client.Client, cr *api.PerconaServerMongoDB, rsName string, rsExposed bool, pod corev1.Pod) (string, error) {
+	if cr.Spec.ClusterServiceDNSMode == api.DnsModeServiceMesh {
+		return GetServiceMeshAddr(cr, pod.Name, cr.Namespace), nil
 	}
 
 	if rsExposed {
-		if m.MCSEnabled() {
-			imported, err := IsServiceImported(ctx, cl, m, pod.Name)
+		if cr.MCSEnabled() {
+			imported, err := IsServiceImported(ctx, cl, cr, pod.Name)
 			if err != nil {
 				return "", errors.Wrapf(err, "check if service imported for %s", pod.Name)
 			}
 
 			if !imported {
-				return getExtAddr(ctx, cl, m.Namespace, pod)
+				return getExtAddr(ctx, cl, cr.Namespace, pod)
 			}
 
-			return GetMCSAddr(m, pod.Name), nil
+			return GetMCSAddr(cr, pod.Name), nil
 		}
 
-		return getExtAddr(ctx, cl, m.Namespace, pod)
+		return getExtAddr(ctx, cl, cr.Namespace, pod)
 	}
 
-	return GetAddr(m, pod.Name, rsName), nil
+	return GetAddr(cr, pod.Name, rsName), nil
 }
 
 // MongosHost returns the mongos host for given pod
@@ -328,20 +328,20 @@ func getExtAddr(ctx context.Context, cl client.Client, namespace string, pod cor
 }
 
 // GetAddr returns replicaSet pod address in cluster
-func GetAddr(m *api.PerconaServerMongoDB, pod, replset string) string {
-	return strings.Join([]string{pod, m.Name + "-" + replset, m.Namespace, m.Spec.ClusterServiceDNSSuffix}, ".") +
-		":" + strconv.Itoa(int(api.MongodPort(m)))
+func GetAddr(cr *api.PerconaServerMongoDB, pod, replset string) string {
+	return strings.Join([]string{pod, cr.Name + "-" + replset, cr.Namespace, cr.Spec.ClusterServiceDNSSuffix}, ".") +
+		":" + strconv.Itoa(int(api.MongodPort(cr)))
 }
 
 // GetAddr returns replicaSet pod address in a service mesh
-func GetServiceMeshAddr(m *api.PerconaServerMongoDB, pod, replset string) string {
-	return strings.Join([]string{pod, m.Namespace, m.Spec.ClusterServiceDNSSuffix}, ".") +
-		":" + strconv.Itoa(int(api.MongodPort(m)))
+func GetServiceMeshAddr(cr *api.PerconaServerMongoDB, pod, replset string) string {
+	return strings.Join([]string{pod, cr.Namespace, cr.Spec.ClusterServiceDNSSuffix}, ".") +
+		":" + strconv.Itoa(int(api.MongodPort(cr)))
 }
 
 // GetMCSAddr returns ReplicaSet pod address using MultiCluster FQDN
-func GetMCSAddr(m *api.PerconaServerMongoDB, pod string) string {
-	return fmt.Sprintf("%s.%s.%s:%d", pod, m.Namespace, m.Spec.MultiCluster.DNSSuffix, api.DefaultMongodPort)
+func GetMCSAddr(cr *api.PerconaServerMongoDB, pod string) string {
+	return fmt.Sprintf("%s.%s.%s:%d", pod, cr.Namespace, cr.Spec.MultiCluster.DNSSuffix, api.DefaultMongodPort)
 }
 
 var ErrServiceNotExists = errors.New("service doesn't exist")


### PR DESCRIPTION
[![K8SPSMDB-770](https://badgen.net/badge/JIRA/K8SPSMDB-770/green)](https://jira.percona.com/browse/K8SPSMDB-770) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
Couple of logs were missing namespace and cluster name keys.

**Cause:**
Couple of logs were written with a logger not coming from the context.

**Solution:**
Pass a context where necessary and get the logger from it.

**Note**: PR also fixes duplicate cluster name and namespace keys in some logs. Also adds a bit of refactoring.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Are E2E tests passing?
- [ ] Are unit tests passing?
- [ ] Are linting tests passing?
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?