### PR TITLE
Fail TLS configuration if provided certificates do not exist

### DIFF
--- a/healthcheck/tools/db/ssl_test.go
+++ b/healthcheck/tools/db/ssl_test.go
@@ -1,0 +1,86 @@
+package db
+
+import (
+	"fmt"
+	"testing"
+)
+
+const (
+	notExistingFilePath = "not-existing-file-path"
+)
+
+func TestSSLNotEnabled(t *testing.T) {
+	cfg := &Config{
+		SSL: &SSLConfig{
+			Enabled: false,
+		},
+	}
+
+	if err := cfg.configureTLS(); err != nil {
+		t.Fatalf("TLS configuration failed: %s", err)
+	}
+
+	if cfg.TLSConf != nil {
+		t.Error("Expected TLSConf to be nil")
+	}
+}
+
+func TestSSLEnabled(t *testing.T) {
+	cfg := &Config{
+		SSL: &SSLConfig{
+			Enabled: true,
+		},
+	}
+
+	if err := cfg.configureTLS(); err != nil {
+		t.Fatalf("TLS configuration failed: %s", err)
+	}
+
+	if cfg.TLSConf == nil {
+		t.Error("Expected TLSConf to not be nil")
+	}
+}
+
+func TestPEMKeyFileDoesNotExists(t *testing.T) {
+	cfg := &Config{
+		SSL: &SSLConfig{
+			Enabled:    true,
+			PEMKeyFile: notExistingFilePath,
+		},
+	}
+
+	err := cfg.configureTLS()
+	if err == nil {
+		t.Fatal("Expected TLS config to fail, but it returned no error")
+	}
+
+	expectedErrorMessage := fmt.Sprintf(
+		"check if file with name %s exists: stat %s: no such file or directory",
+		notExistingFilePath, notExistingFilePath,
+	)
+	if err.Error() != expectedErrorMessage {
+		t.Errorf("error message '%s' does not match expected '%s'", err.Error(), expectedErrorMessage)
+	}
+}
+
+func TestCAFileDoesNotExists(t *testing.T) {
+	cfg := &Config{
+		SSL: &SSLConfig{
+			Enabled: true,
+			CAFile:  notExistingFilePath,
+		},
+	}
+
+	err := cfg.configureTLS()
+	if err == nil {
+		t.Fatal("Expected TLS config to fail, but it returned no error")
+	}
+
+	expectedErrorMessage := fmt.Sprintf(
+		"check if file with name %s exists: stat %s: no such file or directory",
+		notExistingFilePath, notExistingFilePath,
+	)
+	if err.Error() != expectedErrorMessage {
+		t.Errorf("error message '%s' does not match expected '%s'", err.Error(), expectedErrorMessage)
+	}
+}


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
*Short explanation of the problem.*

Healthcheck runs without TLS appropriately configured (when it is enabled).

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

Invalid TLS configuration is silently dropped.

**Solution:**
*Short explanation of the solution we are providing with this PR.*

Fail the healthcheck when TLS configuration is provided, but is invalid.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
