### PR TITLE
K8SPSMDB-873: Change HOME dir for mongosh

### DIFF
--- a/build/ps-entry.sh
+++ b/build/ps-entry.sh
@@ -33,7 +33,7 @@ fi
 
 MONGODB_VERSION=$(mongod --version | head -1 | awk '{print $3}' | awk -F'.' '{print $1"."$2}')
 
-mongo_shell=mongosh
+mongo_shell="HOME=${TMPDIR:-/tmp} mongosh"
 if [ "$MONGODB_VERSION" != 'v6.0' ]; then
 	echo "MongoDB version $MONGODB_VERSION present, using mongo shell"
     mongo_shell=mongo
@@ -213,7 +213,7 @@ _parse_config() {
 	if configPath="$(_mongod_hack_get_arg_val --config "$@")"; then
 		# if --config is specified, parse it into a JSON file so we can remove a few problematic keys (especially SSL-related keys)
 		# see https://docs.mongodb.com/manual/reference/configuration-options/
-		if [ $mongo_shell == 'mongosh' ]; then
+		if [[ $mongo_shell =~ 'mongosh' ]]; then
 			echo "parsing config with mongosh"
 			$mongo_shell --norc --nodb --quiet --eval "load('/js-yaml.js','/fs.js'); JSON.stringify((jsyaml.load(fs.readFileSync($(_js_escape "$configPath"),'utf8'))),null,2)" >"$jsonConfigFile"
 		else

--- a/build/ps-entry.sh
+++ b/build/ps-entry.sh
@@ -33,7 +33,7 @@ fi
 
 MONGODB_VERSION=$(mongod --version | head -1 | awk '{print $3}' | awk -F'.' '{print $1"."$2}')
 
-mongo_shell="HOME=${TMPDIR:-/tmp} mongosh"
+mongo_shell="env HOME=${TMPDIR:-/tmp} mongosh"
 if [ "$MONGODB_VERSION" != 'v6.0' ]; then
 	echo "MongoDB version $MONGODB_VERSION present, using mongo shell"
     mongo_shell=mongo
@@ -220,7 +220,7 @@ _parse_config() {
 			echo "parsing config with mongo"
 			$mongo_shell --norc --nodb --quiet --eval "load('/js-yaml.js'); printjson(jsyaml.load(cat($(_js_escape "$configPath"))))" >"$jsonConfigFile"
 		fi
-	
+
 		jq 'del(.systemLog, .processManagement, .net, .security)' "$jsonConfigFile" >"$tempConfigFile"
 		return 0
 	fi

--- a/build/ps-entry.sh
+++ b/build/ps-entry.sh
@@ -36,7 +36,7 @@ MONGODB_VERSION=$(mongod --version | head -1 | awk '{print $3}' | awk -F'.' '{pr
 mongo_shell="env HOME=${TMPDIR:-/tmp} mongosh"
 if [ "$MONGODB_VERSION" != 'v6.0' ]; then
 	echo "MongoDB version $MONGODB_VERSION present, using mongo shell"
-    mongo_shell=mongo
+	mongo_shell=mongo
 fi
 
 # usage: file_env VAR [DEFAULT]

--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -19,7 +19,7 @@ spec:
 #    certValidityDuration: 2160h
 #  imagePullSecrets:
 #    - name: private-registry-credentials
-#  initImage: percona/percona-xtradb-cluster-operator:1.13.0
+#  initImage: percona/percona-server-mongodb-operator:1.13.0
 #  initContainerSecurityContext: {}
   allowUnsafeConfigurations: false
   updateStrategy: SmartUpdate


### PR DESCRIPTION
[![K8SPSMDB-873](https://badgen.net/badge/JIRA/K8SPSMDB-873/green)](https://jira.percona.com/browse/K8SPSMDB-873) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**Problem:**
Parsing config fails due to mongosh writes the error message to the config file.

**Cause:**
On openshift 4.11 mongosh wants to write to the root home dir which has no permissions, it returns the error and writes it to the config file which then fails when trying to parse it as JSON.

**Solution:**
When executing `mongosh` set home dir to `/tmp` rather than `/`

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?
- [x] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are the manifests (crd/bundle) regenerated if needed?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported MongoDB version?
- [x] Does the change support oldest and newest supported Kubernetes version?