### PR TITLE
K8SPSMDB-981: Upgrade PBM to v2.3.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/go-openapi/validate v0.22.1
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.18.0
 	github.com/hashicorp/go-version v1.6.0
-	github.com/percona/percona-backup-mongodb v1.8.1-0.20230725073611-5d2c6eeb81be
+	github.com/percona/percona-backup-mongodb v1.8.1-0.20230920143330-3b1c2e263901
 	github.com/pkg/errors v0.9.1
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -107,7 +107,7 @@ github.com/evanphx/json-patch/v5 v5.0.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2Vvl
 github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJCLunww=
 github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
-github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0XL9UY=
+github.com/frankban/quicktest v1.14.5 h1:dfYrrRyLtiqT9GyKXgdh+k4inNeTvmGbuSgZ3lx3GhA=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
@@ -435,8 +435,8 @@ github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYr
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
-github.com/percona/percona-backup-mongodb v1.8.1-0.20230725073611-5d2c6eeb81be h1:h9DOQtF2k4TJSn4aAgnsGH6jtvsCedNTuiaidvgMISw=
-github.com/percona/percona-backup-mongodb v1.8.1-0.20230725073611-5d2c6eeb81be/go.mod h1:Vmj4S69ydcMSN2li6hOC1iRrK86R1FbIbo3VJhtYfcg=
+github.com/percona/percona-backup-mongodb v1.8.1-0.20230920143330-3b1c2e263901 h1:BDgsZRCjEuxl2/z4yWBqB0s8d20shuIDks7/RVdZiLs=
+github.com/percona/percona-backup-mongodb v1.8.1-0.20230920143330-3b1c2e263901/go.mod h1:fZRCMpUqkWlLVdRKqqaj001LoVP2eo6F0ZhoMPeXDng=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pierrec/lz4 v2.6.1+incompatible h1:9UY3+iC23yxF0UfGaYrGplQ+79Rg+h/q9FV9ix19jjM=
 github.com/pierrec/lz4 v2.6.1+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=

--- a/pkg/controller/perconaservermongodbrestore/logical.go
+++ b/pkg/controller/perconaservermongodbrestore/logical.go
@@ -106,7 +106,7 @@ func (r *ReconcilePerconaServerMongoDBRestore) reconcileLogicalRestore(ctx conte
 			return status, nil
 		}
 
-		log.Info("Starting restore")
+		log.Info("Starting restore", "backup", backupName)
 		status.PBMname, err = runRestore(ctx, backupName, pbmc, cr.Spec.PITR)
 		status.State = psmdbv1.RestoreStateRequested
 		return status, err
@@ -188,8 +188,9 @@ func runRestore(ctx context.Context, backup string, pbmc backup.PBM, pitr *psmdb
 		cmd = pbm.Cmd{
 			Cmd: pbm.CmdRestore,
 			Restore: &pbm.RestoreCmd{
-				Name:    rName,
-				OplogTS: primitive.Timestamp{T: uint32(ts)},
+				Name:       rName,
+				BackupName: backup,
+				OplogTS:    primitive.Timestamp{T: uint32(ts)},
 			},
 		}
 	case pitr.Type == psmdbv1.PITRestoreTypeLatest:
@@ -201,8 +202,9 @@ func runRestore(ctx context.Context, backup string, pbmc backup.PBM, pitr *psmdb
 		cmd = pbm.Cmd{
 			Cmd: pbm.CmdRestore,
 			Restore: &pbm.RestoreCmd{
-				Name:    rName,
-				OplogTS: primitive.Timestamp{T: tl.End},
+				Name:       rName,
+				BackupName: backup,
+				OplogTS:    primitive.Timestamp{T: tl.End},
 			},
 		}
 	}


### PR DESCRIPTION
[![K8SPSMDB-981](https://badgen.net/badge/JIRA/K8SPSMDB-981/green)](https://jira.percona.com/browse/K8SPSMDB-981) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
PITR stopped working.

**Cause:**
PBM now needs the backup name in RestoreCmd.

**Solution:**
Bump PBM and send backup name in RestoreCmd.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?
- [x] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are the manifests (crd/bundle) regenerated if needed?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported MongoDB version?
- [x] Does the change support oldest and newest supported Kubernetes version?