### PR TITLE
K8SPSMDB-980 - Add case in finalizer test for delete when rs0-0 is not primary

### DIFF
--- a/e2e-tests/finalizer/run
+++ b/e2e-tests/finalizer/run
@@ -9,14 +9,34 @@ test_dir=$(realpath "$(dirname "$0")")
 create_infra "$namespace"
 cluster="some-name"
 
+desc 'create secrets and start client'
+kubectl_bin apply \
+	-f $conf_dir/secrets_with_tls.yml \
+	-f $conf_dir/client.yml
+
 apply_cluster "$test_dir/conf/$cluster.yml"
 desc 'check if all 3 Pods started'
 wait_for_running "$cluster-rs0" 3
+wait_for_running "$cluster-cfg" 3
+wait_cluster_consistency "${cluster}"
 
-kubectl_bin delete psmdb $cluster
+desc "Kill primary to elect new one and test cluster deletion when primary is not rs0-0"
+primary=$(get_mongo_primary "clusterAdmin:clusterAdmin123456@$cluster-rs0.$namespace" "$cluster")
+if [ "$primary" == "$cluster-rs0-0" ]; then
+	kubectl_bin delete pods --grace-period=0 --force $primary
+	wait_for_running "$cluster-rs0" 3
+	wait_cluster_consistency "${cluster}"
+fi
+primary=$(get_mongo_primary "clusterAdmin:clusterAdmin123456@$cluster-rs0.$namespace" "$cluster")
+if [ "$primary" == "$cluster-rs0-0" ]; then
+	echo "Primary is the same as before, something went wrong!"
+	exit 1
+fi
+
+kubectl_bin delete psmdb $cluster --wait=false
 
 desc "Wait for delete cluster $cluster"
-wait_for_delete psmdb/$cluster
+wait_for_delete psmdb/$cluster 180
 
 desc "Wait for delete PVCs"
 wait_for_delete pvc/mongod-data-$cluster-cfg-0

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -579,6 +579,7 @@ wait_for_running() {
 
 wait_for_delete() {
 	local res="$1"
+	local wait_time=${2:-60}
 
 	set +o xtrace
 	echo -n "$res - "
@@ -587,7 +588,7 @@ wait_for_delete() {
 		sleep 1
 		echo -n .
 		let retry+=1
-		if [ $retry -ge 60 ]; then
+		if [ $retry -ge $wait_time ]; then
 			kubectl_bin logs ${OPERATOR_NS:+-n $OPERATOR_NS} $(get_operator_pod) \
 				| grep -v 'level=info' \
 				| grep -v 'level=debug' \
@@ -805,7 +806,7 @@ get_mongo_primary() {
 	else
 		kubectl_bin get service -o wide \
 			| grep " ${endpoint/:*/} " \
-			| awk '{print$1}'
+			| awk '{print $1}'
 	fi
 }
 


### PR DESCRIPTION
[![K8SPSMDB-980](https://badgen.net/badge/JIRA/K8SPSMDB-980/green)](https://jira.percona.com/browse/K8SPSMDB-980) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
*It was impossible to delete a cluster if rs0-0 was not primary and we were missing a test case for this so this PR is adding a test case.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?