### PR TITLE
K8SPSMDB-853: fix `version_test` unit-test

### DIFF
--- a/pkg/controller/perconaservermongodb/version_test.go
+++ b/pkg/controller/perconaservermongodb/version_test.go
@@ -671,12 +671,16 @@ func startFakeVersionService(t *testing.T, addr string, port int, gwport int) er
 		Addr:    fmt.Sprintf("%s:%d", addr, gwport),
 		Handler: gwmux,
 	}
-
+	gwLis, err := net.Listen("tcp", gwServer.Addr)
+	if err != nil {
+		return errors.Wrap(err, "failed to listen gateway")
+	}
 	go func() {
-		if err := gwServer.ListenAndServe(); err != nil {
+		if err := gwServer.Serve(gwLis); err != nil {
 			t.Error("failed to serve gRPC-Gateway", err)
 		}
 	}()
+
 	return nil
 }
 


### PR DESCRIPTION
[![K8SPSMDB-853](https://badgen.net/badge/JIRA/K8SPSMDB-853/green)](https://jira.percona.com/browse/K8SPSMDB-853) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://jira.percona.com/browse/K8SPSMDB-853

**DESCRIPTION**
---
**Problem:**
*`version_test.go` sometimes fails in our pipelines*

**Cause:**
*Version service gateway is launched in another goroutine and starts after sending requests to it*

**Solution:**
*We should wait until the gateway starts to listen for connections and then serve it in another goroutine*

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?