### PR TITLE
K8SPSMDB-962: fix memory leak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,7 @@ percona-server-mongodb-operator
 mongodb-healthcheck
 
 !cmd/percona-server-mongodb-operator
+!cmd/mongodb-healthcheck
 
 # End of https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
 

--- a/healthcheck/health.go
+++ b/healthcheck/health.go
@@ -22,7 +22,6 @@ import (
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
-	mgo "go.mongodb.org/mongo-driver/mongo"
 )
 
 // OkMemberStates is a slice of acceptable replication member states
@@ -57,8 +56,8 @@ func isStateOk(memberState *mongo.MemberState, okMemberStates []mongo.MemberStat
 }
 
 // HealthCheck checks the replication member state of the local MongoDB member
-func HealthCheck(client *mgo.Client, okMemberStates []mongo.MemberState) (State, *mongo.MemberState, error) {
-	rsStatus, err := mongo.RSStatus(context.TODO(), client)
+func HealthCheck(client mongo.Client, okMemberStates []mongo.MemberState) (State, *mongo.MemberState, error) {
+	rsStatus, err := client.RSStatus(context.TODO())
 	if err != nil {
 		return StateFailed, nil, errors.Wrap(err, "get replica set status")
 	}
@@ -74,8 +73,8 @@ func HealthCheck(client *mgo.Client, okMemberStates []mongo.MemberState) (State,
 	return StateFailed, state, errors.Errorf("member has unhealthy replication state: %d", state)
 }
 
-func HealthCheckMongosLiveness(client *mgo.Client) error {
-	isMasterResp, err := mongo.IsMaster(context.TODO(), client)
+func HealthCheckMongosLiveness(client mongo.Client) error {
+	isMasterResp, err := client.IsMaster(context.TODO())
 	if err != nil {
 		return errors.Wrap(err, "get isMaster response")
 	}
@@ -87,13 +86,13 @@ func HealthCheckMongosLiveness(client *mgo.Client) error {
 	return nil
 }
 
-func HealthCheckMongodLiveness(client *mgo.Client, startupDelaySeconds int64) (*mongo.MemberState, error) {
-	isMasterResp, err := mongo.IsMaster(context.TODO(), client)
+func HealthCheckMongodLiveness(client mongo.Client, startupDelaySeconds int64) (*mongo.MemberState, error) {
+	isMasterResp, err := client.IsMaster(context.TODO())
 	if err != nil {
 		return nil, errors.Wrap(err, "get isMaster response")
 	}
 
-	buildInfo, err := mongo.RSBuildInfo(context.TODO(), client)
+	buildInfo, err := client.RSBuildInfo(context.TODO())
 	if err != nil {
 		return nil, errors.Wrap(err, "get buildInfo response")
 	}

--- a/healthcheck/readiness.go
+++ b/healthcheck/readiness.go
@@ -19,22 +19,23 @@ import (
 
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/readpref"
+
+	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb/mongo"
 )
 
 // ReadinessCheck runs a ping on a pmgo.SessionManager to check server readiness
-func ReadinessCheck(client *mongo.Client) (State, error) {
-	if err := client.Ping(context.TODO(), readpref.Primary()); err != nil {
+func ReadinessCheck(ctx context.Context, client mongo.Client) (State, error) {
+	if err := client.Ping(ctx, readpref.Primary()); err != nil {
 		return StateFailed, errors.Wrap(err, "ping")
 	}
 
 	return StateOk, nil
 }
 
-func MongosReadinessCheck(client *mongo.Client) error {
+func MongosReadinessCheck(ctx context.Context, client mongo.Client) error {
 	ss := ServerStatus{}
-	cur := client.Database("admin").RunCommand(context.TODO(), bson.D{
+	cur := client.Database("admin").RunCommand(ctx, bson.D{
 		{Key: "listDatabases", Value: 1},
 		{Key: "filter", Value: bson.D{{Key: "name", Value: "admin"}}},
 		{Key: "nameOnly", Value: true}})

--- a/pkg/controller/perconaservermongodb/backup.go
+++ b/pkg/controller/perconaservermongodb/backup.go
@@ -357,7 +357,7 @@ func (r *ReconcilePerconaServerMongoDB) updatePITR(ctx context.Context, cr *api.
 		}
 	}
 
-	val, err := pbm.C.GetConfigVar("pitr.enabled")
+	val, err := pbm.GetConfigVar("pitr.enabled")
 	if err != nil {
 		if !errors.Is(err, mongo.ErrNoDocuments) {
 			return errors.Wrap(err, "get pitr.enabled")
@@ -374,7 +374,7 @@ func (r *ReconcilePerconaServerMongoDB) updatePITR(ctx context.Context, cr *api.
 	if enabled != cr.Spec.Backup.PITR.Enabled {
 		val := strconv.FormatBool(cr.Spec.Backup.PITR.Enabled)
 		log.Info("Setting pitr.enabled in PBM config", "enabled", val)
-		if err := pbm.C.SetConfigVar("pitr.enabled", val); err != nil {
+		if err := pbm.SetConfigVar("pitr.enabled", val); err != nil {
 			return errors.Wrap(err, "update pitr.enabled")
 		}
 	}
@@ -383,7 +383,7 @@ func (r *ReconcilePerconaServerMongoDB) updatePITR(ctx context.Context, cr *api.
 		return nil
 	}
 
-	val, err = pbm.C.GetConfigVar("pitr.oplogSpanMin")
+	val, err = pbm.GetConfigVar("pitr.oplogSpanMin")
 	if err != nil {
 		if !errors.Is(err, mongo.ErrNoDocuments) {
 			return errors.Wrap(err, "get pitr.oplogSpanMin")
@@ -399,12 +399,12 @@ func (r *ReconcilePerconaServerMongoDB) updatePITR(ctx context.Context, cr *api.
 
 	if oplogSpanMin != cr.Spec.Backup.PITR.OplogSpanMin.Float64() {
 		val := cr.Spec.Backup.PITR.OplogSpanMin.String()
-		if err := pbm.C.SetConfigVar("pitr.oplogSpanMin", val); err != nil {
+		if err := pbm.SetConfigVar("pitr.oplogSpanMin", val); err != nil {
 			return errors.Wrap(err, "update pitr.oplogSpanMin")
 		}
 	}
 
-	val, err = pbm.C.GetConfigVar("pitr.compression")
+	val, err = pbm.GetConfigVar("pitr.compression")
 	var compression = ""
 	if err != nil {
 		if errors.Is(err, mongo.ErrNoDocuments) {
@@ -421,23 +421,23 @@ func (r *ReconcilePerconaServerMongoDB) updatePITR(ctx context.Context, cr *api.
 
 	if compression != string(cr.Spec.Backup.PITR.CompressionType) {
 		if string(cr.Spec.Backup.PITR.CompressionType) == "" {
-			if err := pbm.C.DeleteConfigVar("pitr.compression"); err != nil {
+			if err := pbm.DeleteConfigVar("pitr.compression"); err != nil {
 				return errors.Wrap(err, "delete pitr.compression")
 			}
-		} else if err := pbm.C.SetConfigVar("pitr.compression", string(cr.Spec.Backup.PITR.CompressionType)); err != nil {
+		} else if err := pbm.SetConfigVar("pitr.compression", string(cr.Spec.Backup.PITR.CompressionType)); err != nil {
 			return errors.Wrap(err, "update pitr.compression")
 		}
 
 		// PBM needs to disabling and enabling PITR to change compression type
-		if err := pbm.C.SetConfigVar("pitr.enabled", "false"); err != nil {
+		if err := pbm.SetConfigVar("pitr.enabled", "false"); err != nil {
 			return errors.Wrap(err, "disable pitr")
 		}
-		if err := pbm.C.SetConfigVar("pitr.enabled", "true"); err != nil {
+		if err := pbm.SetConfigVar("pitr.enabled", "true"); err != nil {
 			return errors.Wrap(err, "enable pitr")
 		}
 	}
 
-	val, err = pbm.C.GetConfigVar("pitr.compressionLevel")
+	val, err = pbm.GetConfigVar("pitr.compressionLevel")
 	var compressionLevel *int = nil
 	if err != nil {
 		if errors.Is(err, mongo.ErrNoDocuments) {
@@ -455,18 +455,18 @@ func (r *ReconcilePerconaServerMongoDB) updatePITR(ctx context.Context, cr *api.
 
 	if !reflect.DeepEqual(compressionLevel, cr.Spec.Backup.PITR.CompressionLevel) {
 		if cr.Spec.Backup.PITR.CompressionLevel == nil {
-			if err := pbm.C.DeleteConfigVar("pitr.compressionLevel"); err != nil {
+			if err := pbm.DeleteConfigVar("pitr.compressionLevel"); err != nil {
 				return errors.Wrap(err, "delete pitr.compressionLevel")
 			}
-		} else if err := pbm.C.SetConfigVar("pitr.compressionLevel", strconv.FormatInt(int64(*cr.Spec.Backup.PITR.CompressionLevel), 10)); err != nil {
+		} else if err := pbm.SetConfigVar("pitr.compressionLevel", strconv.FormatInt(int64(*cr.Spec.Backup.PITR.CompressionLevel), 10)); err != nil {
 			return errors.Wrap(err, "update pitr.compressionLevel")
 		}
 
 		// PBM needs to disabling and enabling PITR to change compression level
-		if err := pbm.C.SetConfigVar("pitr.enabled", "false"); err != nil {
+		if err := pbm.SetConfigVar("pitr.enabled", "false"); err != nil {
 			return errors.Wrap(err, "disable pitr")
 		}
-		if err := pbm.C.SetConfigVar("pitr.enabled", "true"); err != nil {
+		if err := pbm.SetConfigVar("pitr.enabled", "true"); err != nil {
 			return errors.Wrap(err, "enable pitr")
 		}
 	}

--- a/pkg/controller/perconaservermongodb/balancer.go
+++ b/pkg/controller/perconaservermongodb/balancer.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb"
-	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb/mongo"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
@@ -87,13 +86,13 @@ func (r *ReconcilePerconaServerMongoDB) enableBalancerIfNeeded(ctx context.Conte
 		}
 	}()
 
-	run, err := mongo.IsBalancerRunning(ctx, mongosSession)
+	run, err := mongosSession.IsBalancerRunning(ctx)
 	if err != nil {
 		return errors.Wrap(err, "failed to check if balancer running")
 	}
 
 	if !run {
-		err := mongo.StartBalancer(ctx, mongosSession)
+		err := mongosSession.StartBalancer(ctx)
 		if err != nil {
 			return errors.Wrap(err, "failed to start balancer")
 		}
@@ -133,13 +132,13 @@ func (r *ReconcilePerconaServerMongoDB) disableBalancer(ctx context.Context, cr 
 		}
 	}()
 
-	run, err := mongo.IsBalancerRunning(ctx, mongosSession)
+	run, err := mongosSession.IsBalancerRunning(ctx)
 	if err != nil {
 		return errors.Wrap(err, "failed to check if balancer running")
 	}
 
 	if run {
-		err := mongo.StopBalancer(ctx, mongosSession)
+		err := mongosSession.StopBalancer(ctx)
 		if err != nil {
 			return errors.Wrap(err, "failed to stop balancer")
 		}

--- a/pkg/controller/perconaservermongodb/connections.go
+++ b/pkg/controller/perconaservermongodb/connections.go
@@ -4,37 +4,66 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
-	mgo "go.mongodb.org/mongo-driver/mongo"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
 	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb"
+	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb/mongo"
 )
 
+type MongoClientProvider interface {
+	Mongo(ctx context.Context, cr *api.PerconaServerMongoDB, rs api.ReplsetSpec, role UserRole) (mongo.Client, error)
+	Mongos(ctx context.Context, cr *api.PerconaServerMongoDB, role UserRole) (mongo.Client, error)
+	Standalone(ctx context.Context, cr *api.PerconaServerMongoDB, role UserRole, host string) (mongo.Client, error)
+}
+
+func (r *ReconcilePerconaServerMongoDB) MongoClientProvider() MongoClientProvider {
+	if r.mongoClientProvider == nil {
+		return &mongoClientProvider{r.client}
+	}
+	return r.mongoClientProvider
+}
+
+type mongoClientProvider struct {
+	k8sclient client.Client
+}
+
+func (p *mongoClientProvider) Mongo(ctx context.Context, cr *api.PerconaServerMongoDB, rs api.ReplsetSpec, role UserRole) (mongo.Client, error) {
+	c, err := getInternalCredentials(ctx, p.k8sclient, cr, role)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get credentials")
+	}
+
+	return psmdb.MongoClient(ctx, p.k8sclient, cr, rs, c)
+}
+
+func (p *mongoClientProvider) Mongos(ctx context.Context, cr *api.PerconaServerMongoDB, role UserRole) (mongo.Client, error) {
+	c, err := getInternalCredentials(ctx, p.k8sclient, cr, role)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get credentials")
+	}
+
+	return psmdb.MongosClient(ctx, p.k8sclient, cr, c)
+}
+
+func (p *mongoClientProvider) Standalone(ctx context.Context, cr *api.PerconaServerMongoDB, role UserRole, host string) (mongo.Client, error) {
+	c, err := getInternalCredentials(ctx, p.k8sclient, cr, role)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get credentials")
+	}
+
+	return psmdb.StandaloneClient(ctx, p.k8sclient, cr, c, host)
+}
+
 func (r *ReconcilePerconaServerMongoDB) mongoClientWithRole(ctx context.Context, cr *api.PerconaServerMongoDB, rs api.ReplsetSpec,
-	role UserRole) (*mgo.Client, error) {
-
-	c, err := r.getInternalCredentials(ctx, cr, role)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get credentials")
-	}
-
-	return psmdb.MongoClient(ctx, r.client, cr, rs, c)
+	role UserRole) (mongo.Client, error) {
+	return r.MongoClientProvider().Mongo(ctx, cr, rs, role)
 }
 
-func (r *ReconcilePerconaServerMongoDB) mongosClientWithRole(ctx context.Context, cr *api.PerconaServerMongoDB, role UserRole) (*mgo.Client, error) {
-	c, err := r.getInternalCredentials(ctx, cr, role)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get credentials")
-	}
-
-	return psmdb.MongosClient(ctx, r.client, cr, c)
+func (r *ReconcilePerconaServerMongoDB) mongosClientWithRole(ctx context.Context, cr *api.PerconaServerMongoDB, role UserRole) (mongo.Client, error) {
+	return r.MongoClientProvider().Mongos(ctx, cr, role)
 }
 
-func (r *ReconcilePerconaServerMongoDB) standaloneClientWithRole(ctx context.Context, cr *api.PerconaServerMongoDB, role UserRole, host string) (*mgo.Client, error) {
-	c, err := r.getInternalCredentials(ctx, cr, role)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get credentials")
-	}
-
-	return psmdb.StandaloneClient(ctx, r.client, cr, c, host)
+func (r *ReconcilePerconaServerMongoDB) standaloneClientWithRole(ctx context.Context, cr *api.PerconaServerMongoDB, role UserRole, host string) (mongo.Client, error) {
+	return r.MongoClientProvider().Standalone(ctx, cr, role, host)
 }

--- a/pkg/controller/perconaservermongodb/connections.go
+++ b/pkg/controller/perconaservermongodb/connections.go
@@ -63,7 +63,3 @@ func (r *ReconcilePerconaServerMongoDB) mongoClientWithRole(ctx context.Context,
 func (r *ReconcilePerconaServerMongoDB) mongosClientWithRole(ctx context.Context, cr *api.PerconaServerMongoDB, role UserRole) (mongo.Client, error) {
 	return r.MongoClientProvider().Mongos(ctx, cr, role)
 }
-
-func (r *ReconcilePerconaServerMongoDB) standaloneClientWithRole(ctx context.Context, cr *api.PerconaServerMongoDB, role UserRole, host string) (mongo.Client, error) {
-	return r.MongoClientProvider().Standalone(ctx, cr, role, host)
-}

--- a/pkg/controller/perconaservermongodb/connections_test.go
+++ b/pkg/controller/perconaservermongodb/connections_test.go
@@ -1,0 +1,518 @@
+package perconaservermongodb
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
+	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb"
+	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb/mongo"
+	mongoFake "github.com/percona/percona-server-mongodb-operator/pkg/psmdb/mongo/fake"
+	"github.com/percona/percona-server-mongodb-operator/version"
+)
+
+// TestConnectionLeaks aims to cover every initialization of a connection to the MongoDB database.
+// Whenever we establish a connection to the MongoDB database, the "connectionCount" variable increments,
+// and every time we call `Disconnect`, this variable decrements. If at the end of each reconciliation,
+// this variable is not 0, it indicates that we have not closed the connection somewhere.
+func TestConnectionLeaks(t *testing.T) {
+	logf.SetLogger(zap.New(zap.WriteTo(io.Discard)))
+	ctx := context.Background()
+
+	q, err := resource.ParseQuantity("1Gi")
+	if err != nil {
+		t.Fatal(err)
+	}
+	volumeSpec := &api.VolumeSpec{
+		PersistentVolumeClaim: api.PVCSpec{
+			PersistentVolumeClaimSpec: &corev1.PersistentVolumeClaimSpec{
+				Resources: corev1.ResourceRequirements{
+					Requests: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceStorage: q,
+					},
+				},
+			},
+		},
+	}
+	cr := &api.PerconaServerMongoDB{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "psmdb-mock",
+			Namespace:  "psmdb",
+			Generation: 1,
+		},
+		Spec: api.PerconaServerMongoDBSpec{
+			Backup: api.BackupSpec{
+				Enabled: false,
+			},
+			CRVersion: version.Version,
+			Image:     "percona/percona-server-mongodb:latest",
+			Replsets: []*api.ReplsetSpec{
+				{
+					Name:       "rs0",
+					Size:       3,
+					VolumeSpec: volumeSpec,
+				},
+			},
+			UpdateStrategy: api.SmartUpdateStatefulSetStrategyType,
+			UpgradeOptions: api.UpgradeOptions{
+				SetFCV: true,
+			},
+			Sharding: api.Sharding{Enabled: false},
+		},
+		Status: api.PerconaServerMongoDBStatus{
+			MongoVersion:       "4.2",
+			ObservedGeneration: 1,
+			State:              api.AppStateReady,
+			MongoImage:         "percona/percona-server-mongodb:4.0",
+		},
+	}
+
+	tests := []struct {
+		name string
+		cr   *api.PerconaServerMongoDB
+	}{
+		{
+			name: "not sharded",
+			cr:   cr.DeepCopy(),
+		},
+		{
+			name: "not sharded unmanaged",
+			cr: updateResource(cr.DeepCopy(), func(cr *api.PerconaServerMongoDB) {
+				cr.Spec.Unmanaged = true
+				cr.Spec.UpdateStrategy = appsv1.RollingUpdateStatefulSetStrategyType
+			}),
+		},
+		{
+			name: "sharded",
+			cr: updateResource(cr.DeepCopy(), func(cr *api.PerconaServerMongoDB) {
+				cr.Spec.Sharding.Enabled = true
+				cr.Spec.Sharding.ConfigsvrReplSet = &api.ReplsetSpec{
+					Size:       3,
+					VolumeSpec: volumeSpec,
+				}
+				cr.Spec.Sharding.Mongos = &api.MongosSpec{
+					Size: 3,
+				}
+			}),
+		},
+		{
+			name: "sharded unmanaged",
+			cr: updateResource(cr.DeepCopy(), func(cr *api.PerconaServerMongoDB) {
+				cr.Spec.Unmanaged = true
+				cr.Spec.UpdateStrategy = appsv1.RollingUpdateStatefulSetStrategyType
+				cr.Spec.Sharding.Enabled = true
+				cr.Spec.Sharding.ConfigsvrReplSet = &api.ReplsetSpec{
+					Size:       3,
+					VolumeSpec: volumeSpec,
+				}
+				cr.Spec.Sharding.Mongos = &api.MongosSpec{
+					Size: 3,
+				}
+			}),
+		},
+	}
+	for _, tt := range tests {
+		cr := tt.cr
+		t.Run(tt.name, func(t *testing.T) {
+			updatedRevision := "some-revision"
+
+			obj := []client.Object{}
+			obj = append(obj, cr,
+				fakeStatefulset(cr, cr.Spec.Replsets[0].Name, cr.Spec.Replsets[0].Size, updatedRevision),
+				fakeStatefulset(cr, "deleted-sts", 0, ""),
+			)
+
+			rsPods := fakePodsForRS(cr, cr.Spec.Replsets[0])
+			allPods := append([]client.Object{}, rsPods...)
+
+			if cr.Spec.Sharding.Enabled {
+				sts := psmdb.MongosStatefulset(cr)
+				sts.Spec = psmdb.MongosStatefulsetSpec(cr, corev1.PodTemplateSpec{})
+				obj = append(obj, sts)
+
+				allPods = append(allPods, fakePodsForMongos(cr)...)
+
+				cr := cr.DeepCopy()
+				if err := cr.CheckNSetDefaults(version.PlatformKubernetes, logf.FromContext(ctx)); err != nil {
+					t.Fatal(err)
+				}
+				obj = append(obj, fakeStatefulset(cr, cr.Spec.Sharding.ConfigsvrReplSet.Name, cr.Spec.Sharding.ConfigsvrReplSet.Size, updatedRevision))
+				allPods = append(allPods, fakePodsForRS(cr, cr.Spec.Sharding.ConfigsvrReplSet)...)
+			}
+
+			obj = append(obj, allPods...)
+
+			if cr.Spec.Unmanaged {
+				cr := cr.DeepCopy()
+				if err := cr.CheckNSetDefaults(version.PlatformKubernetes, logf.FromContext(ctx)); err != nil {
+					t.Fatal(err)
+				}
+				obj = append(obj, &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      cr.Spec.Secrets.Users,
+						Namespace: cr.Namespace,
+					},
+				})
+			}
+
+			connectionCount := new(int)
+
+			r := buildFakeClient(obj...)
+			r.mongoClientProvider = &fakeMongoClientProvider{pods: rsPods, cr: cr, connectionCount: connectionCount}
+			r.serverVersion = &version.ServerVersion{Platform: version.PlatformKubernetes}
+
+			g, gCtx := errgroup.WithContext(ctx)
+			gCtx, cancel := context.WithCancel(gCtx)
+			g.Go(func() error {
+				return updatePodsForSmartUpdate(gCtx, r.client, cr, allPods, updatedRevision)
+			})
+			g.Go(func() error {
+				defer cancel()
+				_, err := r.Reconcile(gCtx, reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Namespace: cr.Namespace,
+						Name:      cr.Name,
+					},
+				})
+				if *connectionCount != 0 {
+					return errors.Errorf("open connections: %d", *connectionCount)
+				}
+				if err != nil {
+					return err
+				}
+				// smart update sets status to initializing
+				// we need second reconcile to update status to ready
+				_, err = r.Reconcile(gCtx, reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Namespace: cr.Namespace,
+						Name:      cr.Name,
+					},
+				})
+				if *connectionCount != 0 {
+					return errors.Errorf("open connections: %d", *connectionCount)
+				}
+				if err != nil {
+					return err
+				}
+
+				if err := updateUsersSecret(ctx, r.client, cr); err != nil {
+					return err
+				}
+
+				// and third reconcile to have cr with ready status from the start
+				_, err = r.Reconcile(gCtx, reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Namespace: cr.Namespace,
+						Name:      cr.Name,
+					},
+				})
+				if *connectionCount != 0 {
+					return errors.Errorf("open connections: %d", *connectionCount)
+				}
+				return err
+			},
+			)
+			if err := g.Wait(); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+
+}
+
+func updateResource[T any](resource T, update func(T)) T {
+	update(resource)
+	return resource
+}
+
+func updateUsersSecret(ctx context.Context, cl client.Client, cr *api.PerconaServerMongoDB) error {
+	cr = cr.DeepCopy()
+	if err := cr.CheckNSetDefaults(version.PlatformKubernetes, logf.FromContext(ctx)); err != nil {
+		return err
+	}
+	secret := corev1.Secret{}
+	err := cl.Get(ctx,
+		types.NamespacedName{
+			Namespace: cr.Namespace,
+			Name:      cr.Spec.Secrets.Users,
+		},
+		&secret,
+	)
+	if err != nil {
+		return err
+	}
+	if secret.Data == nil {
+		secret.Data = make(map[string][]byte)
+	}
+	secret.Data["MONGODB_CLUSTER_ADMIN_PASSWORD"] = []byte("new-password")
+	return cl.Update(ctx, &secret)
+}
+
+func updatePodsForSmartUpdate(ctx context.Context, cl client.Client, cr *api.PerconaServerMongoDB, pods []client.Object, updatedRevision string) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+		time.Sleep(time.Second)
+
+		podList := corev1.PodList{}
+		err := cl.List(ctx,
+			&podList,
+			&client.ListOptions{
+				Namespace: cr.Namespace,
+			},
+		)
+		if err != nil {
+			return err
+		}
+		if len(podList.Items) < len(pods) {
+			podNames := make(map[string]struct{}, len(pods))
+			for _, pod := range podList.Items {
+				podNames[pod.GetName()] = struct{}{}
+			}
+			for _, pod := range pods {
+				if _, ok := podNames[pod.GetName()]; !ok {
+					pod := pod.DeepCopyObject().(*corev1.Pod)
+					pod.Labels["controller-revision-hash"] = updatedRevision
+					pod.ResourceVersion = ""
+					if err := cl.Create(ctx, pod); err != nil {
+						return err
+					}
+				}
+			}
+		}
+	}
+}
+
+func fakePodsForRS(cr *api.PerconaServerMongoDB, rs *api.ReplsetSpec) []client.Object {
+	pods := []client.Object{}
+	ls := psmdb.RSLabels(cr, rs.Name)
+
+	ls["app.kubernetes.io/component"] = "mongod"
+	if rs.Name == api.ConfigReplSetName {
+		ls["app.kubernetes.io/component"] = api.ConfigReplSetName
+	}
+	for i := 0; i < int(rs.Size); i++ {
+		pods = append(pods, fakePod(fmt.Sprintf("%s-%s-%d", cr.Name, rs.Name, i), cr.Namespace, ls, "mongod"))
+	}
+	return pods
+}
+
+func fakePodsForMongos(cr *api.PerconaServerMongoDB) []client.Object {
+	pods := []client.Object{}
+	ls := psmdb.MongosLabels(cr)
+	ms := cr.Spec.Sharding.Mongos
+	for i := 0; i < int(ms.Size); i++ {
+		pods = append(pods, fakePod(fmt.Sprintf("%s-%s-%d", cr.Name, "mongos", i), cr.Namespace, ls, "mongos"))
+	}
+	return pods
+}
+
+func fakePod(name, namespace string, ls map[string]string, containerName string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    ls,
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:  containerName,
+					Ready: true,
+					State: corev1.ContainerState{
+						Running: &corev1.ContainerStateRunning{
+							StartedAt: metav1.Now(),
+						},
+					},
+				},
+			},
+			Conditions: []corev1.PodCondition{
+				{
+					Type:   corev1.ContainersReady,
+					Status: corev1.ConditionTrue,
+				},
+				{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionTrue,
+				},
+			},
+		},
+	}
+}
+
+func fakeStatefulset(cr *api.PerconaServerMongoDB, rsName string, size int32, updateRevision string) client.Object {
+	return &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-%s", cr.Name, rsName),
+			Namespace: cr.Namespace,
+			Labels:    psmdb.RSLabels(cr, rsName),
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &size,
+		},
+		Status: appsv1.StatefulSetStatus{
+			UpdateRevision: updateRevision,
+		},
+	}
+}
+
+type fakeMongoClientProvider struct {
+	pods            []client.Object
+	cr              *api.PerconaServerMongoDB
+	connectionCount *int
+}
+
+func (g *fakeMongoClientProvider) Mongo(ctx context.Context, cr *api.PerconaServerMongoDB, rs api.ReplsetSpec, role UserRole) (mongo.Client, error) {
+	*g.connectionCount++
+
+	fakeClient := mongoFake.NewClient()
+	return &fakeMongoClient{pods: g.pods, cr: g.cr, connectionCount: g.connectionCount, Client: fakeClient}, nil
+}
+func (g *fakeMongoClientProvider) Mongos(ctx context.Context, cr *api.PerconaServerMongoDB, role UserRole) (mongo.Client, error) {
+	*g.connectionCount++
+
+	fakeClient := mongoFake.NewClient()
+	return &fakeMongoClient{pods: g.pods, cr: g.cr, connectionCount: g.connectionCount, Client: fakeClient}, nil
+}
+func (g *fakeMongoClientProvider) Standalone(ctx context.Context, cr *api.PerconaServerMongoDB, role UserRole, host string) (mongo.Client, error) {
+	*g.connectionCount++
+
+	fakeClient := mongoFake.NewClient()
+	return &fakeMongoClient{pods: g.pods, cr: g.cr, connectionCount: g.connectionCount, Client: fakeClient}, nil
+}
+
+type fakeMongoClient struct {
+	pods            []client.Object
+	cr              *api.PerconaServerMongoDB
+	connectionCount *int
+	mongo.Client
+}
+
+func (c *fakeMongoClient) Disconnect(ctx context.Context) error {
+	*c.connectionCount--
+	return nil
+}
+
+func (c *fakeMongoClient) GetFCV(ctx context.Context) (string, error) {
+	return "4.0", nil
+}
+
+func (c *fakeMongoClient) GetRole(ctx context.Context, role string) (*mongo.Role, error) {
+	return &mongo.Role{
+		Role: string(roleClusterAdmin),
+	}, nil
+}
+
+func (c *fakeMongoClient) GetUserInfo(ctx context.Context, username string) (*mongo.User, error) {
+	return &mongo.User{
+		Roles: []map[string]interface{}{},
+	}, nil
+}
+
+func (c *fakeMongoClient) RSBuildInfo(ctx context.Context) (mongo.BuildInfo, error) {
+	return mongo.BuildInfo{
+		Version: "4.2",
+		OKResponse: mongo.OKResponse{
+			OK: 1,
+		},
+	}, nil
+}
+
+func (c *fakeMongoClient) RSStatus(ctx context.Context) (mongo.Status, error) {
+	log := logf.FromContext(ctx)
+	cr := c.cr.DeepCopy()
+	if err := cr.CheckNSetDefaults(version.PlatformKubernetes, log); err != nil {
+		return mongo.Status{}, err
+	}
+	members := []*mongo.Member{}
+	for key, pod := range c.pods {
+		host := psmdb.GetAddr(cr, pod.GetName(), cr.Spec.Replsets[0].Name)
+		state := mongo.MemberStateSecondary
+		if key == 0 {
+			state = mongo.MemberStatePrimary
+		}
+		member := mongo.Member{
+			Id:    key,
+			Name:  host,
+			State: state,
+		}
+		members = append(members, &member)
+	}
+	return mongo.Status{
+		Members: members,
+		OKResponse: mongo.OKResponse{
+			OK: 1,
+		},
+	}, nil
+}
+
+func (c *fakeMongoClient) ReadConfig(ctx context.Context) (mongo.RSConfig, error) {
+	log := logf.FromContext(ctx)
+	cr := c.cr.DeepCopy()
+	if err := cr.CheckNSetDefaults(version.PlatformKubernetes, log); err != nil {
+		return mongo.RSConfig{}, err
+	}
+	members := []mongo.ConfigMember{}
+	for key, pod := range c.pods {
+		host := psmdb.GetAddr(cr, pod.GetName(), cr.Spec.Replsets[0].Name)
+
+		member := mongo.ConfigMember{
+			ID:           key,
+			Host:         host,
+			BuildIndexes: true,
+			Priority:     mongo.DefaultPriority,
+			Votes:        mongo.DefaultVotes,
+		}
+
+		member.Tags = mongo.ReplsetTags{
+			"podName":     pod.GetName(),
+			"serviceName": cr.Name,
+		}
+
+		members = append(members, member)
+	}
+	return mongo.RSConfig{
+		Members: members,
+	}, nil
+}
+
+func (c *fakeMongoClient) RemoveShard(ctx context.Context, shard string) (mongo.ShardRemoveResp, error) {
+	return mongo.ShardRemoveResp{
+		State: mongo.ShardRemoveCompleted,
+		OKResponse: mongo.OKResponse{
+			OK: 1,
+		},
+	}, nil
+
+}
+
+func (c *fakeMongoClient) IsBalancerRunning(ctx context.Context) (bool, error) {
+	return true, nil
+}
+
+func (c *fakeMongoClient) ListShard(ctx context.Context) (mongo.ShardList, error) {
+	return mongo.ShardList{
+		OKResponse: mongo.OKResponse{
+			OK: 1,
+		},
+	}, nil
+}

--- a/pkg/controller/perconaservermongodb/fcv.go
+++ b/pkg/controller/perconaservermongodb/fcv.go
@@ -5,7 +5,6 @@ import (
 
 	v "github.com/hashicorp/go-version"
 	"github.com/pkg/errors"
-	mgo "go.mongodb.org/mongo-driver/mongo"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
@@ -24,7 +23,7 @@ func (r *ReconcilePerconaServerMongoDB) getFCV(ctx context.Context, cr *api.Perc
 		}
 	}()
 
-	return mongo.GetFCV(ctx, c)
+	return c.GetFCV(ctx)
 }
 
 func (r *ReconcilePerconaServerMongoDB) setFCV(ctx context.Context, cr *api.PerconaServerMongoDB, version string) error {
@@ -37,7 +36,7 @@ func (r *ReconcilePerconaServerMongoDB) setFCV(ctx context.Context, cr *api.Perc
 		return errors.Wrap(err, "failed to get go semver")
 	}
 
-	var cli *mgo.Client
+	var cli mongo.Client
 	var connErr error
 
 	if cr.Spec.Sharding.Enabled {
@@ -56,5 +55,5 @@ func (r *ReconcilePerconaServerMongoDB) setFCV(ctx context.Context, cr *api.Perc
 		}
 	}()
 
-	return mongo.SetFCV(ctx, cli, MajorMinor(v))
+	return cli.SetFCV(ctx, MajorMinor(v))
 }

--- a/pkg/controller/perconaservermongodb/mgo.go
+++ b/pkg/controller/perconaservermongodb/mgo.go
@@ -770,42 +770,6 @@ func (r *ReconcilePerconaServerMongoDB) createOrUpdateSystemUsers(ctx context.Co
 	return nil
 }
 
-func (r *ReconcilePerconaServerMongoDB) recoverReplsetNoPrimary(ctx context.Context, cr *api.PerconaServerMongoDB, replset *api.ReplsetSpec, pod corev1.Pod) error {
-	host, err := psmdb.MongoHost(ctx, r.client, cr, replset.Name, replset.Expose.Enabled, pod)
-	if err != nil {
-		return errors.Wrapf(err, "get mongo hostname for pod/%s", pod.Name)
-	}
-
-	cli, err := r.standaloneClientWithRole(ctx, cr, roleClusterAdmin, host)
-	if err != nil {
-		return errors.Wrap(err, "get standalone client")
-	}
-
-	cnf, err := cli.ReadConfig(ctx)
-	if err != nil {
-		return errors.Wrap(err, "get mongo config")
-	}
-
-	for i := 0; i < len(cnf.Members); i++ {
-		tags := []mongo.ConfigMember(cnf.Members)[i].Tags
-		podName, ok := tags["podName"]
-		if !ok {
-			continue
-		}
-
-		[]mongo.ConfigMember(cnf.Members)[i].Host = replset.PodFQDNWithPort(cr, podName)
-	}
-
-	cnf.Version++
-	logf.FromContext(ctx).Info("Writing replicaset config", "config", cnf)
-
-	if err := cli.WriteConfig(ctx, cnf); err != nil {
-		return errors.Wrap(err, "write mongo config")
-	}
-
-	return nil
-}
-
 func (r *ReconcilePerconaServerMongoDB) restoreInProgress(ctx context.Context, cr *api.PerconaServerMongoDB, replset *api.ReplsetSpec) (bool, error) {
 	sts := appsv1.StatefulSet{}
 	stsName := cr.Name + "-" + replset.Name

--- a/pkg/controller/perconaservermongodb/mgo.go
+++ b/pkg/controller/perconaservermongodb/mgo.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	mgo "go.mongodb.org/mongo-driver/mongo"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -124,7 +123,7 @@ func (r *ReconcilePerconaServerMongoDB) reconcileCluster(ctx context.Context, cr
 	}()
 
 	if cr.Spec.Unmanaged {
-		status, err := mongo.RSStatus(ctx, cli)
+		status, err := cli.RSStatus(ctx)
 		if err != nil {
 			return api.AppStateError, errors.Wrap(err, "failed to get rs status")
 		}
@@ -180,7 +179,7 @@ func (r *ReconcilePerconaServerMongoDB) reconcileCluster(ctx context.Context, cr
 			}
 		}()
 
-		err = mongo.SetDefaultRWConcern(ctx, mongosSession, mongo.DefaultReadConcern, mongo.DefaultWriteConcern)
+		err = mongosSession.SetDefaultRWConcern(ctx, mongo.DefaultReadConcern, mongo.DefaultWriteConcern)
 		// SetDefaultRWConcern introduced in MongoDB 4.4
 		if err != nil && !strings.Contains(err.Error(), "CommandNotFound") {
 			return api.AppStateError, errors.Wrap(err, "set default RW concern")
@@ -193,7 +192,6 @@ func (r *ReconcilePerconaServerMongoDB) reconcileCluster(ctx context.Context, cr
 
 		if !in {
 			log.Info("adding rs to shard", "rs", replset.Name)
-
 			err := r.handleRsAddToShard(ctx, cr, replset, pods.Items[0], mongosPods[0])
 			if err != nil {
 				return api.AppStateError, errors.Wrap(err, "add shard")
@@ -210,7 +208,7 @@ func (r *ReconcilePerconaServerMongoDB) reconcileCluster(ctx context.Context, cr
 	}
 
 	if replset.Arbiter.Enabled && !cr.Spec.Sharding.Enabled {
-		err := mongo.SetDefaultRWConcern(ctx, cli, mongo.DefaultReadConcern, mongo.DefaultWriteConcern)
+		err := cli.SetDefaultRWConcern(ctx, mongo.DefaultReadConcern, mongo.DefaultWriteConcern)
 		// SetDefaultRWConcern introduced in MongoDB 4.4
 		if err != nil && !strings.Contains(err.Error(), "CommandNotFound") {
 			return api.AppStateError, errors.Wrap(err, "set default RW concern")
@@ -229,7 +227,7 @@ func (r *ReconcilePerconaServerMongoDB) reconcileCluster(ctx context.Context, cr
 	return api.AppStateInit, nil
 }
 
-func (r *ReconcilePerconaServerMongoDB) updateConfigMembers(ctx context.Context, cli *mgo.Client, cr *api.PerconaServerMongoDB, rs *api.ReplsetSpec) (int, error) {
+func (r *ReconcilePerconaServerMongoDB) updateConfigMembers(ctx context.Context, cli mongo.Client, cr *api.PerconaServerMongoDB, rs *api.ReplsetSpec) (int, error) {
 	log := logf.FromContext(ctx)
 	// Primary with a Secondary and an Arbiter (PSA)
 	unsafePSA := cr.Spec.UnsafeConf && rs.Arbiter.Enabled && rs.Arbiter.Size == 1 && !rs.NonVoting.Enabled && rs.Size == 2
@@ -239,7 +237,7 @@ func (r *ReconcilePerconaServerMongoDB) updateConfigMembers(ctx context.Context,
 		return 0, errors.Wrap(err, "get rs pods")
 	}
 
-	cnf, err := mongo.ReadConfig(ctx, cli)
+	cnf, err := cli.ReadConfig(ctx)
 	if err != nil {
 		return 0, errors.Wrap(err, "get mongo config")
 	}
@@ -315,7 +313,7 @@ func (r *ReconcilePerconaServerMongoDB) updateConfigMembers(ctx context.Context,
 
 		log.Info("Fixing member tags", "replset", rs.Name)
 
-		if err := mongo.WriteConfig(ctx, cli, cnf); err != nil {
+		if err := cli.WriteConfig(ctx, cnf); err != nil {
 			return 0, errors.Wrap(err, "fix tags: write mongo config")
 		}
 	}
@@ -325,7 +323,7 @@ func (r *ReconcilePerconaServerMongoDB) updateConfigMembers(ctx context.Context,
 
 		log.Info("Fixing member hosts", "replset", rs.Name)
 
-		err = mongo.WriteConfig(ctx, cli, cnf)
+		err = cli.WriteConfig(ctx, cnf)
 		if err != nil {
 			return 0, errors.Wrap(err, "fix hosts: write mongo config")
 		}
@@ -336,7 +334,7 @@ func (r *ReconcilePerconaServerMongoDB) updateConfigMembers(ctx context.Context,
 
 		log.Info("Removing old nodes", "replset", rs.Name)
 
-		err = mongo.WriteConfig(ctx, cli, cnf)
+		err = cli.WriteConfig(ctx, cnf)
 		if err != nil {
 			return 0, errors.Wrap(err, "delete: write mongo config")
 		}
@@ -347,7 +345,7 @@ func (r *ReconcilePerconaServerMongoDB) updateConfigMembers(ctx context.Context,
 
 		log.Info("Adding new nodes", "replset", rs.Name)
 
-		err = mongo.WriteConfig(ctx, cli, cnf)
+		err = cli.WriteConfig(ctx, cnf)
 		if err != nil {
 			return 0, errors.Wrap(err, "add new: write mongo config")
 		}
@@ -358,7 +356,7 @@ func (r *ReconcilePerconaServerMongoDB) updateConfigMembers(ctx context.Context,
 
 		log.Info("Updating external nodes", "replset", rs.Name)
 
-		err = mongo.WriteConfig(ctx, cli, cnf)
+		err = cli.WriteConfig(ctx, cnf)
 		if err != nil {
 			return 0, errors.Wrap(err, "update external nodes: write mongo config")
 		}
@@ -371,13 +369,13 @@ func (r *ReconcilePerconaServerMongoDB) updateConfigMembers(ctx context.Context,
 
 		log.Info("Configuring member votes and priorities", "replset", rs.Name)
 
-		err := mongo.WriteConfig(ctx, cli, cnf)
+		err := cli.WriteConfig(ctx, cnf)
 		if err != nil {
 			return 0, errors.Wrap(err, "set votes: write mongo config")
 		}
 	}
 
-	rsStatus, err := mongo.RSStatus(ctx, cli)
+	rsStatus, err := cli.RSStatus(ctx)
 	if err != nil {
 		return 0, errors.Wrap(err, "unable to get replset members")
 	}
@@ -413,8 +411,8 @@ func (r *ReconcilePerconaServerMongoDB) updateConfigMembers(ctx context.Context,
 	return membersLive, nil
 }
 
-func inShard(ctx context.Context, client *mgo.Client, rsName string) (bool, error) {
-	shardList, err := mongo.ListShard(ctx, client)
+func inShard(ctx context.Context, client mongo.Client, rsName string) (bool, error) {
+	shardList, err := client.ListShard(ctx)
 	if err != nil {
 		return false, errors.Wrap(err, "unable to get shard list")
 	}
@@ -459,7 +457,7 @@ func (r *ReconcilePerconaServerMongoDB) removeRSFromShard(ctx context.Context, c
 	}()
 
 	for {
-		resp, err := mongo.RemoveShard(ctx, cli, rsName)
+		resp, err := cli.RemoveShard(ctx, rsName)
 		if err != nil {
 			return errors.Wrap(err, "remove shard")
 		}
@@ -502,7 +500,7 @@ func (r *ReconcilePerconaServerMongoDB) handleRsAddToShard(ctx context.Context, 
 		}
 	}()
 
-	err = mongo.AddShard(ctx, cli, replset.Name, host)
+	err = cli.AddShard(ctx, replset.Name, host)
 	if err != nil {
 		return errors.Wrap(err, "failed to add shard")
 	}
@@ -571,7 +569,7 @@ func (r *ReconcilePerconaServerMongoDB) handleReplsetInit(ctx context.Context, c
 
 		time.Sleep(time.Second * 5)
 
-		userAdmin, err := r.getInternalCredentials(ctx, cr, roleUserAdmin)
+		userAdmin, err := getInternalCredentials(ctx, r.client, cr, roleUserAdmin)
 		if err != nil {
 			return errors.Wrap(err, "failed to get userAdmin credentials")
 		}
@@ -666,17 +664,17 @@ func comparePrivileges(x []mongo.RolePrivilege, y []mongo.RolePrivilege) bool {
 	return true
 }
 
-func (r *ReconcilePerconaServerMongoDB) createOrUpdateSystemRoles(ctx context.Context, cli *mgo.Client, role string, privileges []mongo.RolePrivilege) error {
-	roleInfo, err := mongo.GetRole(ctx, cli, role)
+func (r *ReconcilePerconaServerMongoDB) createOrUpdateSystemRoles(ctx context.Context, cli mongo.Client, role string, privileges []mongo.RolePrivilege) error {
+	roleInfo, err := cli.GetRole(ctx, role)
 	if err != nil {
 		return errors.Wrap(err, "mongo get role")
 	}
 	if roleInfo == nil {
-		err = mongo.CreateRole(ctx, cli, role, privileges, []interface{}{})
+		err = cli.CreateRole(ctx, role, privileges, []interface{}{})
 		return errors.Wrapf(err, "create role %s", role)
 	}
 	if !comparePrivileges(privileges, roleInfo.Privileges) {
-		err = mongo.UpdateRole(ctx, cli, role, privileges, []interface{}{})
+		err = cli.UpdateRole(ctx, role, privileges, []interface{}{})
 		return errors.Wrapf(err, "update role")
 	}
 	return nil
@@ -746,24 +744,24 @@ func (r *ReconcilePerconaServerMongoDB) createOrUpdateSystemUsers(ctx context.Co
 	}
 
 	for _, role := range users {
-		creds, err := r.getInternalCredentials(ctx, cr, role)
+		creds, err := getInternalCredentials(ctx, r.client, cr, role)
 		if err != nil {
 			log.Error(err, "failed to get credentials", "role", role)
 			continue
 		}
-		user, err := mongo.GetUserInfo(ctx, cli, creds.Username)
+		user, err := cli.GetUserInfo(ctx, creds.Username)
 		if err != nil {
 			return errors.Wrap(err, "get user info")
 		}
 		if user == nil {
-			err = mongo.CreateUser(ctx, cli, creds.Username, creds.Password, getRoles(cr, role)...)
+			err = cli.CreateUser(ctx, creds.Username, creds.Password, getRoles(cr, role)...)
 			if err != nil {
 				return errors.Wrapf(err, "failed to create user %s", role)
 			}
 			continue
 		}
 		if !compareRoles(user.Roles, getRoles(cr, role)) {
-			err = mongo.UpdateUserRoles(ctx, cli, creds.Username, getRoles(cr, role))
+			err = cli.UpdateUserRoles(ctx, creds.Username, getRoles(cr, role))
 			if err != nil {
 				return errors.Wrapf(err, "failed to create user %s", role)
 			}
@@ -783,7 +781,7 @@ func (r *ReconcilePerconaServerMongoDB) recoverReplsetNoPrimary(ctx context.Cont
 		return errors.Wrap(err, "get standalone client")
 	}
 
-	cnf, err := mongo.ReadConfig(ctx, cli)
+	cnf, err := cli.ReadConfig(ctx)
 	if err != nil {
 		return errors.Wrap(err, "get mongo config")
 	}
@@ -801,7 +799,7 @@ func (r *ReconcilePerconaServerMongoDB) recoverReplsetNoPrimary(ctx context.Cont
 	cnf.Version++
 	logf.FromContext(ctx).Info("Writing replicaset config", "config", cnf)
 
-	if err := mongo.WriteConfig(ctx, cli, cnf); err != nil {
+	if err := cli.WriteConfig(ctx, cnf); err != nil {
 		return errors.Wrap(err, "write mongo config")
 	}
 

--- a/pkg/controller/perconaservermongodb/secrets.go
+++ b/pkg/controller/perconaservermongodb/secrets.go
@@ -10,6 +10,7 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
 	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb"
@@ -42,19 +43,19 @@ const (
 	roleBackup         UserRole = "backup"
 )
 
-func (r *ReconcilePerconaServerMongoDB) getUserSecret(ctx context.Context, cr *api.PerconaServerMongoDB, name string) (corev1.Secret, error) {
+func getUserSecret(ctx context.Context, cl client.Reader, cr *api.PerconaServerMongoDB, name string) (corev1.Secret, error) {
 	secrets := corev1.Secret{}
-	err := r.client.Get(ctx, types.NamespacedName{Name: name, Namespace: cr.Namespace}, &secrets)
+	err := cl.Get(ctx, types.NamespacedName{Name: name, Namespace: cr.Namespace}, &secrets)
 	return secrets, errors.Wrap(err, "get user secrets")
 }
 
-func (r *ReconcilePerconaServerMongoDB) getInternalCredentials(ctx context.Context, cr *api.PerconaServerMongoDB, role UserRole) (psmdb.Credentials, error) {
-	return r.getCredentials(ctx, cr, api.UserSecretName(cr), role)
+func getInternalCredentials(ctx context.Context, cl client.Reader, cr *api.PerconaServerMongoDB, role UserRole) (psmdb.Credentials, error) {
+	return getCredentials(ctx, cl, cr, api.UserSecretName(cr), role)
 }
 
-func (r *ReconcilePerconaServerMongoDB) getCredentials(ctx context.Context, cr *api.PerconaServerMongoDB, name string, role UserRole) (psmdb.Credentials, error) {
+func getCredentials(ctx context.Context, cl client.Reader, cr *api.PerconaServerMongoDB, name string, role UserRole) (psmdb.Credentials, error) {
 	creds := psmdb.Credentials{}
-	usersSecret, err := r.getUserSecret(ctx, cr, name)
+	usersSecret, err := getUserSecret(ctx, cl, cr, name)
 	if err != nil {
 		return creds, errors.Wrap(err, "failed to get user secret")
 	}

--- a/pkg/controller/perconaservermongodb/smart.go
+++ b/pkg/controller/perconaservermongodb/smart.go
@@ -19,7 +19,6 @@ import (
 	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
 	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb"
 	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb/backup"
-	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb/mongo"
 )
 
 func (r *ReconcilePerconaServerMongoDB) smartUpdate(ctx context.Context, cr *api.PerconaServerMongoDB, sfs *appsv1.StatefulSet,
@@ -98,7 +97,7 @@ func (r *ReconcilePerconaServerMongoDB) smartUpdate(ctx context.Context, cr *api
 		return nil
 	}
 
-	hasActiveJobs, err := backup.HasActiveJobs(ctx, r.client, cr, backup.Job{}, backup.NotPITRLock)
+	hasActiveJobs, err := backup.HasActiveJobs(ctx, r.newPBM, r.client, cr, backup.Job{}, backup.NotPITRLock)
 	if err != nil {
 		return errors.Wrap(err, "failed to check active jobs")
 	}
@@ -181,7 +180,7 @@ func (r *ReconcilePerconaServerMongoDB) smartUpdate(ctx context.Context, cr *api
 	if sfs.Labels["app.kubernetes.io/component"] != "nonVoting" && len(primaryPod.Name) > 0 {
 		forceStepDown := replset.Size == 1
 		log.Info("doing step down...", "force", forceStepDown)
-		err = mongo.StepDown(ctx, client, forceStepDown)
+		err = client.StepDown(ctx, forceStepDown)
 		if err != nil {
 			return errors.Wrap(err, "failed to do step down")
 		}
@@ -229,7 +228,7 @@ func (r *ReconcilePerconaServerMongoDB) smartMongosUpdate(ctx context.Context, c
 		return nil
 	}
 
-	hasActiveJobs, err := backup.HasActiveJobs(ctx, r.client, cr, backup.Job{}, backup.NotPITRLock)
+	hasActiveJobs, err := backup.HasActiveJobs(ctx, r.newPBM, r.client, cr, backup.Job{}, backup.NotPITRLock)
 	if err != nil {
 		return errors.Wrap(err, "failed to check active jobs")
 	}

--- a/pkg/controller/perconaservermongodb/status_test.go
+++ b/pkg/controller/perconaservermongodb/status_test.go
@@ -4,24 +4,34 @@ import (
 	"context"
 	"testing"
 
-	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
-
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake" // nolint
+
+	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
+	fakeBackup "github.com/percona/percona-server-mongodb-operator/pkg/psmdb/backup/fake"
 )
 
 // creates a fake client to mock API calls with the mock objects
-func buildFakeClient(objs []runtime.Object) *ReconcilePerconaServerMongoDB {
+func buildFakeClient(objs ...client.Object) *ReconcilePerconaServerMongoDB {
 	s := scheme.Scheme
 
-	s.AddKnownTypes(api.SchemeGroupVersion, &api.PerconaServerMongoDB{})
+	s.AddKnownTypes(api.SchemeGroupVersion, new(api.PerconaServerMongoDB))
+	s.AddKnownTypes(api.SchemeGroupVersion, new(api.PerconaServerMongoDBBackup))
+	s.AddKnownTypes(api.SchemeGroupVersion, new(api.PerconaServerMongoDBBackupList))
+	s.AddKnownTypes(api.SchemeGroupVersion, new(api.PerconaServerMongoDBRestore))
+	s.AddKnownTypes(api.SchemeGroupVersion, new(api.PerconaServerMongoDBRestoreList))
 
-	cl := fake.NewFakeClientWithScheme(s, objs...)
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(objs...).WithStatusSubresource(objs...).Build()
 
-	return &ReconcilePerconaServerMongoDB{client: cl, scheme: s}
+	return &ReconcilePerconaServerMongoDB{
+		client:  cl,
+		scheme:  s,
+		lockers: newLockStore(),
+		newPBM:  fakeBackup.NewPBM,
+	}
 }
 
 func TestUpdateStatus(t *testing.T) {
@@ -29,15 +39,15 @@ func TestUpdateStatus(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "psmdb-mock", Namespace: "psmdb"},
 		Spec: api.PerconaServerMongoDBSpec{
 			CRVersion: "1.12.0",
-			Replsets: []*api.ReplsetSpec{{Name: "rs0", Size: 3}, {Name: "rs1", Size: 3}},
-			Sharding: api.Sharding{Enabled: true, Mongos: &api.MongosSpec{Size: 3}},
+			Replsets:  []*api.ReplsetSpec{{Name: "rs0", Size: 3}, {Name: "rs1", Size: 3}},
+			Sharding:  api.Sharding{Enabled: true, Mongos: &api.MongosSpec{Size: 3}},
 		},
 	}
 
 	rs0 := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "psmdb-mock-rs0", Namespace: "psmdb"}}
 	rs1 := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "psmdb-mock-rs1", Namespace: "psmdb"}}
 
-	r := buildFakeClient([]runtime.Object{cr, rs0, rs1})
+	r := buildFakeClient(cr, rs0, rs1)
 
 	if err := r.updateStatus(context.TODO(), cr, nil, api.AppStateInit); err != nil {
 		t.Error(err)

--- a/pkg/controller/perconaservermongodb/users.go
+++ b/pkg/controller/perconaservermongodb/users.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
-	mongod "go.mongodb.org/mongo-driver/mongo"
 	"golang.org/x/sync/errgroup"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -327,13 +326,13 @@ func (r *ReconcilePerconaServerMongoDB) updateUsers(ctx context.Context, cr *api
 	return grp.Wait()
 }
 
-func (u *systemUser) updateMongo(ctx context.Context, c *mongod.Client) error {
+func (u *systemUser) updateMongo(ctx context.Context, c mongo.Client) error {
 	if bytes.Equal(u.currName, u.name) {
-		err := mongo.UpdateUserPass(ctx, c, string(u.name), string(u.pass))
+		err := c.UpdateUserPass(ctx, string(u.name), string(u.pass))
 		return errors.Wrapf(err, "change password for user %s", u.name)
 	}
 
-	err := mongo.UpdateUser(ctx, c, string(u.currName), string(u.name), string(u.pass))
+	err := c.UpdateUser(ctx, string(u.currName), string(u.name), string(u.pass))
 	return errors.Wrapf(err, "update user %s -> %s", u.currName, u.name)
 }
 

--- a/pkg/controller/perconaservermongodb/version.go
+++ b/pkg/controller/perconaservermongodb/version.go
@@ -21,7 +21,6 @@ import (
 	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
 	v1 "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
 	"github.com/percona/percona-server-mongodb-operator/pkg/k8s"
-	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb/mongo"
 )
 
 func (r *ReconcilePerconaServerMongoDB) deleteEnsureVersion(cr *api.PerconaServerMongoDB, id int) {
@@ -442,7 +441,7 @@ func (r *ReconcilePerconaServerMongoDB) fetchVersionFromMongo(ctx context.Contex
 		}
 	}()
 
-	info, err := mongo.RSBuildInfo(ctx, session)
+	info, err := session.RSBuildInfo(ctx)
 	if err != nil {
 		return errors.Wrap(err, "get build info")
 	}

--- a/pkg/controller/perconaservermongodbbackup/backup.go
+++ b/pkg/controller/perconaservermongodbbackup/backup.go
@@ -21,7 +21,7 @@ const (
 )
 
 type Backup struct {
-	pbm  *backup.PBM
+	pbm  backup.PBM
 	spec api.BackupSpec
 }
 
@@ -59,7 +59,7 @@ func (b *Backup) Start(ctx context.Context, k8sclient client.Client, cluster *ap
 		compLevel = &l
 	}
 
-	err = b.pbm.C.SendCmd(pbm.Cmd{
+	err = b.pbm.SendCmd(pbm.Cmd{
 		Cmd: pbm.CmdBackup,
 		Backup: &pbm.BackupCmd{
 			Name:             name,
@@ -108,7 +108,7 @@ func (b *Backup) Start(ctx context.Context, k8sclient client.Client, cluster *ap
 func (b *Backup) Status(ctx context.Context, cr *api.PerconaServerMongoDBBackup) (api.PerconaServerMongoDBBackupStatus, error) {
 	status := cr.Status
 
-	meta, err := b.pbm.C.GetBackupMeta(cr.Status.PBMname)
+	meta, err := b.pbm.GetBackupMeta(cr.Status.PBMname)
 	if err != nil && !errors.Is(err, pbm.ErrNotFound) {
 		return status, errors.Wrap(err, "get pbm backup meta")
 	}

--- a/pkg/controller/perconaservermongodbbackup/perconaservermongodbbackup_controller.go
+++ b/pkg/controller/perconaservermongodbbackup/perconaservermongodbbackup_controller.go
@@ -45,7 +45,11 @@ func Add(mgr manager.Manager) error {
 
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager) reconcile.Reconciler {
-	return &ReconcilePerconaServerMongoDBBackup{client: mgr.GetClient(), scheme: mgr.GetScheme()}
+	return &ReconcilePerconaServerMongoDBBackup{
+		client:     mgr.GetClient(),
+		scheme:     mgr.GetScheme(),
+		newPBMFunc: backup.NewPBM,
+	}
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
@@ -82,6 +86,8 @@ type ReconcilePerconaServerMongoDBBackup struct {
 	// that reads objects from the cache and writes to the apiserver
 	client client.Client
 	scheme *runtime.Scheme
+
+	newPBMFunc backup.NewPBMFunc
 }
 
 // Reconcile reads that state of the cluster for a PerconaServerMongoDBBackup object and makes changes based on the state read
@@ -207,7 +213,7 @@ func (r *ReconcilePerconaServerMongoDBBackup) reconcile(
 		return status, errors.Wrap(err, "failed to run backup")
 	}
 
-	cjobs, err := backup.HasActiveJobs(ctx, r.client, cluster, backup.NewBackupJob(cr.Name), backup.NotPITRLock)
+	cjobs, err := backup.HasActiveJobs(ctx, r.newPBMFunc, r.client, cluster, backup.NewBackupJob(cr.Name), backup.NotPITRLock)
 	if err != nil {
 		return status, errors.Wrap(err, "check for concurrent jobs")
 	}
@@ -340,7 +346,7 @@ func (r *ReconcilePerconaServerMongoDBBackup) deleteBackupFinalizer(ctx context.
 	var err error
 
 	if b.pbm != nil {
-		meta, err = b.pbm.C.GetBackupMeta(cr.Status.PBMname)
+		meta, err = b.pbm.GetBackupMeta(cr.Status.PBMname)
 		if err != nil {
 			if !errors.Is(err, pbm.ErrNotFound) {
 				return errors.Wrap(err, "get backup meta")
@@ -378,14 +384,14 @@ func (r *ReconcilePerconaServerMongoDBBackup) deleteBackupFinalizer(ctx context.
 	if err != nil {
 		return errors.Wrapf(err, "set backup config with storage %s", cr.Spec.StorageName)
 	}
-	e := b.pbm.C.Logger().NewEvent(string(pbm.CmdDeleteBackup), "", "", primitive.Timestamp{})
+	e := b.pbm.Logger().NewEvent(string(pbm.CmdDeleteBackup), "", "", primitive.Timestamp{})
 	// We should delete PITR oplog chunks until `LastWriteTS` of the backup,
 	// as it's not possible to delete backup if it is a base for the PITR timeline
 	err = r.deletePITR(ctx, b, meta.LastWriteTS, e)
 	if err != nil {
 		return errors.Wrap(err, "failed to delete PITR")
 	}
-	err = b.pbm.C.DeleteBackup(cr.Status.PBMname, e)
+	err = b.pbm.DeleteBackup(cr.Status.PBMname, e)
 	if err != nil {
 		return errors.Wrap(err, "failed to delete backup")
 	}
@@ -396,12 +402,12 @@ func (r *ReconcilePerconaServerMongoDBBackup) deleteBackupFinalizer(ctx context.
 func (r *ReconcilePerconaServerMongoDBBackup) deletePITR(ctx context.Context, b *Backup, until primitive.Timestamp, e *pbmLog.Event) error {
 	log := logf.FromContext(ctx)
 
-	stg, err := b.pbm.C.GetStorage(e)
+	stg, err := b.pbm.GetStorage(e)
 	if err != nil {
 		return errors.Wrap(err, "get storage")
 	}
 
-	chunks, err := b.pbm.C.PITRGetChunksSlice("", primitive.Timestamp{}, until)
+	chunks, err := b.pbm.PITRGetChunksSlice("", primitive.Timestamp{}, until)
 	if err != nil {
 		return errors.Wrap(err, "get pitr chunks")
 	}
@@ -415,7 +421,7 @@ func (r *ReconcilePerconaServerMongoDBBackup) deletePITR(ctx context.Context, b 
 			return errors.Wrapf(err, "delete pitr chunk '%s' (%v) from storage", chnk.FName, chnk)
 		}
 
-		_, err = b.pbm.C.Conn.Database(pbm.DB).Collection(pbm.PITRChunksCollection).DeleteOne(
+		_, err = b.pbm.Conn().Database(pbm.DB).Collection(pbm.PITRChunksCollection).DeleteOne(
 			ctx,
 			bson.D{
 				{Key: "rs", Value: chnk.RS},

--- a/pkg/controller/perconaservermongodbrestore/logical.go
+++ b/pkg/controller/perconaservermongodbrestore/logical.go
@@ -42,7 +42,7 @@ func (r *ReconcilePerconaServerMongoDBRestore) reconcileLogicalRestore(ctx conte
 		return status, errors.Wrapf(err, "set defaults for %s/%s", cluster.Namespace, cluster.Name)
 	}
 
-	cjobs, err := backup.HasActiveJobs(ctx, r.client, cluster, backup.NewRestoreJob(cr), backup.NotPITRLock)
+	cjobs, err := backup.HasActiveJobs(ctx, r.newPBMFunc, r.client, cluster, backup.NewRestoreJob(cr), backup.NotPITRLock)
 	if err != nil {
 		return status, errors.Wrap(err, "check for concurrent jobs")
 	}
@@ -112,7 +112,7 @@ func (r *ReconcilePerconaServerMongoDBRestore) reconcileLogicalRestore(ctx conte
 		return status, err
 	}
 
-	meta, err := pbmc.C.GetRestoreMeta(cr.Status.PBMname)
+	meta, err := pbmc.GetRestoreMeta(cr.Status.PBMname)
 	if err != nil && !errors.Is(err, pbm.ErrNotFound) {
 		return status, errors.Wrap(err, "get pbm metadata")
 	}
@@ -144,12 +144,12 @@ func (r *ReconcilePerconaServerMongoDBRestore) reconcileLogicalRestore(ctx conte
 	return status, nil
 }
 
-func reEnablePITR(pbm *backup.PBM, backup psmdbv1.BackupSpec) (err error) {
+func reEnablePITR(pbm backup.PBM, backup psmdbv1.BackupSpec) (err error) {
 	if !backup.IsEnabledPITR() {
 		return
 	}
 
-	err = pbm.C.SetConfigVar("pitr.enabled", "true")
+	err = pbm.SetConfigVar("pitr.enabled", "true")
 	if err != nil {
 		return
 	}
@@ -157,9 +157,9 @@ func reEnablePITR(pbm *backup.PBM, backup psmdbv1.BackupSpec) (err error) {
 	return
 }
 
-func runRestore(ctx context.Context, backup string, pbmc *backup.PBM, pitr *psmdbv1.PITRestoreSpec) (string, error) {
-	e := pbmc.C.Logger().NewEvent(string(pbm.CmdResync), "", "", primitive.Timestamp{})
-	err := pbmc.C.ResyncStorage(e)
+func runRestore(ctx context.Context, backup string, pbmc backup.PBM, pitr *psmdbv1.PITRestoreSpec) (string, error) {
+	e := pbmc.Logger().NewEvent(string(pbm.CmdResync), "", "", primitive.Timestamp{})
+	err := pbmc.ResyncStorage(e)
 	if err != nil {
 		return "", errors.Wrap(err, "set resync backup list from the store")
 	}
@@ -207,7 +207,7 @@ func runRestore(ctx context.Context, backup string, pbmc *backup.PBM, pitr *psmd
 		}
 	}
 
-	if err = pbmc.C.SendCmd(cmd); err != nil {
+	if err = pbmc.SendCmd(cmd); err != nil {
 		return "", errors.Wrap(err, "send restore cmd")
 	}
 

--- a/pkg/controller/perconaservermongodbrestore/perconaservermongodbrestore_controller.go
+++ b/pkg/controller/perconaservermongodbrestore/perconaservermongodbrestore_controller.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/percona/percona-server-mongodb-operator/clientcmd"
 	psmdbv1 "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
+	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb/backup"
 )
 
 // Add creates a new PerconaServerMongoDBRestore Controller and adds it to the Manager. The Manager will set fields on the Controller
@@ -45,9 +46,10 @@ func newReconciler(mgr manager.Manager) (reconcile.Reconciler, error) {
 	}
 
 	return &ReconcilePerconaServerMongoDBRestore{
-		client:    mgr.GetClient(),
-		scheme:    mgr.GetScheme(),
-		clientcmd: cli,
+		client:     mgr.GetClient(),
+		scheme:     mgr.GetScheme(),
+		clientcmd:  cli,
+		newPBMFunc: backup.NewPBM,
 	}, nil
 }
 
@@ -85,6 +87,8 @@ type ReconcilePerconaServerMongoDBRestore struct {
 	client    client.Client
 	scheme    *runtime.Scheme
 	clientcmd *clientcmd.Client
+
+	newPBMFunc backup.NewPBMFunc
 }
 
 // Reconcile reads that state of the cluster for a PerconaServerMongoDBRestore object and makes changes based on the state read

--- a/pkg/psmdb/backup/backup.go
+++ b/pkg/psmdb/backup/backup.go
@@ -45,7 +45,7 @@ func NewRestoreJob(cr *api.PerconaServerMongoDBRestore) Job {
 
 // HasActiveJobs returns true if there are running backups or restores
 // in given cluster and namespace
-func HasActiveJobs(ctx context.Context, cl client.Client, cluster *api.PerconaServerMongoDB, current Job, allowLock ...LockHeaderPredicate) (bool, error) {
+func HasActiveJobs(ctx context.Context, newPBMFunc NewPBMFunc, cl client.Client, cluster *api.PerconaServerMongoDB, current Job, allowLock ...LockHeaderPredicate) (bool, error) {
 	l := log.FromContext(ctx)
 
 	bcps := &api.PerconaServerMongoDBBackupList{}
@@ -94,7 +94,7 @@ func HasActiveJobs(ctx context.Context, cl client.Client, cluster *api.PerconaSe
 		}
 	}
 
-	pbm, err := NewPBM(ctx, cl, cluster)
+	pbm, err := newPBMFunc(ctx, cl, cluster)
 	if err != nil {
 		return false, errors.Wrap(err, "getting PBM object")
 	}

--- a/pkg/psmdb/backup/fake/pbm.go
+++ b/pkg/psmdb/backup/fake/pbm.go
@@ -1,0 +1,73 @@
+package fake
+
+import (
+	"context"
+
+	"github.com/percona/percona-backup-mongodb/pbm"
+	pbmLog "github.com/percona/percona-backup-mongodb/pbm/log"
+	"github.com/percona/percona-backup-mongodb/pbm/storage"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
+	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb/backup"
+)
+
+type fakePBM struct {
+}
+
+func NewPBM(_ context.Context, _ client.Client, _ *api.PerconaServerMongoDB) (backup.PBM, error) {
+	return new(fakePBM), nil
+}
+func (p *fakePBM) Conn() *mongo.Client {
+	return nil
+}
+func (p *fakePBM) GetPITRChunkContains(ctx context.Context, unixTS int64) (*pbm.OplogChunk, error) {
+	return nil, nil
+}
+func (p *fakePBM) GetLatestTimelinePITR() (pbm.Timeline, error) {
+	return pbm.Timeline{}, nil
+}
+func (p *fakePBM) PITRGetChunksSlice(rs string, from, to primitive.Timestamp) ([]pbm.OplogChunk, error) {
+	return nil, nil
+}
+func (p *fakePBM) Logger() *pbmLog.Logger {
+	return nil
+}
+func (p *fakePBM) GetStorage(l *pbmLog.Event) (storage.Storage, error) {
+	return nil, nil
+}
+func (p *fakePBM) ResyncStorage(l *pbmLog.Event) error {
+	return nil
+}
+func (p *fakePBM) SendCmd(cmd pbm.Cmd) error {
+	return nil
+}
+func (p *fakePBM) Close(ctx context.Context) error {
+	return nil
+}
+func (p *fakePBM) HasLocks(predicates ...backup.LockHeaderPredicate) (bool, error) {
+	return false, nil
+}
+func (p *fakePBM) GetRestoreMeta(name string) (*pbm.RestoreMeta, error) {
+	return nil, nil
+}
+func (p *fakePBM) GetBackupMeta(name string) (*pbm.BackupMeta, error) {
+	return nil, nil
+}
+func (p *fakePBM) DeleteBackup(name string, l *pbmLog.Event) error {
+	return nil
+}
+func (p *fakePBM) SetConfig(ctx context.Context, k8sclient client.Client, cluster *api.PerconaServerMongoDB, stg api.BackupStorageSpec) error {
+	return nil
+}
+func (p *fakePBM) SetConfigVar(key, val string) error {
+	return nil
+}
+func (p *fakePBM) GetConfigVar(key string) (any, error) {
+	return nil, nil
+}
+func (p *fakePBM) DeleteConfigVar(key string) error {
+	return nil
+}

--- a/pkg/psmdb/backup/pbm.go
+++ b/pkg/psmdb/backup/pbm.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/percona/percona-backup-mongodb/pbm"
+	pbmLog "github.com/percona/percona-backup-mongodb/pbm/log"
 	"github.com/percona/percona-backup-mongodb/pbm/storage"
 	"github.com/percona/percona-backup-mongodb/pbm/storage/azure"
 	"github.com/percona/percona-backup-mongodb/pbm/storage/s3"
@@ -33,10 +34,34 @@ const (
 	AzureStorageAccountKeySecretKey  = "AZURE_STORAGE_ACCOUNT_KEY"
 )
 
-type PBM struct {
-	C         *pbm.PBM
+type pbmC struct {
+	*pbm.PBM
 	k8c       client.Client
 	namespace string
+}
+
+type PBM interface {
+	Conn() *mongo.Client
+
+	GetPITRChunkContains(ctx context.Context, unixTS int64) (*pbm.OplogChunk, error)
+	GetLatestTimelinePITR() (pbm.Timeline, error)
+	PITRGetChunksSlice(rs string, from, to primitive.Timestamp) ([]pbm.OplogChunk, error)
+
+	Logger() *pbmLog.Logger
+	GetStorage(l *pbmLog.Event) (storage.Storage, error)
+	ResyncStorage(l *pbmLog.Event) error
+	SendCmd(cmd pbm.Cmd) error
+	Close(ctx context.Context) error
+	HasLocks(predicates ...LockHeaderPredicate) (bool, error)
+
+	GetRestoreMeta(name string) (*pbm.RestoreMeta, error)
+	GetBackupMeta(name string) (*pbm.BackupMeta, error)
+	DeleteBackup(name string, l *pbmLog.Event) error
+
+	SetConfig(ctx context.Context, k8sclient client.Client, cluster *api.PerconaServerMongoDB, stg api.BackupStorageSpec) error
+	SetConfigVar(key, val string) error
+	GetConfigVar(key string) (any, error)
+	DeleteConfigVar(key string) error
 }
 
 func getMongoUri(ctx context.Context, k8sclient client.Client, cr *api.PerconaServerMongoDB, addrs []string) (string, error) {
@@ -97,9 +122,11 @@ func getMongoUri(ctx context.Context, k8sclient client.Client, cr *api.PerconaSe
 	return murl, nil
 }
 
+type NewPBMFunc func(ctx context.Context, c client.Client, cluster *api.PerconaServerMongoDB) (PBM, error)
+
 // NewPBM creates a new connection to PBM.
 // It should be closed after the last use with.
-func NewPBM(ctx context.Context, c client.Client, cluster *api.PerconaServerMongoDB) (*PBM, error) {
+func NewPBM(ctx context.Context, c client.Client, cluster *api.PerconaServerMongoDB) (PBM, error) {
 	rs := cluster.Spec.Replsets[0]
 
 	pods, err := psmdb.GetRSPods(ctx, c, cluster, rs.Name, false)
@@ -128,8 +155,8 @@ func NewPBM(ctx context.Context, c client.Client, cluster *api.PerconaServerMong
 
 	pbmc.InitLogger("", "")
 
-	return &PBM{
-		C:         pbmc,
+	return &pbmC{
+		PBM:       pbmc,
 		k8c:       c,
 		namespace: cluster.Namespace,
 	}, nil
@@ -254,26 +281,29 @@ func GetPBMConfig(ctx context.Context, k8sclient client.Client, cluster *api.Per
 	return conf, nil
 }
 
+func (b *pbmC) Conn() *mongo.Client {
+	return b.PBM.Conn
+}
+
 // SetConfig sets the pbm config with storage defined in the cluster CR
 // by given storageName
-func (b *PBM) SetConfig(ctx context.Context, k8sclient client.Client, cluster *api.PerconaServerMongoDB, stg api.BackupStorageSpec) error {
+func (b *pbmC) SetConfig(ctx context.Context, k8sclient client.Client, cluster *api.PerconaServerMongoDB, stg api.BackupStorageSpec) error {
 	conf, err := GetPBMConfig(ctx, k8sclient, cluster, stg)
 	if err != nil {
 		return errors.Wrap(err, "get PBM config")
 	}
 
-	if err := b.C.SetConfig(conf); err != nil {
+	if err := b.PBM.SetConfig(conf); err != nil {
 		return errors.Wrap(err, "write config")
 	}
 
 	time.Sleep(11 * time.Second) // give time to init new storage
-
 	return nil
 }
 
 // Close close the PBM connection
-func (b *PBM) Close(ctx context.Context) error {
-	return b.C.Conn.Disconnect(ctx)
+func (b *pbmC) Close(ctx context.Context) error {
+	return b.PBM.Conn.Disconnect(ctx)
 }
 
 func getSecret(ctx context.Context, cl client.Client, namespace, secretName string) (*corev1.Secret, error) {
@@ -316,8 +346,8 @@ func NotJobLock(j Job) LockHeaderPredicate {
 	}
 }
 
-func (b *PBM) HasLocks(predicates ...LockHeaderPredicate) (bool, error) {
-	locks, err := b.C.GetLocks(&pbm.LockHeader{})
+func (b *pbmC) HasLocks(predicates ...LockHeaderPredicate) (bool, error) {
+	locks, err := b.PBM.GetLocks(&pbm.LockHeader{})
 	if err != nil {
 		return false, errors.Wrap(err, "getting lock data")
 	}
@@ -342,13 +372,13 @@ func (b *PBM) HasLocks(predicates ...LockHeaderPredicate) (bool, error) {
 
 var errNoOplogsForPITR = errors.New("there is no oplogs that can cover the date/time or no oplogs at all")
 
-func (b *PBM) GetLastPITRChunk() (*pbm.OplogChunk, error) {
-	nodeInfo, err := b.C.GetNodeInfo()
+func (b *pbmC) GetLastPITRChunk() (*pbm.OplogChunk, error) {
+	nodeInfo, err := b.PBM.GetNodeInfo()
 	if err != nil {
 		return nil, errors.Wrap(err, "getting node information")
 	}
 
-	c, err := b.C.PITRLastChunkMeta(nodeInfo.SetName)
+	c, err := b.PBM.PITRLastChunkMeta(nodeInfo.SetName)
 	if err != nil {
 		if errors.Is(err, mongo.ErrNoDocuments) {
 			return nil, errNoOplogsForPITR
@@ -363,19 +393,19 @@ func (b *PBM) GetLastPITRChunk() (*pbm.OplogChunk, error) {
 	return c, nil
 }
 
-func (b *PBM) GetTimelinesPITR() ([]pbm.Timeline, error) {
+func (b *pbmC) GetTimelinesPITR() ([]pbm.Timeline, error) {
 	var (
 		now       = time.Now().UTC().Unix()
 		timelines [][]pbm.Timeline
 	)
 
-	shards, err := b.C.ClusterMembers()
+	shards, err := b.PBM.ClusterMembers()
 	if err != nil {
 		return nil, errors.Wrap(err, "getting cluster members")
 	}
 
 	for _, s := range shards {
-		rsTimelines, err := b.C.PITRGetValidTimelines(s.RS, primitive.Timestamp{T: uint32(now)})
+		rsTimelines, err := b.PBM.PITRGetValidTimelines(s.RS, primitive.Timestamp{T: uint32(now)})
 		if err != nil {
 			return nil, errors.Wrapf(err, "getting timelines for %s", s.RS)
 		}
@@ -386,7 +416,7 @@ func (b *PBM) GetTimelinesPITR() ([]pbm.Timeline, error) {
 	return pbm.MergeTimelines(timelines...), nil
 }
 
-func (b *PBM) GetLatestTimelinePITR() (pbm.Timeline, error) {
+func (b *pbmC) GetLatestTimelinePITR() (pbm.Timeline, error) {
 	timelines, err := b.GetTimelinesPITR()
 	if err != nil {
 		return pbm.Timeline{}, err
@@ -401,8 +431,8 @@ func (b *PBM) GetLatestTimelinePITR() (pbm.Timeline, error) {
 
 // PITRGetChunkContains returns a pitr slice chunk that belongs to the
 // given replica set and contains the given timestamp
-func (p *PBM) pitrGetChunkContains(ctx context.Context, rs string, ts primitive.Timestamp) (*pbm.OplogChunk, error) {
-	res := p.C.Conn.Database(pbm.DB).Collection(pbm.PITRChunksCollection).FindOne(
+func (p *pbmC) pitrGetChunkContains(ctx context.Context, rs string, ts primitive.Timestamp) (*pbm.OplogChunk, error) {
+	res := p.PBM.Conn.Database(pbm.DB).Collection(pbm.PITRChunksCollection).FindOne(
 		ctx,
 		bson.D{
 			{"rs", rs},
@@ -419,8 +449,8 @@ func (p *PBM) pitrGetChunkContains(ctx context.Context, rs string, ts primitive.
 	return chnk, errors.Wrap(err, "decode")
 }
 
-func (b *PBM) GetPITRChunkContains(ctx context.Context, unixTS int64) (*pbm.OplogChunk, error) {
-	nodeInfo, err := b.C.GetNodeInfo()
+func (b *pbmC) GetPITRChunkContains(ctx context.Context, unixTS int64) (*pbm.OplogChunk, error) {
+	nodeInfo, err := b.PBM.GetNodeInfo()
 	if err != nil {
 		return nil, errors.Wrap(err, "getting node information")
 	}

--- a/pkg/psmdb/client.go
+++ b/pkg/psmdb/client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
-	mgo "go.mongodb.org/mongo-driver/mongo"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
@@ -17,7 +16,7 @@ type Credentials struct {
 	Password string
 }
 
-func MongoClient(ctx context.Context, k8sclient client.Client, cr *api.PerconaServerMongoDB, rs api.ReplsetSpec, c Credentials) (*mgo.Client, error) {
+func MongoClient(ctx context.Context, k8sclient client.Client, cr *api.PerconaServerMongoDB, rs api.ReplsetSpec, c Credentials) (mongo.Client, error) {
 	pods, err := GetRSPods(ctx, k8sclient, cr, rs.Name, false)
 	if err != nil {
 		return nil, errors.Wrapf(err, "get pods list for replset %s", rs.Name)
@@ -47,7 +46,7 @@ func MongoClient(ctx context.Context, k8sclient client.Client, cr *api.PerconaSe
 	return mongo.Dial(conf)
 }
 
-func MongosClient(ctx context.Context, k8sclient client.Client, cr *api.PerconaServerMongoDB, c Credentials) (*mgo.Client, error) {
+func MongosClient(ctx context.Context, k8sclient client.Client, cr *api.PerconaServerMongoDB, c Credentials) (mongo.Client, error) {
 	hosts, err := GetMongosAddrs(ctx, k8sclient, cr)
 	if err != nil {
 		return nil, errors.Wrap(err, "get mongos addrs")
@@ -70,7 +69,7 @@ func MongosClient(ctx context.Context, k8sclient client.Client, cr *api.PerconaS
 	return mongo.Dial(&conf)
 }
 
-func StandaloneClient(ctx context.Context, k8sclient client.Client, cr *api.PerconaServerMongoDB, c Credentials, host string) (*mgo.Client, error) {
+func StandaloneClient(ctx context.Context, k8sclient client.Client, cr *api.PerconaServerMongoDB, c Credentials, host string) (mongo.Client, error) {
 	conf := mongo.Config{
 		Hosts:    []string{host},
 		Username: c.Username,

--- a/pkg/psmdb/mongo/fake/client.go
+++ b/pkg/psmdb/mongo/fake/client.go
@@ -1,0 +1,149 @@
+package fake
+
+import (
+	"context"
+
+	"go.mongodb.org/mongo-driver/bson"
+	mgo "go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.mongodb.org/mongo-driver/mongo/readpref"
+
+	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb/mongo"
+)
+
+type fakeMongoClient struct {
+}
+
+func NewClient() mongo.Client {
+	return &fakeMongoClient{}
+}
+
+func (c *fakeMongoClient) Disconnect(ctx context.Context) error {
+	return nil
+}
+
+type fakeMongoClientDatabase struct {
+}
+
+func (c *fakeMongoClientDatabase) RunCommand(ctx context.Context, runCommand interface{}, opts ...*options.RunCmdOptions) *mgo.SingleResult {
+	return singleResult(mongo.OKResponse{
+		OK: 1,
+	})
+}
+
+func singleResult(doc any) *mgo.SingleResult {
+	bsonData, err := bson.Marshal(doc)
+	if err != nil {
+		return mgo.NewSingleResultFromDocument(bson.D{}, err, nil)
+	}
+	var bsonD bson.D
+	err = bson.Unmarshal(bsonData, &bsonD)
+	if err != nil {
+		return mgo.NewSingleResultFromDocument(bson.D{}, err, nil)
+	}
+	return mgo.NewSingleResultFromDocument(bsonD, nil, nil)
+}
+
+func (c *fakeMongoClient) Database(name string, opts ...*options.DatabaseOptions) mongo.ClientDatabase {
+	return new(fakeMongoClientDatabase)
+}
+
+func (c *fakeMongoClient) Ping(ctx context.Context, rp *readpref.ReadPref) error {
+	return nil
+}
+
+func (c *fakeMongoClient) SetDefaultRWConcern(ctx context.Context, readConcern, writeConcern string) error {
+	return nil
+}
+
+func (c *fakeMongoClient) ReadConfig(ctx context.Context) (mongo.RSConfig, error) {
+	return mongo.RSConfig{}, nil
+}
+
+func (c *fakeMongoClient) CreateRole(ctx context.Context, role string, privileges []mongo.RolePrivilege, roles []interface{}) error {
+	return nil
+}
+
+func (c *fakeMongoClient) UpdateRole(ctx context.Context, role string, privileges []mongo.RolePrivilege, roles []interface{}) error {
+	return nil
+}
+
+func (c *fakeMongoClient) GetRole(ctx context.Context, role string) (*mongo.Role, error) {
+	return nil, nil
+}
+
+func (c *fakeMongoClient) CreateUser(ctx context.Context, user, pwd string, roles ...map[string]interface{}) error {
+	return nil
+}
+
+func (c *fakeMongoClient) AddShard(ctx context.Context, rsName, host string) error {
+	return nil
+}
+
+func (c *fakeMongoClient) WriteConfig(ctx context.Context, cfg mongo.RSConfig) error {
+	return nil
+}
+
+func (c *fakeMongoClient) RSStatus(ctx context.Context) (mongo.Status, error) {
+	return mongo.Status{}, nil
+}
+
+func (c *fakeMongoClient) StartBalancer(ctx context.Context) error {
+	return nil
+}
+
+func (c *fakeMongoClient) StopBalancer(ctx context.Context) error {
+	return nil
+}
+
+func (c *fakeMongoClient) IsBalancerRunning(ctx context.Context) (bool, error) {
+	return false, nil
+}
+
+func (c *fakeMongoClient) GetFCV(ctx context.Context) (string, error) {
+	return "", nil
+}
+
+func (c *fakeMongoClient) SetFCV(ctx context.Context, version string) error {
+	return nil
+}
+
+func (c *fakeMongoClient) ListDBs(ctx context.Context) (mongo.DBList, error) {
+	return mongo.DBList{}, nil
+}
+
+func (c *fakeMongoClient) ListShard(ctx context.Context) (mongo.ShardList, error) {
+	return mongo.ShardList{}, nil
+}
+
+func (c *fakeMongoClient) RemoveShard(ctx context.Context, shard string) (mongo.ShardRemoveResp, error) {
+	return mongo.ShardRemoveResp{}, nil
+}
+
+func (c *fakeMongoClient) RSBuildInfo(ctx context.Context) (mongo.BuildInfo, error) {
+	return mongo.BuildInfo{}, nil
+}
+
+func (c *fakeMongoClient) StepDown(ctx context.Context, force bool) error {
+	return nil
+}
+
+func (c *fakeMongoClient) IsMaster(ctx context.Context) (*mongo.IsMasterResp, error) {
+	return nil, nil
+}
+
+func (c *fakeMongoClient) GetUserInfo(ctx context.Context, username string) (*mongo.User, error) {
+	return nil, nil
+}
+
+func (c *fakeMongoClient) UpdateUserRoles(ctx context.Context, username string, roles []map[string]interface{}) error {
+	return nil
+}
+
+func (c *fakeMongoClient) UpdateUserPass(ctx context.Context, name, pass string) error {
+	return nil
+}
+
+func (c *fakeMongoClient) UpdateUser(ctx context.Context, currName, newName, pass string) error {
+	return nil
+}

--- a/pkg/psmdb/mongos.go
+++ b/pkg/psmdb/mongos.go
@@ -24,7 +24,7 @@ func MongosStatefulset(cr *api.PerconaServerMongoDB) *appsv1.StatefulSet {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.MongosNamespacedName().Name,
 			Namespace: cr.MongosNamespacedName().Namespace,
-			Labels:    mongosLabels(cr),
+			Labels:    MongosLabels(cr),
 		},
 	}
 }
@@ -59,7 +59,7 @@ func MongosStatefulsetSpec(cr *api.PerconaServerMongoDB, template corev1.PodTemp
 	return appsv1.StatefulSetSpec{
 		Replicas: &cr.Spec.Sharding.Mongos.Size,
 		Selector: &metav1.LabelSelector{
-			MatchLabels: mongosLabels(cr),
+			MatchLabels: MongosLabels(cr),
 		},
 		Template:       template,
 		UpdateStrategy: updateStrategy,
@@ -71,7 +71,7 @@ func MongosDeploymentSpec(cr *api.PerconaServerMongoDB, template corev1.PodTempl
 	return appsv1.DeploymentSpec{
 		Replicas: &cr.Spec.Sharding.Mongos.Size,
 		Selector: &metav1.LabelSelector{
-			MatchLabels: mongosLabels(cr),
+			MatchLabels: MongosLabels(cr),
 		},
 		Template: template,
 		Strategy: appsv1.DeploymentStrategy{
@@ -84,7 +84,7 @@ func MongosDeploymentSpec(cr *api.PerconaServerMongoDB, template corev1.PodTempl
 }
 
 func MongosTemplateSpec(cr *api.PerconaServerMongoDB, initImage string, log logr.Logger, customConf CustomConfig, cfgInstances []string) (corev1.PodTemplateSpec, error) {
-	ls := mongosLabels(cr)
+	ls := MongosLabels(cr)
 
 	if cr.Spec.Sharding.Mongos.Labels != nil {
 		for k, v := range cr.Spec.Sharding.Mongos.Labels {
@@ -390,7 +390,7 @@ func MongosService(cr *api.PerconaServerMongoDB, name string) corev1.Service {
 		},
 	}
 	if cr.CompareVersion("1.12.0") >= 0 {
-		svc.Labels = mongosLabels(cr)
+		svc.Labels = MongosLabels(cr)
 	}
 
 	if cr.Spec.Sharding.Mongos != nil {
@@ -406,7 +406,7 @@ func MongosService(cr *api.PerconaServerMongoDB, name string) corev1.Service {
 }
 
 func MongosServiceSpec(cr *api.PerconaServerMongoDB, podName string) corev1.ServiceSpec {
-	ls := mongosLabels(cr)
+	ls := MongosLabels(cr)
 
 	if cr.Spec.Sharding.Mongos.Expose.ServicePerPod {
 		ls["statefulset.kubernetes.io/pod-name"] = podName


### PR DESCRIPTION
[![K8SPSMDB-962](https://badgen.net/badge/JIRA/K8SPSMDB-962/green)](https://jira.percona.com/browse/K8SPSMDB-962) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://jira.percona.com/browse/K8SPSMDB-962

**DESCRIPTION**
---
**Problem:**
*While using a cluster with `unmanaged: true`, the operator continually increases both CPU and memory usage.*

**Cause:**
*Regression was introduced in https://github.com/percona/percona-server-mongodb-operator/commit/2fa149d8c0a874944399c96cf9b3c3b1c108ae47. In this commit, I added code to exit the function if the cluster is unmanaged before declaring the client disconnection with defer.*

**Solution:**
*Fix the issue. Add a `TestConnectionLeaks` unit test that covers all mongo client initializations and checks whether all connections in the code are closed. This test will help to avoid such programmer mistakes in the future.*

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?