### PR TITLE
K8SPSMDB-807: Allow customizing replset name with custom config

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ void CreateCluster(String CLUSTER_PREFIX) {
             gcloud auth activate-service-account --key-file $CLIENT_SECRET_FILE
             gcloud config set project $GCP_PROJECT
             gcloud container clusters list --filter $CLUSTER_NAME-${CLUSTER_PREFIX} --zone $GKERegion --format='csv[no-heading](name)' | xargs gcloud container clusters delete --zone $GKERegion --quiet || true
-            gcloud container clusters create --zone $GKERegion $CLUSTER_NAME-${CLUSTER_PREFIX} --cluster-version=1.20 --machine-type=n1-standard-4 --preemptible --num-nodes=3 --network=jenkins-vpc --subnetwork=jenkins-${CLUSTER_PREFIX} --no-enable-autoupgrade
+            gcloud container clusters create --zone $GKERegion $CLUSTER_NAME-${CLUSTER_PREFIX} --cluster-version=1.23 --machine-type=n1-standard-4 --preemptible --num-nodes=3 --network=jenkins-vpc --subnetwork=jenkins-${CLUSTER_PREFIX} --no-enable-autoupgrade
             kubectl create clusterrolebinding cluster-admin-binding --clusterrole cluster-admin --user jenkins@"$GCP_PROJECT".iam.gserviceaccount.com
         """
    }

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	go.mongodb.org/mongo-driver v1.7.0
 	golang.org/x/tools v0.0.0-20201028153306-37f0764111ff // indirect
 	gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	honnef.co/go/tools v0.0.1-2020.1.5 // indirect
 	k8s.io/api v0.18.0
 	k8s.io/apimachinery v0.18.0

--- a/pkg/controller/perconaservermongodb/mgo.go
+++ b/pkg/controller/perconaservermongodb/mgo.go
@@ -362,14 +362,19 @@ func (r *ReconcilePerconaServerMongoDB) handleRsAddToShard(m *api.PerconaServerM
 // This must be ran from within the running container to utilize the MongoDB Localhost Exception.
 //
 // See: https://docs.mongodb.com/manual/core/security-users/#localhost-exception
-//
 func (r *ReconcilePerconaServerMongoDB) handleReplsetInit(m *api.PerconaServerMongoDB, replset *api.ReplsetSpec, pods []corev1.Pod) error {
 	for _, pod := range pods {
 		if !isMongodPod(pod) || !isContainerAndPodRunning(pod, "mongod") || !isPodReady(pod) {
 			continue
 		}
 
-		log.Info("initiating replset", "replset", replset.Name, "pod", pod.Name)
+		replsetName := replset.Name
+		name, err := replset.CustomReplsetName()
+		if err == nil {
+			replsetName = name
+		}
+
+		log.Info("initiating replset", "replset", replsetName, "pod", pod.Name)
 
 		host, err := psmdb.MongoHost(r.client, m, replset.Name, replset.Expose.Enabled, pod)
 		if err != nil {
@@ -391,7 +396,7 @@ func (r *ReconcilePerconaServerMongoDB) handleReplsetInit(m *api.PerconaServerMo
 					}
 				)
 				EOF
-			`, replset.Name, host),
+			`, replsetName, host),
 		}
 
 		var errb, outb bytes.Buffer
@@ -418,7 +423,7 @@ func (r *ReconcilePerconaServerMongoDB) handleReplsetInit(m *api.PerconaServerMo
 			return fmt.Errorf("exec add admin user: %v / %s / %s", err, outb.String(), errb.String())
 		}
 
-		log.Info("replset was initialized", "replset", replset.Name, "pod", pod.Name)
+		log.Info("replset was initialized", "replset", replsetName, "pod", pod.Name)
 
 		return nil
 	}

--- a/pkg/psmdb/client.go
+++ b/pkg/psmdb/client.go
@@ -29,8 +29,14 @@ func MongoClient(k8sclient client.Client, cr *api.PerconaServerMongoDB, rs api.R
 		return nil, errors.Wrap(err, "get replset addr")
 	}
 
+	rsName := rs.Name
+	name, err := rs.CustomReplsetName()
+	if err == nil {
+		rsName = name
+	}
+
 	conf := &mongo.Config{
-		ReplSetName: rs.Name,
+		ReplSetName: rsName,
 		Hosts:       rsAddrs,
 		Username:    c.Username,
 		Password:    c.Password,

--- a/pkg/psmdb/container.go
+++ b/pkg/psmdb/container.go
@@ -125,8 +125,7 @@ func container(cr *api.PerconaServerMongoDB, replset *api.ReplsetSpec, name stri
 }
 
 // containerArgs returns the args to pass to the mSpec container
-func containerArgs(m *api.PerconaServerMongoDB, replset *api.ReplsetSpec, resources corev1.ResourceRequirements,
-	useConfigFile bool) []string {
+func containerArgs(m *api.PerconaServerMongoDB, replset *api.ReplsetSpec, resources corev1.ResourceRequirements, useConfigFile bool) []string {
 	mSpec := m.Spec.Mongod
 	// TODO(andrew): in the safe mode `sslAllowInvalidCertificates` should be set only with the external services
 	args := []string{
@@ -138,6 +137,11 @@ func containerArgs(m *api.PerconaServerMongoDB, replset *api.ReplsetSpec, resour
 		"--storageEngine=" + string(replset.Storage.Engine),
 		"--relaxPermChecks",
 		"--sslAllowInvalidCertificates",
+	}
+
+	name, err := replset.CustomReplsetName()
+	if err == nil {
+		args[4] = "--replSet=" + name
 	}
 
 	if m.Spec.UnsafeConf {
@@ -303,7 +307,6 @@ func containerArgs(m *api.PerconaServerMongoDB, replset *api.ReplsetSpec, resour
 // explicitly set the WiredTiger cache size to fix this.
 //
 // https://docs.mongodb.com/manual/reference/configuration-options/#storage.wiredTiger.engineConfig.cacheSizeGB
-//
 func getWiredTigerCacheSizeGB(resourceList corev1.ResourceList, cacheRatio float64, subtract1GB bool) float64 {
 	maxMemory := resourceList[corev1.ResourceMemory]
 	var size float64

--- a/pkg/psmdb/mongos.go
+++ b/pkg/psmdb/mongos.go
@@ -214,9 +214,15 @@ func mongosContainerArgs(cr *api.PerconaServerMongoDB, resources corev1.Resource
 	msSpec := cr.Spec.Sharding.Mongos
 	cfgRs := cr.Spec.Sharding.ConfigsvrReplSet
 
+	cfgRsName := cfgRs.Name
+	name, err := cfgRs.CustomReplsetName()
+	if err == nil {
+		cfgRsName = name
+	}
+
 	// sort config instances to prevent unnecessary updates
 	sort.Strings(cfgInstances)
-	configDB := fmt.Sprintf("%s/%s", cfgRs.Name, strings.Join(cfgInstances, ","))
+	configDB := fmt.Sprintf("%s/%s", cfgRsName, strings.Join(cfgInstances, ","))
 	args := []string{
 		"mongos",
 		"--bind_ip_all",

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -398,6 +398,7 @@ gopkg.in/mgo.v2/internal/json
 gopkg.in/mgo.v2/internal/sasl
 gopkg.in/mgo.v2/internal/scram
 # gopkg.in/yaml.v2 v2.4.0
+## explicit
 gopkg.in/yaml.v2
 # gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c
 gopkg.in/yaml.v3


### PR DESCRIPTION
[![K8SPSMDB-807](https://badgen.net/badge/JIRA/K8SPSMDB-807/green)](https://jira.percona.com/browse/K8SPSMDB-807) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
Users can't change config server replset name through CR. This is especially important for migration scenarios where it's not feasible to change replset name in source cluster.

**Solution:**
To minimize the required step to change replset name, we're checking if custom config has `replSetName` under `replication` key and use it if exists.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?