### PR TITLE
CLOUD-789 - adding password leak check in demand-backup, init-deploy, monitoring-2-0

### DIFF
--- a/e2e-tests/demand-backup-sharded/run
+++ b/e2e-tests/demand-backup-sharded/run
@@ -176,5 +176,8 @@ if [ -z "$SKIP_BACKUPS_TO_AWS_GCP_AZURE" ]; then
 	check_backup_deletion "https://engk8soperators.blob.core.windows.net/operator-testing/${backup_dest_azure}" "azure-blob"
 fi
 
+desc 'check for passwords leak'
+check_passwords_leak
+
 kubectl_bin delete -f "$conf_dir/container-rc.yaml"
 destroy "$namespace"

--- a/e2e-tests/demand-backup/run
+++ b/e2e-tests/demand-backup/run
@@ -180,6 +180,9 @@ if [ -z "$SKIP_BACKUPS_TO_AWS_GCP_AZURE" ]; then
 	check_backup_deletion "https://engk8soperators.blob.core.windows.net/operator-testing/${backup_dest_azure}" "azure-blob"
 fi
 
+desc 'check for passwords leak'
+check_passwords_leak
+
 destroy $namespace
 
 desc 'test passed'

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -1236,7 +1236,7 @@ check_passwords_leak() {
 			containers=$(kubectl_bin -n "$NS" get pod $p -o jsonpath='{.spec.containers[*].name}')
 			for c in $containers; do
 				# temporary, because of: https://jira.percona.com/browse/PMM-8357
-				if [[ ${c,,} =~ "pmm" ]]; then
+				if [[ ${c} =~ "pmm" ]]; then
 					continue
 				fi
 				kubectl_bin -n "$NS" logs $p -c $c > ${TEMP_DIR}/logs_output-$p-$c.txt

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -1217,3 +1217,45 @@ function get_mongod_ver_from_image() {
 	fi
 	echo ${version_info}
 }
+
+check_passwords_leak() {
+	secrets=$(kubectl_bin get secrets -o json | jq -r '.items[].data | to_entries | .[] | select(.key | (contains("_PASSWORD"))) | .value')
+	echo secrets=$secrets
+
+	passwords="$(for i in $secrets; do base64 -d <<< $i; echo; done) $secrets"
+	echo passwords=$passwords
+
+	pods=$(kubectl_bin get pods -o name | awk -F "/" '{print $2}')
+	echo pods=$pods
+
+	TEMP_DIR=$(mktemp -d)
+
+	collect_logs() {
+		NS=$1
+		for p in $pods; do
+			containers=$(kubectl_bin -n "$NS" get pod $p -o jsonpath='{.spec.containers[*].name}')
+			for c in $containers; do
+				# temporary, because of: https://jira.percona.com/browse/PMM-8357
+				if [[ ${c,,} =~ "pmm" ]]; then
+					continue
+				fi
+				kubectl_bin -n "$NS" logs $p -c $c > ${TEMP_DIR}/logs_output-$p-$c.txt
+				echo logs saved in: ${TEMP_DIR}/logs_output-$p-$c.txt
+				for pass in $passwords; do
+					count=$(grep -c --fixed-strings -- "$pass" ${TEMP_DIR}/logs_output-$p-$c.txt || :)
+					if [[ $count != 0 ]]; then
+						echo leaked passwords are found in log ${TEMP_DIR}/logs_output-$p-$c.txt
+						false
+					fi
+				done
+			done
+			echo
+		done
+	}
+
+	collect_logs $namespace
+	if [ -n "$OPERATOR_NS" ]; then
+		pods=$(kubectl_bin -n "${OPERATOR_NS}" get pods -o name | awk -F "/" '{print $2}')
+		collect_logs $OPERATOR_NS
+	fi
+}

--- a/e2e-tests/init-deploy/run
+++ b/e2e-tests/init-deploy/run
@@ -97,6 +97,9 @@ compare_mongo_cmd "find" "myApp:myPass@$cluster2-0.$cluster2.$namespace" "-3rd"
 compare_mongo_cmd "find" "myApp:myPass@$cluster2-1.$cluster2.$namespace" "-3rd"
 compare_mongo_cmd "find" "myApp:myPass@$cluster2-2.$cluster2.$namespace" "-3rd"
 
+desc 'check for passwords leak'
+check_passwords_leak
+
 desc 'delete custom RuntimeClass'
 kubectl_bin delete -f "$conf_dir/container-rc.yaml"
 destroy $namespace

--- a/e2e-tests/monitoring-2-0/run
+++ b/e2e-tests/monitoring-2-0/run
@@ -91,6 +91,9 @@ if [[ -n ${OPENSHIFT} ]]; then
 	oc adm policy remove-scc-from-user privileged -z percona-server-mongodb-operator
 fi
 
+desc 'check for passwords leak'
+check_passwords_leak
+
 helm uninstall monitoring
 destroy $namespace
 


### PR DESCRIPTION
[![CLOUD-789](https://badgen.net/badge/JIRA/CLOUD-789/green)](https://jira.percona.com/browse/CLOUD-789) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Create a test to start the cluster with some fixed passwords and then let the script loop over pods/containers and check the logs for the strings.