### PR TITLE
Add backup type into restore example for backupSource

### DIFF
--- a/deploy/backup/restore.yaml
+++ b/deploy/backup/restore.yaml
@@ -9,6 +9,7 @@ spec:
 #    type: date
 #    date: YYYY-MM-DD HH:MM:SS
 #  backupSource:
+#    type: physical
 #    destination: s3://S3-BACKUP-BUCKET-NAME-HERE/BACKUP-DESTINATION
 #    s3:
 #      credentialsSecret: my-cluster-name-backup-s3


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Solution:**
*New option for backup type is missing from backupSource example in restore.yaml so add it in.*

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?
- [x] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are the manifests (crd/bundle) regenerated if needed?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported MongoDB version?
- [x] Does the change support oldest and newest supported Kubernetes version?