### PR TITLE
fix cross-site-sharded

### DIFF
--- a/e2e-tests/cross-site-sharded/conf/cross-site-sharded-main.yml
+++ b/e2e-tests/cross-site-sharded/conf/cross-site-sharded-main.yml
@@ -4,6 +4,7 @@ metadata:
   name: cross-site-sharded-main
 spec:
   #platform: openshift
+  clusterServiceDNSMode: External
   unmanaged: false
   image:
   imagePullPolicy: Always

--- a/e2e-tests/cross-site-sharded/conf/cross-site-sharded-replica.yml
+++ b/e2e-tests/cross-site-sharded/conf/cross-site-sharded-replica.yml
@@ -3,6 +3,7 @@ kind: PerconaServerMongoDB
 metadata:
   name: cross-site-sharded-replica
 spec:
+  clusterServiceDNSMode: External
   unmanaged: true
   image:
   imagePullPolicy: Always

--- a/e2e-tests/cross-site-sharded/disaster_recovery.js
+++ b/e2e-tests/cross-site-sharded/disaster_recovery.js
@@ -1,3 +1,16 @@
 cfg = rs.config();
-cfg.members = [cfg.members[3], cfg.members[4], cfg.members[5]];
+
+member1 = cfg.members[3];
+member1.priority = 2
+member1.votes = 1
+
+member2 = cfg.members[4];
+member2.priority = 2
+member2.votes = 1
+
+member3 = cfg.members[5];
+member3.priority = 2
+member3.votes = 1
+
+cfg.members = [member1, member2, member3];
 rs.reconfig(cfg, {force: true});

--- a/e2e-tests/cross-site-sharded/run
+++ b/e2e-tests/cross-site-sharded/run
@@ -118,7 +118,7 @@ sleep 30
 
 desc "create replica PSMDB cluster $cluster"
 apply_cluster "$test_dir/conf/${replica_cluster}.yml"
-sleep 600
+sleep 300
 
 replica_cfg_0_endpoint=$(get_service_ip cross-site-sharded-replica-cfg-0 'cfg')
 replica_cfg_1_endpoint=$(get_service_ip cross-site-sharded-replica-cfg-1 'cfg')
@@ -167,10 +167,17 @@ desc 'test failover'
 kubectl_bin config set-context $(kubectl_bin config current-context) --namespace="$namespace"
 kubectl_bin delete psmdb $main_cluster
 sleep 60
+
+desc 'run disaster recovery script for replset: cfg'
 run_script_mongos "${test_dir}/disaster_recovery.js" "clusterAdmin:clusterAdmin123456@$replica_cfg_0_endpoint" "mongodb" ":27017"
+
+desc 'run disaster recovery script for replset: rs0'
 run_script_mongos "${test_dir}/disaster_recovery.js" "clusterAdmin:clusterAdmin123456@$replica_rs0_0_endpoint" "mongodb" ":27017"
+
+desc 'run disaster recovery script for replset: rs1'
 run_script_mongos "${test_dir}/disaster_recovery.js" "clusterAdmin:clusterAdmin123456@$replica_rs1_0_endpoint" "mongodb" ":27017"
 
+desc 'make replica cluster managed'
 kubectl_bin config set-context $(kubectl_bin config current-context) --namespace="$replica_namespace"
 kubectl_bin patch psmdb ${replica_cluster} --type=merge --patch '{"spec":{"unmanaged": false}}'
 sleep 120
@@ -178,6 +185,8 @@ sleep 120
 desc "check failover status"
 compare_mongos_cmd "find" "myApp:myPass@$replica_cluster-mongos.$replica_namespace"
 desc "Failover check finished successfully"
+
+wait_cluster_consistency ${replica_cluster}
 
 destroy "$namespace" "true"
 


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
cross-site-sharded sometimes fails on failover check.

**Cause:**
this test mixes exposed IPs and local FQDNs in the replset config. 

**Solution:**
* we should use `clusterServiceDNSMode: External` in main and replica clusters.
* now test output is a bit more informative.
* now test waits for replica cluster to be ready.