### PR TITLE
K8SPSMDB-713: Retry PBM describe-restore on failure

### DIFF
--- a/pkg/controller/perconaservermongodb/version_test.go
+++ b/pkg/controller/perconaservermongodb/version_test.go
@@ -671,12 +671,16 @@ func startFakeVersionService(t *testing.T, addr string, port int, gwport int) er
 		Addr:    fmt.Sprintf("%s:%d", addr, gwport),
 		Handler: gwmux,
 	}
-
+	gwLis, err := net.Listen("tcp", gwServer.Addr)
+	if err != nil {
+		return errors.Wrap(err, "failed to listen gateway")
+	}
 	go func() {
-		if err := gwServer.ListenAndServe(); err != nil {
+		if err := gwServer.Serve(gwLis); err != nil {
 			t.Error("failed to serve gRPC-Gateway", err)
 		}
 	}()
+
 	return nil
 }
 


### PR DESCRIPTION
[![K8SPSMDB-713](https://badgen.net/badge/JIRA/K8SPSMDB-713/green)](https://jira.percona.com/browse/K8SPSMDB-713) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

---
**Problem:**
PBM describe-restore command not retried on failure

**Solution:**
On `container is not created or running` error retry PBM describe-restore command.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?
- [x] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are the manifests (crd/bundle) regenerated if needed?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported MongoDB version?
- [x] Does the change support oldest and newest supported Kubernetes version?