### PR TITLE
Fix for version-service semver channel name

### DIFF
--- a/e2e-tests/demand-backup-physical/compare/statefulset_some-name-rs0_restore-oc.yml
+++ b/e2e-tests/demand-backup-physical/compare/statefulset_some-name-rs0_restore-oc.yml
@@ -1,0 +1,248 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations:
+    percona.com/restore-in-progress: "true"
+  generation: 2
+  labels:
+    app.kubernetes.io/component: mongod
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/managed-by: percona-server-mongodb-operator
+    app.kubernetes.io/name: percona-server-mongodb
+    app.kubernetes.io/part-of: percona-server-mongodb
+    app.kubernetes.io/replset: rs0
+  name: some-name-rs0
+  ownerReferences:
+    - controller: true
+      kind: PerconaServerMongoDB
+      name: some-name
+spec:
+  podManagementPolicy: OrderedReady
+  replicas: 3
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: mongod
+      app.kubernetes.io/instance: some-name
+      app.kubernetes.io/managed-by: percona-server-mongodb-operator
+      app.kubernetes.io/name: percona-server-mongodb
+      app.kubernetes.io/part-of: percona-server-mongodb
+      app.kubernetes.io/replset: rs0
+  serviceName: some-name-rs0
+  template:
+    metadata:
+      annotations: {}
+      labels:
+        app.kubernetes.io/component: mongod
+        app.kubernetes.io/instance: some-name
+        app.kubernetes.io/managed-by: percona-server-mongodb-operator
+        app.kubernetes.io/name: percona-server-mongodb
+        app.kubernetes.io/part-of: percona-server-mongodb
+        app.kubernetes.io/replset: rs0
+    spec:
+      containers:
+        - args:
+            - --bind_ip_all
+            - --auth
+            - --dbpath=/data/db
+            - --port=27017
+            - --replSet=rs0
+            - --storageEngine=wiredTiger
+            - --relaxPermChecks
+            - --sslAllowInvalidCertificates
+            - --clusterAuthMode=x509
+            - --enableEncryption
+            - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
+            - --wiredTigerCacheSizeGB=0.25
+            - --wiredTigerIndexPrefixCompression=true
+            - --config=/etc/mongodb-config/mongod.conf
+          command:
+            - /opt/percona/physical-restore-ps-entry.sh
+          env:
+            - name: SERVICE_NAME
+              value: some-name
+            - name: MONGODB_PORT
+              value: "27017"
+            - name: MONGODB_REPLSET
+              value: rs0
+            - name: PBM_AGENT_MONGODB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  key: MONGODB_BACKUP_USER
+                  name: some-users
+            - name: PBM_AGENT_MONGODB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: MONGODB_BACKUP_PASSWORD
+                  name: some-users
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: PBM_MONGODB_URI
+              value: mongodb://$(PBM_AGENT_MONGODB_USERNAME):$(PBM_AGENT_MONGODB_PASSWORD)@$(POD_NAME)
+          envFrom:
+            - secretRef:
+                name: internal-some-name-users
+                optional: false
+          imagePullPolicy: Always
+          livenessProbe:
+            exec:
+              command:
+                - /opt/percona/mongodb-healthcheck
+                - k8s
+                - liveness
+                - --ssl
+                - --sslInsecure
+                - --sslCAFile
+                - /etc/mongodb-ssl/ca.crt
+                - --sslPEMKeyFile
+                - /tmp/tls.pem
+                - --startupDelaySeconds
+                - "7200"
+            failureThreshold: 4
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 10
+          name: mongod
+          ports:
+            - containerPort: 27017
+              name: mongodb
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 8
+            initialDelaySeconds: 10
+            periodSeconds: 3
+            successThreshold: 1
+            tcpSocket:
+              port: 27017
+            timeoutSeconds: 2
+          resources:
+            limits:
+              cpu: 500m
+              memory: 1G
+            requests:
+              cpu: 100m
+              memory: 100M
+          securityContext:
+            runAsNonRoot: true
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /data/db
+              name: mongod-data
+            - mountPath: /etc/mongodb-secrets
+              name: some-name-mongodb-keyfile
+              readOnly: true
+            - mountPath: /etc/mongodb-ssl
+              name: ssl
+              readOnly: true
+            - mountPath: /etc/mongodb-ssl-internal
+              name: ssl-internal
+              readOnly: true
+            - mountPath: /etc/mongodb-config
+              name: config
+            - mountPath: /opt/percona
+              name: bin
+            - mountPath: /etc/mongodb-encryption
+              name: some-name-mongodb-encryption-key
+              readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
+            - mountPath: /etc/pbm/
+              name: pbm-config
+              readOnly: true
+          workingDir: /data/db
+      dnsPolicy: ClusterFirst
+      initContainers:
+        - command:
+            - /init-entrypoint.sh
+          imagePullPolicy: Always
+          name: mongo-init
+          resources:
+            limits:
+              cpu: 500m
+              memory: 1G
+            requests:
+              cpu: 100m
+              memory: 100M
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /data/db
+              name: mongod-data
+            - mountPath: /opt/percona
+              name: bin
+        - command:
+            - bash
+            - -c
+            - install -D /usr/bin/pbm /opt/percona/pbm && install -D /usr/bin/pbm-agent /opt/percona/pbm-agent
+          imagePullPolicy: Always
+          name: pbm-init
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /data/db
+              name: mongod-data
+            - mountPath: /opt/percona
+              name: bin
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: default
+      serviceAccountName: default
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: some-name-mongodb-keyfile
+          secret:
+            defaultMode: 288
+            optional: false
+            secretName: some-name-mongodb-keyfile
+        - emptyDir: {}
+          name: bin
+        - configMap:
+            defaultMode: 420
+            name: some-name-rs0-mongod
+            optional: true
+          name: config
+        - name: some-name-mongodb-encryption-key
+          secret:
+            defaultMode: 288
+            optional: false
+            secretName: some-name-mongodb-encryption-key
+        - name: ssl
+          secret:
+            defaultMode: 288
+            optional: false
+            secretName: some-name-ssl
+        - name: ssl-internal
+          secret:
+            defaultMode: 288
+            optional: true
+            secretName: some-name-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-some-name-users
+        - name: pbm-config
+          secret:
+            defaultMode: 420
+            secretName: pbm-config
+  updateStrategy:
+    rollingUpdate:
+      partition: 0
+    type: RollingUpdate
+  volumeClaimTemplates:
+    - metadata:
+        name: mongod-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 3Gi
+      status:
+        phase: Pending

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -1192,3 +1192,21 @@ check_crd_for_deletion() {
 		fi
 	done
 }
+
+function get_mongod_ver_from_image() {
+	local image=${1}
+
+	local pod_name=${RANDOM}
+	kubectl_bin run ${pod_name} --image=${image} --restart=Never --command -- sleep infinity >/dev/null
+	kubectl_bin wait --for=condition=Ready pod/${pod_name} >/dev/null
+
+	local version_info=$(kubectl_bin exec ${pod_name} -- mongod --version)
+	kubectl_bin delete pod/${pod_name} --grace-period=0 --force >/dev/null
+	version_info=$(echo ${version_info} | head -n2 | $sed -r 's/^.*db version v(([0-9]+\.){2}[0-9]+-[0-9]+).*$/\1/g')
+
+	if [[ ! ${version_info} =~ ^([0-9]+\.){2}[0-9]+-[0-9]+$ ]]; then
+		printf "No mongod version obtained from %s. Exiting" ${image}
+		exit 1
+	fi
+	echo ${version_info}
+}

--- a/e2e-tests/mongod-major-upgrade-sharded/run
+++ b/e2e-tests/mongod-major-upgrade-sharded/run
@@ -6,24 +6,6 @@ set -o xtrace
 test_dir=$(realpath $(dirname $0))
 . ${test_dir}/../functions
 
-function get_mongod_ver_from_image() {
-	local image=${1}
-
-	local pod_name=${RANDOM}
-	kubectl_bin run ${pod_name} --image=${image} --restart=Never --command -- sleep infinity >/dev/null
-	kubectl_bin wait --for=condition=Ready pod/${pod_name} >/dev/null
-
-	local version_info=$(kubectl_bin exec ${pod_name} -- mongod --version)
-	kubectl_bin delete pod/${pod_name} --grace-period=0 --force >/dev/null
-	version_info=$(echo ${version_info} | head -n2 | $sed -r 's/^.*db version v(([0-9]+\.){2}[0-9]+-[0-9]+).*$/\1/g')
-
-	if [[ ! ${version_info} =~ ^([0-9]+\.){2}[0-9]+-[0-9]+$ ]]; then
-		printf "No mongod version obtained from %s. Exiting" ${image}
-		exit 1
-	fi
-	echo ${version_info}
-}
-
 function generate_vs_json() {
 	local template_path=${1}
 	local target_path=${2}

--- a/e2e-tests/mongod-major-upgrade/run
+++ b/e2e-tests/mongod-major-upgrade/run
@@ -6,24 +6,6 @@ set -o xtrace
 test_dir=$(realpath $(dirname $0))
 . ${test_dir}/../functions
 
-function get_mongod_ver_from_image() {
-	local image=${1}
-
-	local pod_name=${RANDOM}
-	kubectl_bin run ${pod_name} --image=${image} --restart=Never --command -- sleep infinity >/dev/null
-	kubectl_bin wait --for=condition=Ready pod/${pod_name} >/dev/null
-
-	local version_info=$(kubectl_bin exec ${pod_name} -- mongod --version)
-	kubectl_bin delete pod/${pod_name} --grace-period=0 --force >/dev/null
-	version_info=$(echo ${version_info} | head -n2 | $sed -r 's/^.*db version v(([0-9]+\.){2}[0-9]+-[0-9]+).*$/\1/g')
-
-	if [[ ! ${version_info} =~ ^([0-9]+\.){2}[0-9]+-[0-9]+$ ]]; then
-		printf "No mongod version obtained from %s. Exiting" ${image}
-		exit 1
-	fi
-	echo ${version_info}
-}
-
 function generate_vs_json() {
 	local template_path=${1}
 	local target_path=${2}

--- a/e2e-tests/service-per-pod/compare/statefulset_node-port-rs0-oc.yml
+++ b/e2e-tests/service-per-pod/compare/statefulset_node-port-rs0-oc.yml
@@ -1,0 +1,244 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations: {}
+  generation: 1
+  labels:
+    app.kubernetes.io/component: mongod
+    app.kubernetes.io/instance: node-port
+    app.kubernetes.io/managed-by: percona-server-mongodb-operator
+    app.kubernetes.io/name: percona-server-mongodb
+    app.kubernetes.io/part-of: percona-server-mongodb
+    app.kubernetes.io/replset: rs0
+  name: node-port-rs0
+  ownerReferences:
+    - controller: true
+      kind: PerconaServerMongoDB
+      name: node-port
+spec:
+  podManagementPolicy: OrderedReady
+  replicas: 3
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: mongod
+      app.kubernetes.io/instance: node-port
+      app.kubernetes.io/managed-by: percona-server-mongodb-operator
+      app.kubernetes.io/name: percona-server-mongodb
+      app.kubernetes.io/part-of: percona-server-mongodb
+      app.kubernetes.io/replset: rs0
+  serviceName: node-port-rs0
+  template:
+    metadata:
+      annotations: {}
+      labels:
+        app.kubernetes.io/component: mongod
+        app.kubernetes.io/instance: node-port
+        app.kubernetes.io/managed-by: percona-server-mongodb-operator
+        app.kubernetes.io/name: percona-server-mongodb
+        app.kubernetes.io/part-of: percona-server-mongodb
+        app.kubernetes.io/replset: rs0
+    spec:
+      containers:
+        - args:
+            - --bind_ip_all
+            - --auth
+            - --dbpath=/data/db
+            - --port=27017
+            - --replSet=rs0
+            - --storageEngine=wiredTiger
+            - --relaxPermChecks
+            - --sslAllowInvalidCertificates
+            - --clusterAuthMode=x509
+            - --enableEncryption
+            - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
+            - --wiredTigerIndexPrefixCompression=true
+            - --config=/etc/mongodb-config/mongod.conf
+          command:
+            - /opt/percona/ps-entry.sh
+          env:
+            - name: SERVICE_NAME
+              value: node-port
+            - name: MONGODB_PORT
+              value: "27017"
+            - name: MONGODB_REPLSET
+              value: rs0
+          envFrom:
+            - secretRef:
+                name: internal-node-port-users
+                optional: false
+          imagePullPolicy: Always
+          livenessProbe:
+            exec:
+              command:
+                - /opt/percona/mongodb-healthcheck
+                - k8s
+                - liveness
+                - --ssl
+                - --sslInsecure
+                - --sslCAFile
+                - /etc/mongodb-ssl/ca.crt
+                - --sslPEMKeyFile
+                - /tmp/tls.pem
+                - --startupDelaySeconds
+                - "7200"
+            failureThreshold: 4
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 10
+          name: mongod
+          ports:
+            - containerPort: 27017
+              name: mongodb
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 8
+            initialDelaySeconds: 10
+            periodSeconds: 3
+            successThreshold: 1
+            tcpSocket:
+              port: 27017
+            timeoutSeconds: 2
+          resources: {}
+          securityContext:
+            runAsNonRoot: true
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /data/db
+              name: mongod-data
+            - mountPath: /etc/mongodb-secrets
+              name: node-port-mongodb-keyfile
+              readOnly: true
+            - mountPath: /etc/mongodb-ssl
+              name: ssl
+              readOnly: true
+            - mountPath: /etc/mongodb-ssl-internal
+              name: ssl-internal
+              readOnly: true
+            - mountPath: /etc/mongodb-config
+              name: config
+            - mountPath: /opt/percona
+              name: bin
+            - mountPath: /etc/mongodb-encryption
+              name: node-port-mongodb-encryption-key
+              readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
+          workingDir: /data/db
+        - args:
+            - pbm-agent-entrypoint
+          command:
+            - /opt/percona/pbm-entry.sh
+          env:
+            - name: PBM_AGENT_MONGODB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  key: MONGODB_BACKUP_USER
+                  name: internal-node-port-users
+                  optional: false
+            - name: PBM_AGENT_MONGODB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: MONGODB_BACKUP_PASSWORD
+                  name: internal-node-port-users
+                  optional: false
+            - name: PBM_MONGODB_REPLSET
+              value: rs0
+            - name: PBM_MONGODB_PORT
+              value: "27017"
+            - name: PBM_AGENT_SIDECAR
+              value: "true"
+            - name: PBM_AGENT_SIDECAR_SLEEP
+              value: "5"
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: PBM_MONGODB_URI
+              value: mongodb://$(PBM_AGENT_MONGODB_USERNAME):$(PBM_AGENT_MONGODB_PASSWORD)@$(POD_NAME)
+          imagePullPolicy: Always
+          name: backup-agent
+          resources: {}
+          securityContext:
+            runAsNonRoot: true
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /etc/mongodb-ssl
+              name: ssl
+              readOnly: true
+            - mountPath: /opt/percona
+              name: bin
+              readOnly: true
+            - mountPath: /data/db
+              name: mongod-data
+      dnsPolicy: ClusterFirst
+      initContainers:
+        - command:
+            - /init-entrypoint.sh
+          imagePullPolicy: Always
+          name: mongo-init
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /data/db
+              name: mongod-data
+            - mountPath: /opt/percona
+              name: bin
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: default
+      serviceAccountName: default
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: node-port-mongodb-keyfile
+          secret:
+            defaultMode: 288
+            optional: false
+            secretName: node-port-mongodb-keyfile
+        - emptyDir: {}
+          name: bin
+        - configMap:
+            defaultMode: 420
+            name: node-port-rs0-mongod
+            optional: true
+          name: config
+        - name: node-port-mongodb-encryption-key
+          secret:
+            defaultMode: 288
+            optional: false
+            secretName: node-port-mongodb-encryption-key
+        - name: ssl
+          secret:
+            defaultMode: 288
+            optional: false
+            secretName: node-port-ssl
+        - name: ssl-internal
+          secret:
+            defaultMode: 288
+            optional: true
+            secretName: node-port-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-node-port-users
+  updateStrategy:
+    rollingUpdate:
+      partition: 0
+    type: RollingUpdate
+  volumeClaimTemplates:
+    - metadata:
+        name: mongod-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+      status:
+        phase: Pending

--- a/e2e-tests/service-per-pod/run
+++ b/e2e-tests/service-per-pod/run
@@ -20,6 +20,7 @@ check_cr_config() {
 	compare_kubectl service/$cluster-0
 
 	local URI="$(get_service_ip $cluster-0),$(get_service_ip $cluster-1),$(get_service_ip $cluster-2)"
+	# Wait a bit longer for ELB availability on Openshift
 	sleep 30
 
 	desc 'create user myApp'

--- a/e2e-tests/service-per-pod/run
+++ b/e2e-tests/service-per-pod/run
@@ -20,7 +20,7 @@ check_cr_config() {
 	compare_kubectl service/$cluster-0
 
 	local URI="$(get_service_ip $cluster-0),$(get_service_ip $cluster-1),$(get_service_ip $cluster-2)"
-	sleep 20
+	sleep 30
 
 	desc 'create user myApp'
 	run_mongo \
@@ -44,15 +44,15 @@ check_cr_config() {
 		old_node_port=$(kubectl_bin get svc node-port-rs0-0 -o 'jsonpath={.spec.ports[0].nodePort}')
 		kubectl_bin patch psmdb node-port --type=json --patch '[
 		{
-			"op": "add", 
-			"path": "/spec/replsets/0/expose/serviceAnnotations", 
+			"op": "add",
+			"path": "/spec/replsets/0/expose/serviceAnnotations",
 			"value": {
 				"test": "service-per-pod",
 			}
 		},
 		{
-			"op": "add", 
-			"path": "/spec/replsets/0/expose/serviceLabels", 
+			"op": "add",
+			"path": "/spec/replsets/0/expose/serviceLabels",
 			"value": {
 				"test": "service-per-pod",
 			}

--- a/e2e-tests/version-service/run
+++ b/e2e-tests/version-service/run
@@ -128,9 +128,10 @@ kubectl_bin get deployment/percona-server-mongodb-operator -o yaml ${OPERATOR_NS
 	| yq eval '(.spec.template.spec.containers[0].env[] | select(.name == "DISABLE_TELEMETRY").value) = "true"' \
 	| kubectl_bin apply ${OPERATOR_NS:+-n $OPERATOR_NS} -f -
 
-IMAGE_PREFIX=$(echo -n "${IMAGE_MONGOD}" | sed -r 's/.*([0-9].[0-9])(.[0-9].*)?$/\1/')
+ACTUAL_MONGOD_VERSION=$(get_mongod_ver_from_image "${IMAGE_MONGOD}")
+
 wait_deployment 'percona-server-mongodb-operator'
-check_telemetry_transfer "http://version-service-cr:11000" "${IMAGE_PREFIX}-recommended" "disabled"
+check_telemetry_transfer "http://version-service-cr:11000" "${ACTUAL_MONGOD_VERSION:0:3}-recommended" "disabled"
 
 kubectl_bin get deployment/percona-server-mongodb-operator -o yaml ${OPERATOR_NS:+-n $OPERATOR_NS} \
 	| yq eval '(.spec.template.spec.containers[0].env[] | select(.name == "DISABLE_TELEMETRY").value) = "true"' \


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
6.0.4-3 results in 4-3-recommended

**Cause:**
Human factor

**Solution:**
Utilize the already existing infrastructure

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?