### PR TITLE
K8SPSMDB-767: fix finalizers

### DIFF
--- a/pkg/apis/psmdb/v1/psmdb_types.go
+++ b/pkg/apis/psmdb/v1/psmdb_types.go
@@ -980,13 +980,12 @@ func (cr *PerconaServerMongoDB) GetOrderedFinalizers() []string {
 	copy(finalizers, cr.GetFinalizers())
 	orderedFinalizers := make([]string, 0, len(finalizers))
 
-	i := 0
 	for _, v := range order {
-		for i < len(finalizers) {
+		for i := 0; i < len(finalizers); {
 			if v == finalizers[i] {
 				orderedFinalizers = append(orderedFinalizers, v)
 				finalizers = append(finalizers[:i], finalizers[i+1:]...)
-				break
+				continue
 			}
 			i++
 		}

--- a/pkg/controller/perconaservermongodb/finalizers.go
+++ b/pkg/controller/perconaservermongodb/finalizers.go
@@ -23,7 +23,7 @@ func (r *ReconcilePerconaServerMongoDB) checkFinalizers(ctx context.Context, cr 
 	orderedFinalizers := cr.GetOrderedFinalizers()
 	var finalizers []string
 
-	for _, f := range orderedFinalizers {
+	for i, f := range orderedFinalizers {
 		switch f {
 		case api.FinalizerDeletePVC:
 			err = r.deletePvcFinalizer(ctx, cr)
@@ -43,7 +43,7 @@ func (r *ReconcilePerconaServerMongoDB) checkFinalizers(ctx context.Context, cr 
 			default:
 				log.Error(err, "failed to run finalizer", "finalizer", f)
 			}
-			finalizers = append(finalizers, f)
+			finalizers = append(finalizers, orderedFinalizers[i:]...)
 			break
 		}
 	}


### PR DESCRIPTION
[![K8SPSMDB-767](https://badgen.net/badge/JIRA/K8SPSMDB-767/green)](https://jira.percona.com/browse/K8SPSMDB-767) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://jira.percona.com/browse/K8SPSMDB-767

**CHANGE DESCRIPTION**
---
**Problem:**
*When multiple finalizers are used, only the first one executes and removes the other ones*

**Cause:**
*In the function `checkFinalizers`, when one of the finalizers throws an error, it's getting added to the new finalizers array and saved to the cr without the next ones.*

**Solution:**
*We should save other finalizers when some of them throw an error.*

*Also, this PR fixes `GetOrderedFinalizers` method. In some cases, it could return finalizers in wrong order*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Are E2E tests passing?
- [ ] Are unit tests passing?
- [ ] Are linting tests passing?
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?