### PR TITLE
K8SPSMDB-867: Use local FQDNs unless DNS mode is external

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -383,6 +383,7 @@ pipeline {
                         runTest('self-healing-chaos', 'cluster3')
                         runTest('operator-self-healing-chaos', 'cluster3')
                         runTest('expose-sharded', 'cluster3')
+                        runTest('recover-no-primary', 'cluster3')
                         ShutdownCluster('cluster3')
                     }
                 }

--- a/e2e-tests/expose-sharded/run
+++ b/e2e-tests/expose-sharded/run
@@ -44,16 +44,13 @@ function compare_mongo_config() {
 	enable_expose=${3:-"true"}
 
 	desc "Compare mongo config"
-	if [[ ${enable_expose} == "true" ]]; then
-		cfg_0_endpoint=$(get_service_ip $cluster-cfg-0 'cfg')
-		rs0_0_endpoint=$(get_service_ip $cluster-rs0-0)
-	else
-		cfg_0_endpoint="$cluster-cfg-0.$cluster-cfg.$namespace.svc.cluster.local"
-		rs0_0_endpoint="$cluster-rs0-0.$cluster-rs0.$namespace.svc.cluster.local"
-	fi
 
-	rs0_0_endpoint_actual=$(run_mongo 'var host;var x=0;rs.conf().members.forEach(function(d){ if(d.tags.podName=="some-name-rs0-0"){ host=rs.conf().members[x].host;print(host)};x=x+1; })' "clusterAdmin:clusterAdmin123456@${cluster}-rs0.${namespace}" | egrep -v 'I NETWORK|W NETWORK|Error saving history file|Percona Server for MongoDB|connecting to:|Unable to reach primary for set|Implicit session:|versions do not match|bye')
+	cfg_0_endpoint="$cluster-cfg-0.$cluster-cfg.$namespace.svc.cluster.local"
 	cfg_0_endpoint_actual=$(run_mongo 'var host;var x=0;rs.conf().members.forEach(function(d){ if(d.tags.podName=="some-name-cfg-0"){ host=rs.conf().members[x].host;print(host)};x=x+1; })' "clusterAdmin:clusterAdmin123456@${cluster}-cfg.${namespace}" | egrep -v 'I NETWORK|W NETWORK|Error saving history file|Percona Server for MongoDB|connecting to:|Unable to reach primary for set|Implicit session:|versions do not match|bye')
+
+	rs0_0_endpoint="$cluster-rs0-0.$cluster-rs0.$namespace.svc.cluster.local"
+	rs0_0_endpoint_actual=$(run_mongo 'var host;var x=0;rs.conf().members.forEach(function(d){ if(d.tags.podName=="some-name-rs0-0"){ host=rs.conf().members[x].host;print(host)};x=x+1; })' "clusterAdmin:clusterAdmin123456@${cluster}-rs0.${namespace}" | egrep -v 'I NETWORK|W NETWORK|Error saving history file|Percona Server for MongoDB|connecting to:|Unable to reach primary for set|Implicit session:|versions do not match|bye')
+
 	if [[ $rs0_0_endpoint_actual != "$rs0_0_endpoint:27017" || $cfg_0_endpoint_actual != "$cfg_0_endpoint:27017" ]]; then
 		desc "Actual values rs $rs0_0_endpoint_actual and cfg $cfg_0_endpoint_actual do not match expected rs $rs0_0_endpoint:27017 and cfg $cfg_0_endpoint:27017"
 		exit 1
@@ -77,7 +74,6 @@ function expose_cluster() {
               "op": "replace",
               "path": "/spec/sharding/mongos/expose",
         "value": {
-          "enabled": '${expose_status}',
           "exposeType" : "'"${expose_type}"'"
         }
           },
@@ -172,61 +168,53 @@ function main() {
 	compare_mongo_cmd "find" "myApp:myPass@$cluster-rs0-1.$cluster-rs0.$namespace" "-3nd"
 	compare_mongo_cmd "find" "myApp:myPass@$cluster-rs0-2.$cluster-rs0.$namespace" "-3nd"
 	sleep 60 # Wait LB ip setup
-	compare_mongo_config ${cluster} $namespace
-	# TODO: uncomment  after https://jira.percona.com/browse/K8SPSMDB-843
-	#	desc "Pause Exposed cluster (LoadBalancer)"
-	#	stop_cluster ${cluster}
-	#	start_cluster ${cluster}
-	#
-	#	run_mongos \
-	#		'use myApp\n db.test.insert({ x: 100504 })' \
-	#		"myApp:myPass@$cluster-mongos.$namespace"
-	#
-	#	compare_mongos_cmd "find" "myApp:myPass@$cluster-mongos.$namespace" "-5nd"
-	#	compare_mongo_cmd "find" "myApp:myPass@$cluster-rs0-0.$cluster-rs0.$namespace" "-5nd"
-	#	compare_mongo_cmd "find" "myApp:myPass@$cluster-rs0-1.$cluster-rs0.$namespace" "-5nd"
-	#	compare_mongo_cmd "find" "myApp:myPass@$cluster-rs0-2.$cluster-rs0.$namespace" "-5nd"
-	#
-	#	compare_mongo_config ${cluster}
-	#
-	# TODO: uncomment after https://jira.percona.com/browse/K8SPSMDB-841
-	#	desc "Exposed,  LoadBalancer -> ClusterIP"
-	#	expose_cluster "ClusterIP"
-	#
-	#	wait_for_running $cluster-rs0 3
-	#	wait_for_running $cluster-cfg 3 "false"
-	#	wait_for_running $cluster-mongos 3
-	#	wait_cluster_consistency "${cluster}" 3
-	#
-	#	run_mongos \
-	#		'use myApp\n db.test.insert({ x: 100503 })' \
-	#		"myApp:myPass@$cluster-mongos.$namespace"
-	#
-	#	compare_mongos_cmd "find" "myApp:myPass@$cluster-mongos.$namespace" "-4nd"
-	#	compare_mongo_cmd "find" "myApp:myPass@$cluster-rs0-0.$cluster-rs0.$namespace" "-4nd"
-	#	compare_mongo_cmd "find" "myApp:myPass@$cluster-rs0-1.$cluster-rs0.$namespace" "-4nd"
-	#	compare_mongo_cmd "find" "myApp:myPass@$cluster-rs0-2.$cluster-rs0.$namespace" "-4nd"
-	#
-	#	compare_mongo_config ${cluster} $namespace
-	#
-	#	desc "Exposed -> Unexposed"
-	#	expose_cluster "ClusterIP" "false"
-	#
-	#	wait_for_running $cluster-rs0 3
-	#	wait_for_running $cluster-cfg 3 "false"
-	#	wait_for_running $cluster-mongos 3
-	#	wait_cluster_consistency "${cluster}" 3
-	#
-	#	run_mongos \
-	#		'use myApp\n db.test.insert({ x: 100505 })' \
-	#		"myApp:myPass@$cluster-mongos.$namespace"
-	#
-	#	compare_mongos_cmd "find" "myApp:myPass@$cluster-mongos.$namespace" "-6nd"
-	#	compare_mongo_cmd "find" "myApp:myPass@$cluster-rs0-0.$cluster-rs0.$namespace" "-6nd"
-	#	compare_mongo_cmd "find" "myApp:myPass@$cluster-rs0-1.$cluster-rs0.$namespace" "-6nd"
-	#	compare_mongo_cmd "find" "myApp:myPass@$cluster-rs0-2.$cluster-rs0.$namespace" "-6nd"
-	#
-	#	compare_mongo_config ${cluster} $namespace "false"
+
+	desc "Pause Exposed cluster (LoadBalancer)"
+	stop_cluster ${cluster}
+	start_cluster ${cluster}
+
+	run_mongos \
+		'use myApp\n db.test.insert({ x: 100503 })' \
+		"myApp:myPass@$cluster-mongos.$namespace"
+
+	compare_mongos_cmd "find" "myApp:myPass@$cluster-mongos.$namespace" "-4nd"
+	compare_mongo_cmd "find" "myApp:myPass@$cluster-rs0-0.$cluster-rs0.$namespace" "-4nd"
+	compare_mongo_cmd "find" "myApp:myPass@$cluster-rs0-1.$cluster-rs0.$namespace" "-4nd"
+	compare_mongo_cmd "find" "myApp:myPass@$cluster-rs0-2.$cluster-rs0.$namespace" "-4nd"
+
+	desc "Exposed,  LoadBalancer -> ClusterIP"
+	expose_cluster "ClusterIP"
+
+	wait_for_running $cluster-rs0 3
+	wait_for_running $cluster-cfg 3 "false"
+	wait_for_running $cluster-mongos 3
+	wait_cluster_consistency "${cluster}" 3
+
+	run_mongos \
+		'use myApp\n db.test.insert({ x: 100504 })' \
+		"myApp:myPass@$cluster-mongos.$namespace"
+
+	compare_mongos_cmd "find" "myApp:myPass@$cluster-mongos.$namespace" "-5nd"
+	compare_mongo_cmd "find" "myApp:myPass@$cluster-rs0-0.$cluster-rs0.$namespace" "-5nd"
+	compare_mongo_cmd "find" "myApp:myPass@$cluster-rs0-1.$cluster-rs0.$namespace" "-5nd"
+	compare_mongo_cmd "find" "myApp:myPass@$cluster-rs0-2.$cluster-rs0.$namespace" "-5nd"
+
+	desc "Exposed -> Unexposed"
+	expose_cluster "ClusterIP" "false"
+
+	wait_for_running $cluster-rs0 3
+	wait_for_running $cluster-cfg 3 "false"
+	wait_for_running $cluster-mongos 3
+	wait_cluster_consistency "${cluster}" 3
+
+	run_mongos \
+		'use myApp\n db.test.insert({ x: 100505 })' \
+		"myApp:myPass@$cluster-mongos.$namespace"
+
+	compare_mongos_cmd "find" "myApp:myPass@$cluster-mongos.$namespace" "-6nd"
+	compare_mongo_cmd "find" "myApp:myPass@$cluster-rs0-0.$cluster-rs0.$namespace" "-6nd"
+	compare_mongo_cmd "find" "myApp:myPass@$cluster-rs0-1.$cluster-rs0.$namespace" "-6nd"
+	compare_mongo_cmd "find" "myApp:myPass@$cluster-rs0-2.$cluster-rs0.$namespace" "-6nd"
 
 	kubectl_bin delete -f "$conf_dir/container-rc.yaml"
 	destroy "$namespace"

--- a/e2e-tests/recover-no-primary/conf/some-name-exposed.yml
+++ b/e2e-tests/recover-no-primary/conf/some-name-exposed.yml
@@ -1,0 +1,55 @@
+apiVersion: psmdb.percona.com/v1
+kind: PerconaServerMongoDB
+metadata:
+  name: some-name
+spec:
+  #platform: openshift
+  image:
+  imagePullPolicy: Always
+  allowUnsafeConfigurations: true
+  backup:
+    enabled: false
+    image: perconalab/percona-server-mongodb-operator:0.4.0-backup
+  replsets:
+  - name: rs0
+    size: 3
+    configuration: |
+      operationProfiling:
+        mode: slowOp
+        slowOpThresholdMs: 100
+      security:
+        enableEncryption: true
+        redactClientLogData: false
+      setParameter:
+        ttlMonitorSleepSecs: 60
+        wiredTigerConcurrentReadTransactions: 128
+        wiredTigerConcurrentWriteTransactions: 128
+      storage:
+        engine: wiredTiger
+        wiredTiger:
+          collectionConfig:
+            blockCompressor: snappy
+          engineConfig:
+            directoryForIndexes: false
+            journalCompressor: snappy
+          indexConfig:
+            prefixCompression: true
+    expose:
+      enabled: true
+      exposeType: ClusterIP
+    affinity:
+      antiAffinityTopologyKey: none
+    resources:
+      limits:
+        cpu: 500m
+        memory: 0.5G
+      requests:
+        cpu: 100m
+        memory: 0.1G
+    volumeSpec:
+      persistentVolumeClaim:
+        resources:
+          requests:
+            storage: 1Gi
+  secrets:
+    users: some-users

--- a/e2e-tests/recover-no-primary/conf/some-name-sharded.yml
+++ b/e2e-tests/recover-no-primary/conf/some-name-sharded.yml
@@ -1,0 +1,65 @@
+apiVersion: psmdb.percona.com/v1
+kind: PerconaServerMongoDB
+metadata:
+  name: some-name
+spec:
+  #platform: openshift
+  image:
+  imagePullPolicy: Always
+  sharding:
+    enabled: true
+    configsvrReplSet:
+      size: 3
+      volumeSpec:
+        persistentVolumeClaim:
+          resources:
+            requests:
+              storage: 3Gi
+      expose:
+        enabled: false
+        exposeType: ClusterIP
+    mongos:
+      size: 3
+      expose:
+        exposeType: ClusterIP
+  replsets:
+  - name: rs0
+    affinity:
+      antiAffinityTopologyKey: none
+    expose:
+      enabled: false
+      exposeType: ClusterIP
+    resources:
+      limits:
+        cpu: 500m
+        memory: 1G
+      requests:
+        cpu: 100m
+        memory: 0.1G
+    volumeSpec:
+      persistentVolumeClaim:
+        resources:
+          requests:
+            storage: 1Gi
+    size: 3
+  - name: rs1
+    affinity:
+      antiAffinityTopologyKey: none
+    expose:
+      enabled: false
+      exposeType: ClusterIP
+    resources:
+      limits:
+        cpu: 500m
+        memory: 1G
+      requests:
+        cpu: 100m
+        memory: 0.1G
+    volumeSpec:
+      persistentVolumeClaim:
+        resources:
+          requests:
+            storage: 1Gi
+    size: 3
+  secrets:
+    users: some-users

--- a/e2e-tests/recover-no-primary/conf/some-name.yml
+++ b/e2e-tests/recover-no-primary/conf/some-name.yml
@@ -1,0 +1,34 @@
+apiVersion: psmdb.percona.com/v1
+kind: PerconaServerMongoDB
+metadata:
+  name: some-name
+spec:
+  #platform: openshift
+  image:
+  imagePullPolicy: Always
+  allowUnsafeConfigurations: true
+  backup:
+    enabled: false
+    image: perconalab/percona-server-mongodb-operator:main-backup
+  replsets:
+  - name: rs0
+    size: 3
+    expose:
+      enabled: false
+      exposeType: ClusterIP
+    affinity:
+      antiAffinityTopologyKey: none
+    resources:
+      limits:
+        cpu: 500m
+        memory: 0.5G
+      requests:
+        cpu: 100m
+        memory: 0.1G
+    volumeSpec:
+      persistentVolumeClaim:
+        resources:
+          requests:
+            storage: 1Gi
+  secrets:
+    users: some-users

--- a/e2e-tests/recover-no-primary/run
+++ b/e2e-tests/recover-no-primary/run
@@ -1,0 +1,202 @@
+#!/bin/bash
+
+set -o errexit
+set -o xtrace
+
+test_dir=$(realpath $(dirname $0))
+. ${test_dir}/../functions
+
+create_infra ${namespace}
+
+cluster="some-name"
+kubectl_bin apply \
+	-f ${conf_dir}/secrets_with_tls.yml \
+	-f ${conf_dir}/client.yml
+
+function test_single_replset() {
+	apply_cluster ${test_dir}/conf/${cluster}.yml
+	wait_for_running "${cluster}-rs0" 3
+	wait_cluster_consistency ${cluster}
+
+	## Case 1: Kill pods abruptly and wait for recovery
+
+	desc 'kill pods abruptly and wait for recovery'
+	for i in $(seq 0 2); do
+		kubectl_bin exec ${cluster}-rs0-${i} -c mongod -- kill 1
+	done
+	sleep 10
+	wait_for_running "${cluster}-rs0" 3
+	wait_cluster_consistency ${cluster}
+
+	## Case 2: Delete statefulset and wait for recovery
+
+	desc 'delete statefulset and wait for recovery'
+	kubectl delete sts "${cluster}-rs0"
+	sleep 5
+	wait_for_running "${cluster}-rs0" 3
+	wait_cluster_consistency ${cluster}
+
+	## Case 3: Delete cluster and recreate
+
+	desc 'delete cluster and recreate'
+	kubectl delete psmdb "${cluster}"
+
+	set +e
+	echo -n "waiting for psmdb/${cluster} to be deleted"
+	until ! kubectl get psmdb "${cluster}"; do
+		echo -n "."
+		sleep 1
+	done
+	set -e
+
+	apply_cluster ${test_dir}/conf/${cluster}.yml
+	wait_for_running "${cluster}-rs0" 3
+	wait_cluster_consistency ${cluster}
+
+	kubectl delete psmdb ${cluster}
+	kubectl delete pvc --all
+}
+
+function test_exposed_single_replset() {
+	apply_cluster ${test_dir}/conf/${cluster}-exposed.yml
+	wait_for_running "${cluster}-rs0" 3
+	wait_cluster_consistency ${cluster}
+
+	## Case 1: Kill pods abruptly and wait for recovery
+
+	desc 'kill pods abruptly and wait for recovery'
+	for i in $(seq 0 2); do
+		kubectl_bin exec ${cluster}-rs0-${i} -c mongod -- kill 1
+	done
+	sleep 10
+	wait_for_running "${cluster}-rs0" 3
+	wait_cluster_consistency ${cluster}
+
+	## Case 2: Delete statefulset and wait for recovery
+
+	desc 'delete statefulset and wait for recovery'
+	kubectl delete sts "${cluster}-rs0"
+	sleep 5
+	wait_for_running "${cluster}-rs0" 3
+	wait_cluster_consistency ${cluster}
+
+	## Case 3: Delete cluster and recreate
+
+	desc 'delete cluster and recreate'
+	kubectl delete psmdb "${cluster}"
+
+	set +e
+	echo -n "waiting for psmdb/${cluster} to be deleted"
+	until ! kubectl get psmdb "${cluster}"; do
+		echo -n "."
+		sleep 1
+	done
+	set -e
+
+	apply_cluster ${test_dir}/conf/${cluster}-exposed.yml
+	wait_for_running "${cluster}-rs0" 3
+	wait_cluster_consistency ${cluster}
+
+	kubectl delete psmdb ${cluster}
+	kubectl delete pvc --all
+}
+
+function test_exposed_sharded_cluster() {
+	apply_cluster ${test_dir}/conf/${cluster}-sharded.yml
+	wait_for_running "${cluster}-rs0" 3
+	wait_cluster_consistency ${cluster}
+
+	## Case 1: Kill pods abruptly and wait for recovery
+
+	desc 'kill pods abruptly and wait for recovery'
+
+	for i in $(seq 0 2); do
+		kubectl_bin exec ${cluster}-rs0-${i} -c mongod -- kill 1
+	done
+	sleep 10
+	wait_for_running "${cluster}-rs0" 3
+	wait_cluster_consistency ${cluster}
+
+	for i in $(seq 0 2); do
+		kubectl_bin exec ${cluster}-rs1-${i} -c mongod -- kill 1
+	done
+	sleep 10
+	wait_for_running "${cluster}-rs1" 3
+	wait_cluster_consistency ${cluster}
+
+	for i in $(seq 0 2); do
+		kubectl_bin exec ${cluster}-cfg-${i} -c mongod -- kill 1
+	done
+	sleep 10
+	wait_for_running "${cluster}-cfg" 3
+	wait_cluster_consistency ${cluster}
+
+	## Case 2: Delete statefulsets and wait for recovery
+
+	desc 'delete statefulsets and wait for recovery'
+	kubectl delete sts "${cluster}-rs0"
+	sleep 5
+	wait_for_running "${cluster}-rs0" 3
+	wait_cluster_consistency ${cluster}
+
+	kubectl delete sts "${cluster}-rs1"
+	sleep 5
+	wait_for_running "${cluster}-rs1" 3
+	wait_cluster_consistency ${cluster}
+
+	kubectl delete sts "${cluster}-cfg"
+	sleep 5
+	wait_for_running "${cluster}-cfg" 3
+	wait_cluster_consistency ${cluster}
+
+	## Case 3: Expose and delete cluster then recreate
+	desc 'expose and delete cluster then recreate'
+
+	kubectl_bin patch psmdb ${cluster} --type=json --patch '[
+		{
+			"op": "replace",
+			"path": "/spec/replsets/0/expose",
+			"value": {
+				"enabled": true,
+				"exposeType" : "ClusterIP"
+			}
+		},
+		{
+			"op": "replace",
+			"path": "/spec/replsets/1/expose",
+			"value": {
+				"enabled": true,
+				"exposeType" : "ClusterIP"
+			}
+		},
+	]'
+	kubectl delete psmdb "${cluster}"
+
+	set +e
+	echo -n "waiting for psmdb/${cluster} to be deleted"
+	until ! kubectl get psmdb "${cluster}"; do
+		echo -n "."
+		sleep 1
+	done
+	set -e
+
+	apply_cluster ${test_dir}/conf/${cluster}-sharded.yml
+	wait_for_running "${cluster}-rs0" 3
+	wait_for_running "${cluster}-rs1" 3
+	wait_for_running "${cluster}-cfg" 3
+	wait_cluster_consistency ${cluster}
+
+	kubectl delete psmdb ${cluster}
+	kubectl delete pvc --all
+}
+
+desc 'testing unexposed single replset cluster'
+test_single_replset
+
+desc 'testing exposed single replset cluster'
+test_exposed_single_replset
+
+desc 'testing exposed two replsets sharded cluster'
+test_exposed_sharded_cluster
+
+destroy ${namespace}

--- a/pkg/apis/psmdb/v1/psmdb_defaults.go
+++ b/pkg/apis/psmdb/v1/psmdb_defaults.go
@@ -529,7 +529,7 @@ func (cr *PerconaServerMongoDB) CheckNSetDefaults(platform version.Platform, log
 	}
 
 	if cr.Spec.ClusterServiceDNSMode == "" {
-		cr.Spec.ClusterServiceDNSMode = DnsModeInternal
+		cr.Spec.ClusterServiceDNSMode = DNSModeInternal
 	}
 
 	if cr.Spec.Unmanaged && cr.Spec.Backup.Enabled {

--- a/pkg/apis/psmdb/v1/psmdb_types.go
+++ b/pkg/apis/psmdb/v1/psmdb_types.go
@@ -83,7 +83,7 @@ type PerconaServerMongoDBSpec struct {
 	UpgradeOptions               UpgradeOptions                       `json:"upgradeOptions,omitempty"`
 	SchedulerName                string                               `json:"schedulerName,omitempty"`
 	ClusterServiceDNSSuffix      string                               `json:"clusterServiceDNSSuffix,omitempty"`
-	ClusterServiceDNSMode        DnsMode                              `json:"clusterServiceDNSMode,omitempty"`
+	ClusterServiceDNSMode        DNSMode                              `json:"clusterServiceDNSMode,omitempty"`
 	Sharding                     Sharding                             `json:"sharding,omitempty"`
 	InitImage                    string                               `json:"initImage,omitempty"`
 	InitContainerSecurityContext *corev1.SecurityContext              `json:"initContainerSecurityContext,omitempty"`
@@ -115,16 +115,18 @@ const (
 
 // DNS Mode string describes the mode used to generate fqdn/ip for communication between nodes
 // +enum
-type DnsMode string
+type DNSMode string
 
 const (
-	// DnsModeServiceMesh means a FQDN will be generated, assumming the FQDN is resolvable
-	// and available in all clusters
-	DnsModeServiceMesh DnsMode = "ServiceMesh"
+	// DNSModeServiceMesh means a FQDN (<pod>.<ns>.svc.cluster.local) will be generated,
+	// assumming the FQDN is resolvable and available in all clusters
+	DNSModeServiceMesh DNSMode = "ServiceMesh"
 
-	// DnsModeInternal means a FQDN (svc.cluster.local), a ClusterIP or a public IP will be used
-	// depending on how the service is exposed
-	DnsModeInternal DnsMode = "Internal"
+	// DNSModeInternal means the local FQDN (<pod>.<svc>.<ns>.svc.cluster.local) will be used
+	DNSModeInternal DNSMode = "Internal"
+
+	// DNSModeExternal means external IPs will be used in case of the services are exposed
+	DNSModeExternal DNSMode = "External"
 )
 
 type Sharding struct {

--- a/pkg/controller/perconaservermongodb/mgo.go
+++ b/pkg/controller/perconaservermongodb/mgo.go
@@ -228,7 +228,12 @@ func (r *ReconcilePerconaServerMongoDB) reconcileCluster(ctx context.Context, cr
 			break
 		}
 
-		host, err := psmdb.MongoHost(ctx, r.client, cr, replset.Name, replset.Expose.Enabled, pod)
+		exposed := false
+		if cr.Spec.ClusterServiceDNSMode == api.DNSModeExternal {
+			exposed = replset.Expose.Enabled
+		}
+
+		host, err := psmdb.MongoHost(ctx, r.client, cr, replset.Name, exposed, pod)
 		if err != nil {
 			return api.AppStateError, fmt.Errorf("get host for pod %s: %v", pod.Name, err)
 		}


### PR DESCRIPTION
[![K8SPSMDB-867](https://badgen.net/badge/JIRA/K8SPSMDB-867/green)](https://jira.percona.com/browse/K8SPSMDB-867) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
We were using exposed IPs in replset configuration in case replset is exposed. This was causing occasional full cluster crashes, hard to reason about and apparently against the MongoDB best practices.

Having exposed IP addresses in replset configuration is especially important for enabling multi cluster deployments. In a multi cluster setup, replset members can be in different Kubernetes cluster but they need to be able to reach each other to for replication to work. At the beginning, exposing members to the internet and configuring the replset with exposed IPs was the only solution to ensure connectivity between members. However the community developed their own ways to solve this problem, namely using service meshes. We also integrated the operator with Multi-Cluster Service APIs to enable multi cluster deployments without exposing the database to the internet. Now we can say using exposed IP addresses is not the safest way to have multi cluster topologies.

With these changes, we're going to use local FQDNs in replset configuration even replset is exposed by default. Users will be able to configure this behavior using `clusterServiceDNSMode` field. We're adding a new value to this field: `External` but for the sake of completeness, let's reiterate all possible values:

1. **`Internal`**: Use local FQDNs (i.e. `cluster1-rs0-0.cluster1-rs0.psmdb.svc.cluster.local`) in replset configuration even if the replset is exposed. **This is the default value.**
2. **`ServiceMesh`**:  Use a special FQDN using the pod name (i.e. `cluster1-rs0-0.psmdb.svc.cluster.local`) assuming it's resolvable and available in all clusters.
3. **`External`**:  Use exposed IP in replset configuration if replset is exposed. Otherwise use local FQDN. **This is basically the same with the previous behavior.**

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Are E2E tests passing?
- [ ] Are unit tests passing?
- [ ] Are linting tests passing?
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?