### PR TITLE
K8SPSMDB-881 Force error exit on restore error

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -318,18 +318,22 @@ wait_restore() {
 	set +o xtrace
 	retry=0
 	echo -n "waiting psmdb-restore/${backup_name} to reach ${target_state} state"
-	until [ "$(kubectl_bin get psmdb-restore restore-$backup_name -o jsonpath='{.status.state}')" == ${target_state} ]; do
+	local current_state=
+	until [[ ${current_state} == ${target_state} ]]; do
 		sleep 1
 		echo -n .
 		let retry+=1
-		if [ $retry -ge 720 ]; then
+		current_state=$(kubectl_bin get psmdb-restore restore-$backup_name -o jsonpath='{.status.state}')
+		if [[ $retry -ge 720 || ${current_state} == 'error' ]]; then
 			kubectl_bin logs ${OPERATOR_NS:+-n $OPERATOR_NS} $(get_operator_pod) \
 				| grep -v 'level=info' \
 				| grep -v 'level=debug' \
 				| grep -v 'Getting tasks for pod' \
 				| grep -v 'Getting pods from source' \
 				| tail -100
-			echo max retry count $retry reached. something went wrong with operator or kubernetes cluster
+
+			echo "Restore object restore-${backup_name} is in ${current_state} state."
+			echo something went wrong with operator or kubernetes cluster
 			exit 1
 		fi
 	done

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -217,18 +217,21 @@ wait_backup() {
 	set +o xtrace
 	retry=0
 	echo -n $backup_name
-	until [ "$(kubectl_bin get psmdb-backup $backup_name -o jsonpath='{.status.state}')" == "ready" ]; do
+	local current_status=
+	until [[ ${current_status} == "ready" ]]; do
 		sleep 1
 		echo -n .
 		let retry+=1
-		if [ $retry -ge 360 ]; then
+		current_status=$(kubectl_bin get psmdb-backup $backup_name -o jsonpath='{.status.state}')
+		if [[ $retry -ge 360 || ${current_status} == 'error' ]]; then
 			kubectl_bin logs ${OPERATOR_NS:+-n $OPERATOR_NS} $(get_operator_pod) \
 				| grep -v 'level=info' \
 				| grep -v 'level=debug' \
 				| grep -v 'Getting tasks for pod' \
 				| grep -v 'Getting pods from source' \
 				| tail -100
-			echo max retry count $retry reached. something went wrong with operator or kubernetes cluster
+			echo "Backup object psmdb-backup/${backup_name} is in ${current_state} state."
+			echo something went wrong with operator or kubernetes cluster
 			exit 1
 		fi
 	done


### PR DESCRIPTION
[![K8SPSMDB-881](https://badgen.net/badge/JIRA/K8SPSMDB-881/green)](https://jira.percona.com/browse/K8SPSMDB-881) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

we should not wait any longer if the restore error happened

**CHANGE DESCRIPTION**
---
**Problem:**
The testing framework blindly expects for OK state

**Cause:**
Human factor

**Solution:**
Additional error checking

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?