### PR TITLE
K8SPSMDB-878 - Fix EKS tests

### DIFF
--- a/e2e-tests/demand-backup-sharded/run
+++ b/e2e-tests/demand-backup-sharded/run
@@ -38,6 +38,8 @@ kubectl_bin apply \
 apply_s3_storage_secrets
 if version_gt "1.19" && [ $EKS -ne 1 ]; then
 	cat "$conf_dir/container-rc.yaml" | $sed 's/docker/runc/g' | kubectl_bin apply -f -
+elif version_gt "1.24" && [ $EKS -eq 1 ]; then
+	cat "$conf_dir/container-rc.yaml" | $sed 's/docker/runc/g' | kubectl_bin apply -f -
 else
 	kubectl_bin apply -f "$conf_dir/container-rc.yaml"
 fi

--- a/e2e-tests/expose-sharded/run
+++ b/e2e-tests/expose-sharded/run
@@ -101,6 +101,8 @@ function main() {
 	apply_s3_storage_secrets
 	if version_gt "1.19" && [ $EKS -ne 1 ]; then
 		cat "$conf_dir/container-rc.yaml" | $sed 's/docker/runc/g' | kubectl_bin apply -f -
+	elif version_gt "1.24" && [ $EKS -eq 1 ]; then
+		cat "$conf_dir/container-rc.yaml" | $sed 's/docker/runc/g' | kubectl_bin apply -f -
 	else
 		kubectl_bin apply -f "$conf_dir/container-rc.yaml"
 	fi

--- a/e2e-tests/init-deploy/run
+++ b/e2e-tests/init-deploy/run
@@ -18,6 +18,8 @@ kubectl_bin apply \
 desc 'create custom RuntimeClass'
 if version_gt "1.19" && [ $EKS -ne 1 ]; then
 	cat "$conf_dir/container-rc.yaml" | $sed 's/docker/runc/g' | kubectl_bin apply -f -
+elif version_gt "1.24" && [ $EKS -eq 1 ]; then
+	cat "$conf_dir/container-rc.yaml" | $sed 's/docker/runc/g' | kubectl_bin apply -f -
 else
 	kubectl_bin apply -f "$conf_dir/container-rc.yaml"
 fi

--- a/e2e-tests/multi-cluster-service/run
+++ b/e2e-tests/multi-cluster-service/run
@@ -87,6 +87,8 @@ kubectl_bin apply \
 apply_s3_storage_secrets
 if version_gt "1.19" && [ $EKS -ne 1 ]; then
 	cat "$conf_dir/container-rc.yaml" | $sed 's/docker/runc/g' | kubectl_bin apply -f -
+elif version_gt "1.24" && [ $EKS -eq 1 ]; then
+	cat "$conf_dir/container-rc.yaml" | $sed 's/docker/runc/g' | kubectl_bin apply -f -
 else
 	kubectl_bin apply -f "$conf_dir/container-rc.yaml"
 fi

--- a/e2e-tests/pitr-sharded/run
+++ b/e2e-tests/pitr-sharded/run
@@ -87,6 +87,8 @@ main() {
 	desc 'create custom RuntimeClass'
 	if version_gt "1.19" && [ $EKS -ne 1 ]; then
 		cat "$conf_dir/container-rc.yaml" | $sed 's/docker/runc/g' | kubectl_bin apply -f -
+	elif version_gt "1.24" && [ $EKS -eq 1 ]; then
+		cat "$conf_dir/container-rc.yaml" | $sed 's/docker/runc/g' | kubectl_bin apply -f -
 	else
 		kubectl_bin apply -f "$conf_dir/container-rc.yaml"
 	fi

--- a/e2e-tests/upgrade-consistency/run
+++ b/e2e-tests/upgrade-consistency/run
@@ -19,7 +19,7 @@ main() {
 	apply_cluster "$test_dir/conf/${CLUSTER}-rs0.yml"
 
 	desc 'check if Pod started'
-	wait_for_running "${CLUSTER}-rs0" "1" "false"
+	wait_for_running "${CLUSTER}-rs0" "3" "true"
 
 	desc 'check if service and statefulset created with expected config'
 	compare_kubectl service/${CLUSTER}-rs0 "-1110"
@@ -30,7 +30,7 @@ main() {
         "spec": {"crVersion":"1.12.0"}
     }'
 	desc 'check if Pod started'
-	wait_for_running "${CLUSTER}-rs0" "1" "false"
+	wait_for_running "${CLUSTER}-rs0" "3" "true"
 
 	desc 'check if service and statefulset created with expected config'
 	compare_kubectl service/${CLUSTER}-rs0 "-1120"
@@ -41,7 +41,7 @@ main() {
         "spec": {"crVersion":"1.13.0"}
     }'
 	desc 'check if Pod started'
-	wait_for_running "${CLUSTER}-rs0" "1" "false"
+	wait_for_running "${CLUSTER}-rs0" "3" "true"
 
 	desc 'check if service and statefulset created with expected config'
 	compare_kubectl service/${CLUSTER}-rs0 "-1130"
@@ -54,7 +54,7 @@ main() {
 	# Wait for at least one reconciliation
 	sleep 10
 	desc 'check if Pod started'
-	wait_for_running "${CLUSTER}-rs0" "1" "false"
+	wait_for_running "${CLUSTER}-rs0" "3" "true"
 
 	desc 'check if service and statefulset created with expected config'
 	compare_kubectl service/${CLUSTER}-rs0 "-1140"


### PR DESCRIPTION
[![K8SPSMDB-878](https://badgen.net/badge/JIRA/K8SPSMDB-878/green)](https://jira.percona.com/browse/K8SPSMDB-878) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
*`upgrade-consistency` test is running 3 node replica but only checking for running 1 pod and it doesn't check cluster readyness.
Some tests try to add docker handler for container runtimeclass, but it is unavailable in EKS 1.24*

**Solution:**
*Add missing checks and use runc in EKS 1.24*

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?
- [x] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are the manifests (crd/bundle) regenerated if needed?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported MongoDB version?
- [x] Does the change support oldest and newest supported Kubernetes version?