### PR TITLE
K8SPSMDB-907: Add MarshalJSON to PITRRestoreDate

### DIFF
--- a/pkg/apis/psmdb/v1/perconaservermongodbrestore_types.go
+++ b/pkg/apis/psmdb/v1/perconaservermongodbrestore_types.go
@@ -140,6 +140,10 @@ func (t *PITRestoreDate) UnmarshalJSON(b []byte) (err error) {
 	return nil
 }
 
+func (t *PITRestoreDate) MarshalJSON() ([]byte, error) {
+	return json.Marshal(t.Time.Format("2006-01-02 15:04:05"))
+}
+
 type PITRestoreSpec struct {
 	Type PITRestoreType  `json:"type,omitempty"`
 	Date *PITRestoreDate `json:"date,omitempty"`


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
Custom PITR date breaks dbaas-operator.

**Cause:**
We use custom date format for PITR date but we don't provide `MarshalJSON` to serialize it into json with correct format.

**Solution:**
This PR provides `MarshalJSON`.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?
- [x] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are the manifests (crd/bundle) regenerated if needed?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported MongoDB version?
- [x] Does the change support oldest and newest supported Kubernetes version?
