### PR TITLE
K8SPSMDB-938: Allow configuring hostAliases for pods

### DIFF
--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -240,6 +240,11 @@ spec:
         resources:
           requests:
             storage: 3Gi
+#    hostAliases:
+#    - ip: "10.10.0.2"
+#      hostnames:
+#      - "host1"
+#      - "host2"
 
   sharding:
     enabled: true
@@ -339,6 +344,11 @@ spec:
           resources:
             requests:
               storage: 3Gi
+#      hostAliases:
+#      - ip: "10.10.0.2"
+#        hostnames:
+#        - "host1"
+#        - "host2"
 
     mongos:
       size: 3
@@ -407,6 +417,11 @@ spec:
 #        destination: file
 #        format: BSON
 #        filter: '{}'
+#      hostAliases:
+#      - ip: "10.10.0.2"
+#        hostnames:
+#        - "host1"
+#        - "host2"
 
   mongod:
     net:

--- a/pkg/apis/psmdb/v1/psmdb_types.go
+++ b/pkg/apis/psmdb/v1/psmdb_types.go
@@ -313,6 +313,7 @@ type ReplsetSpec struct {
 	Configuration            string                     `json:"configuration,omitempty"`
 	ExternalNodes            []*ExternalNode            `json:"externalNodes,omitempty"`
 	NonVoting                NonVotingSpec              `json:"nonvoting,omitempty"`
+	HostAliases              []corev1.HostAlias         `json:"hostAliases,omitempty"`
 
 	MultiAZ
 }
@@ -379,6 +380,7 @@ type MongosSpec struct {
 	PodSecurityContext       *corev1.PodSecurityContext `json:"podSecurityContext,omitempty"`
 	ContainerSecurityContext *corev1.SecurityContext    `json:"containerSecurityContext,omitempty"`
 	Configuration            string                     `json:"configuration,omitempty"`
+	HostAliases              []corev1.HostAlias         `json:"hostAliases,omitempty"`
 	*ResourcesSpec           `json:"resources,omitempty"`
 }
 

--- a/pkg/apis/psmdb/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/psmdb/v1/zz_generated.deepcopy.go
@@ -621,6 +621,13 @@ func (in *MongosSpec) DeepCopyInto(out *MongosSpec) {
 		*out = new(corev1.SecurityContext)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.HostAliases != nil {
+		in, out := &in.HostAliases, &out.HostAliases
+		*out = make([]corev1.HostAlias, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.ResourcesSpec != nil {
 		in, out := &in.ResourcesSpec, &out.ResourcesSpec
 		*out = new(ResourcesSpec)
@@ -1374,6 +1381,13 @@ func (in *ReplsetSpec) DeepCopyInto(out *ReplsetSpec) {
 		}
 	}
 	in.NonVoting.DeepCopyInto(&out.NonVoting)
+	if in.HostAliases != nil {
+		in, out := &in.HostAliases, &out.HostAliases
+		*out = make([]corev1.HostAlias, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	in.MultiAZ.DeepCopyInto(&out.MultiAZ)
 	return
 }

--- a/pkg/psmdb/mongos.go
+++ b/pkg/psmdb/mongos.go
@@ -81,6 +81,7 @@ func MongosDeploymentSpec(cr *api.PerconaServerMongoDB, operatorPod corev1.Pod, 
 				Annotations: annotations,
 			},
 			Spec: corev1.PodSpec{
+				HostAliases:       cr.Spec.Sharding.Mongos.HostAliases,
 				SecurityContext:   cr.Spec.Sharding.Mongos.PodSecurityContext,
 				Affinity:          PodAffinity(cr, cr.Spec.Sharding.Mongos.MultiAZ.Affinity, ls),
 				NodeSelector:      cr.Spec.Sharding.Mongos.MultiAZ.NodeSelector,

--- a/pkg/psmdb/statefulset.go
+++ b/pkg/psmdb/statefulset.go
@@ -128,6 +128,7 @@ func StatefulSpec(m *api.PerconaServerMongoDB, replset *api.ReplsetSpec, contain
 				Annotations: annotations,
 			},
 			Spec: corev1.PodSpec{
+				HostAliases:        replset.HostAliases,
 				SecurityContext:    podSecurityContext,
 				Affinity:           PodAffinity(m, multiAZ.Affinity, customLabels),
 				NodeSelector:       multiAZ.NodeSelector,


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
No way to configure hostAliases.

**Solution:**
Add new field to CR and pass them statefulsets and deployments.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
