### PR TITLE
K8SPSMDB-854: Backup gets stuck after cluster expose option toggle

### DIFF
--- a/pkg/controller/perconaservermongodb/psmdb_controller.go
+++ b/pkg/controller/perconaservermongodb/psmdb_controller.go
@@ -1507,7 +1507,7 @@ func (r *ReconcilePerconaServerMongoDB) reconcileStatefulSet(
 		}
 
 		if cr.Spec.Backup.Enabled {
-			agentC := backup.AgentContainer(cr, replset.Name)
+			agentC := backup.AgentContainer(cr, replset)
 			sfsSpec.Template.Spec.Containers = append(sfsSpec.Template.Spec.Containers, agentC)
 		}
 

--- a/pkg/psmdb/backup/agent.go
+++ b/pkg/psmdb/backup/agent.go
@@ -10,7 +10,7 @@ import (
 )
 
 // AgentContainer creates the container object for a backup agent
-func AgentContainer(cr *api.PerconaServerMongoDB, replsetName string) corev1.Container {
+func AgentContainer(cr *api.PerconaServerMongoDB, replset *api.ReplsetSpec) corev1.Container {
 	fvar := false
 	usersSecretName := api.UserSecretName(cr)
 
@@ -45,11 +45,19 @@ func AgentContainer(cr *api.PerconaServerMongoDB, replsetName string) corev1.Con
 			},
 			{
 				Name:  "PBM_MONGODB_REPLSET",
-				Value: replsetName,
+				Value: replset.Name,
 			},
 			{
 				Name:  "PBM_MONGODB_PORT",
 				Value: strconv.Itoa(int(api.MongodPort(cr))),
+			},
+			{
+				Name:  "REPLSET_EXPOSED",
+				Value: strconv.FormatBool(replset.Expose.Enabled),
+			},
+			{
+				Name:  "REPLSET_EXPOSED_TYPE",
+				Value: string(replset.Expose.ExposeType),
 			},
 		},
 		SecurityContext: cr.Spec.Backup.ContainerSecurityContext,

--- a/pkg/psmdb/container.go
+++ b/pkg/psmdb/container.go
@@ -113,14 +113,6 @@ func container(ctx context.Context, cr *api.PerconaServerMongoDB, replset *api.R
 				Name:  "MONGODB_REPLSET",
 				Value: replset.Name,
 			},
-			{
-				Name:  "REPLSET_EXPOSED",
-				Value: strconv.FormatBool(replset.Expose.Enabled),
-			},
-			{
-				Name:  "REPLSET_EXPOSED_TYPE",
-				Value: string(replset.Expose.ExposeType),
-			},
 		},
 		EnvFrom: []corev1.EnvFromSource{
 			{

--- a/pkg/psmdb/container.go
+++ b/pkg/psmdb/container.go
@@ -113,6 +113,14 @@ func container(ctx context.Context, cr *api.PerconaServerMongoDB, replset *api.R
 				Name:  "MONGODB_REPLSET",
 				Value: replset.Name,
 			},
+			{
+				Name:  "REPLSET_EXPOSED",
+				Value: strconv.FormatBool(replset.Expose.Enabled),
+			},
+			{
+				Name:  "REPLSET_EXPOSED_TYPE",
+				Value: string(replset.Expose.ExposeType),
+			},
 		},
 		EnvFrom: []corev1.EnvFromSource{
 			{


### PR DESCRIPTION
[![K8SPSMDB-854](https://badgen.net/badge/JIRA/K8SPSMDB-854/green)](https://jira.percona.com/browse/K8SPSMDB-854) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
When the cluster expose option gets changed, the backup gets stuck with `E [agentCheckup] get replSetGetStatus: not found` error in the backup-agent container.

**Cause:**
When replset `expose.enabled` gets toggled, mongo host in the config gets changed (from FQDN to IP if we expose the cluster) and due to PBM's lack of reading fresh node config, when performing status it compares the old value with the new.
For details check https://perconacorp.slack.com/archives/GDW1BCK6H/p1676444746488449

**Solution:**
Perform rolling restart after expose options is toggled by setting `REPLSET_EXPOSED` and `REPLSET_EXPOSED_TYPE` env variables in backup-agent containers.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Are E2E tests passing?
- [ ] Are unit tests passing?
- [ ] Are linting tests passing?
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?