### PR TITLE
K8SPSMDB-980: fix cluster deletion

### DIFF
--- a/e2e-tests/arbiter/compare/statefulset_arbiter-clusterip-rs0-arbiter-oc.yml
+++ b/e2e-tests/arbiter/compare/statefulset_arbiter-clusterip-rs0-arbiter-oc.yml
@@ -162,7 +162,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
       - name: arbiter-clusterip-mongodb-keyfile
         secret:

--- a/e2e-tests/arbiter/compare/statefulset_arbiter-clusterip-rs0-arbiter.yml
+++ b/e2e-tests/arbiter/compare/statefulset_arbiter-clusterip-rs0-arbiter.yml
@@ -158,7 +158,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
       - name: arbiter-clusterip-mongodb-keyfile
         secret:

--- a/e2e-tests/arbiter/compare/statefulset_arbiter-rs0-arbiter-oc.yml
+++ b/e2e-tests/arbiter/compare/statefulset_arbiter-rs0-arbiter-oc.yml
@@ -161,7 +161,7 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext: {}
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: arbiter-mongodb-keyfile
           secret:

--- a/e2e-tests/arbiter/compare/statefulset_arbiter-rs0-arbiter.yml
+++ b/e2e-tests/arbiter/compare/statefulset_arbiter-rs0-arbiter.yml
@@ -163,7 +163,7 @@ spec:
       schedulerName: default-scheduler
       securityContext:
         fsGroup: 1001
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: arbiter-mongodb-keyfile
           secret:

--- a/e2e-tests/data-at-rest-encryption/compare/statefulset_some-name-cfg-oc.yml
+++ b/e2e-tests/data-at-rest-encryption/compare/statefulset_some-name-cfg-oc.yml
@@ -200,7 +200,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/data-at-rest-encryption/compare/statefulset_some-name-cfg.yml
+++ b/e2e-tests/data-at-rest-encryption/compare/statefulset_some-name-cfg.yml
@@ -203,7 +203,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/data-at-rest-encryption/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/data-at-rest-encryption/compare/statefulset_some-name-rs0-oc.yml
@@ -213,7 +213,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/data-at-rest-encryption/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/data-at-rest-encryption/compare/statefulset_some-name-rs0.yml
@@ -216,7 +216,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/default-cr/compare/statefulset_minimal-cluster-cfg-oc.yml
+++ b/e2e-tests/default-cr/compare/statefulset_minimal-cluster-cfg-oc.yml
@@ -162,7 +162,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: minimal-cluster-mongodb-keyfile
           secret:

--- a/e2e-tests/default-cr/compare/statefulset_minimal-cluster-cfg.yml
+++ b/e2e-tests/default-cr/compare/statefulset_minimal-cluster-cfg.yml
@@ -164,7 +164,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: minimal-cluster-mongodb-keyfile
           secret:

--- a/e2e-tests/default-cr/compare/statefulset_minimal-cluster-rs0-oc.yml
+++ b/e2e-tests/default-cr/compare/statefulset_minimal-cluster-rs0-oc.yml
@@ -162,7 +162,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: minimal-cluster-mongodb-keyfile
           secret:

--- a/e2e-tests/default-cr/compare/statefulset_minimal-cluster-rs0.yml
+++ b/e2e-tests/default-cr/compare/statefulset_minimal-cluster-rs0.yml
@@ -164,7 +164,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: minimal-cluster-mongodb-keyfile
           secret:

--- a/e2e-tests/default-cr/compare/statefulset_my-cluster-name-cfg-oc.yml
+++ b/e2e-tests/default-cr/compare/statefulset_my-cluster-name-cfg-oc.yml
@@ -212,7 +212,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: my-cluster-name-mongodb-keyfile
           secret:

--- a/e2e-tests/default-cr/compare/statefulset_my-cluster-name-cfg.yml
+++ b/e2e-tests/default-cr/compare/statefulset_my-cluster-name-cfg.yml
@@ -215,7 +215,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: my-cluster-name-mongodb-keyfile
           secret:

--- a/e2e-tests/default-cr/compare/statefulset_my-cluster-name-rs0-oc.yml
+++ b/e2e-tests/default-cr/compare/statefulset_my-cluster-name-rs0-oc.yml
@@ -212,7 +212,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: my-cluster-name-mongodb-keyfile
           secret:

--- a/e2e-tests/default-cr/compare/statefulset_my-cluster-name-rs0.yml
+++ b/e2e-tests/default-cr/compare/statefulset_my-cluster-name-rs0.yml
@@ -215,7 +215,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: my-cluster-name-mongodb-keyfile
           secret:

--- a/e2e-tests/demand-backup-eks-credentials/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/demand-backup-eks-credentials/compare/statefulset_some-name-rs0.yml
@@ -215,7 +215,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/demand-backup-physical-sharded/compare/statefulset_some-name-rs0_restore_sharded-oc.yml
+++ b/e2e-tests/demand-backup-physical-sharded/compare/statefulset_some-name-rs0_restore_sharded-oc.yml
@@ -200,7 +200,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/demand-backup-physical-sharded/compare/statefulset_some-name-rs0_restore_sharded.yml
+++ b/e2e-tests/demand-backup-physical-sharded/compare/statefulset_some-name-rs0_restore_sharded.yml
@@ -202,7 +202,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/demand-backup-physical/compare/statefulset_some-name-rs0_restore-arbiter-nv.yml
+++ b/e2e-tests/demand-backup-physical/compare/statefulset_some-name-rs0_restore-arbiter-nv.yml
@@ -201,7 +201,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/demand-backup-physical/compare/statefulset_some-name-rs0_restore-oc.yml
+++ b/e2e-tests/demand-backup-physical/compare/statefulset_some-name-rs0_restore-oc.yml
@@ -199,7 +199,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/demand-backup-physical/compare/statefulset_some-name-rs0_restore.yml
+++ b/e2e-tests/demand-backup-physical/compare/statefulset_some-name-rs0_restore.yml
@@ -201,7 +201,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-cfg-4-oc.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-cfg-4-oc.yml
@@ -222,7 +222,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-cfg-oc.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-cfg-oc.yml
@@ -221,7 +221,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-cfg.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-cfg.yml
@@ -225,7 +225,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-mongos-4-oc.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-mongos-4-oc.yml
@@ -169,7 +169,7 @@ spec:
       runtimeClassName: container-rc
       schedulerName: default-scheduler
       securityContext: {}
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-mongos-oc.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-mongos-oc.yml
@@ -170,7 +170,7 @@ spec:
       schedulerName: default-scheduler
       securityContext:
         fsGroup: 1001
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-mongos-secret-oc.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-mongos-secret-oc.yml
@@ -169,7 +169,7 @@ spec:
       runtimeClassName: container-rc
       schedulerName: default-scheduler
       securityContext: {}
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-mongos-secret.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-mongos-secret.yml
@@ -171,7 +171,7 @@ spec:
       schedulerName: default-scheduler
       securityContext:
         fsGroup: 1001
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-mongos.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-mongos.yml
@@ -171,7 +171,7 @@ spec:
       schedulerName: default-scheduler
       securityContext:
         fsGroup: 1001
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs0-4-oc.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs0-4-oc.yml
@@ -216,7 +216,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs0-oc.yml
@@ -215,7 +215,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs0.yml
@@ -219,7 +219,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs1-oc.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs1-oc.yml
@@ -215,7 +215,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs1.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs1.yml
@@ -218,7 +218,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs2-oc.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs2-oc.yml
@@ -225,7 +225,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs2.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs2.yml
@@ -228,7 +228,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/demand-backup/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/demand-backup/compare/statefulset_some-name-rs0-oc.yml
@@ -212,7 +212,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/demand-backup/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/demand-backup/compare/statefulset_some-name-rs0.yml
@@ -215,7 +215,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/expose-sharded/compare/statefulset_some-name-cfg-4-oc.yml
+++ b/e2e-tests/expose-sharded/compare/statefulset_some-name-cfg-4-oc.yml
@@ -172,7 +172,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/expose-sharded/compare/statefulset_some-name-cfg-oc.yml
+++ b/e2e-tests/expose-sharded/compare/statefulset_some-name-cfg-oc.yml
@@ -171,7 +171,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/expose-sharded/compare/statefulset_some-name-cfg.yml
+++ b/e2e-tests/expose-sharded/compare/statefulset_some-name-cfg.yml
@@ -174,7 +174,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/expose-sharded/compare/statefulset_some-name-mongos-4-oc.yml
+++ b/e2e-tests/expose-sharded/compare/statefulset_some-name-mongos-4-oc.yml
@@ -169,7 +169,7 @@ spec:
       runtimeClassName: container-rc
       schedulerName: default-scheduler
       securityContext: {}
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/expose-sharded/compare/statefulset_some-name-mongos-oc.yml
+++ b/e2e-tests/expose-sharded/compare/statefulset_some-name-mongos-oc.yml
@@ -168,7 +168,7 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext: {}
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/expose-sharded/compare/statefulset_some-name-mongos.yml
+++ b/e2e-tests/expose-sharded/compare/statefulset_some-name-mongos.yml
@@ -171,7 +171,7 @@ spec:
       schedulerName: default-scheduler
       securityContext:
         fsGroup: 1001
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0-4-oc.yml
+++ b/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0-4-oc.yml
@@ -176,7 +176,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0-oc.yml
@@ -175,7 +175,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0.yml
@@ -178,7 +178,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/init-deploy/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/init-deploy/compare/statefulset_some-name-rs0-oc.yml
@@ -164,7 +164,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/init-deploy/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/init-deploy/compare/statefulset_some-name-rs0.yml
@@ -166,7 +166,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/limits/compare/statefulset_no-limits-rs0-increased-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-rs0-increased-oc.yml
@@ -169,7 +169,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: no-limits-mongodb-keyfile
           secret:

--- a/e2e-tests/limits/compare/statefulset_no-limits-rs0-increased.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-rs0-increased.yml
@@ -171,7 +171,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: no-limits-mongodb-keyfile
           secret:

--- a/e2e-tests/limits/compare/statefulset_no-limits-rs0-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-rs0-oc.yml
@@ -169,7 +169,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: no-limits-mongodb-keyfile
           secret:

--- a/e2e-tests/limits/compare/statefulset_no-limits-rs0.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-rs0.yml
@@ -171,7 +171,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: no-limits-mongodb-keyfile
           secret:

--- a/e2e-tests/limits/compare/statefulset_no-requests-no-limits-rs0-increased-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-no-limits-rs0-increased-oc.yml
@@ -163,7 +163,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: no-requests-no-limits-mongodb-keyfile
           secret:

--- a/e2e-tests/limits/compare/statefulset_no-requests-no-limits-rs0-increased.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-no-limits-rs0-increased.yml
@@ -165,7 +165,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: no-requests-no-limits-mongodb-keyfile
           secret:

--- a/e2e-tests/limits/compare/statefulset_no-requests-no-limits-rs0-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-no-limits-rs0-oc.yml
@@ -163,7 +163,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: no-requests-no-limits-mongodb-keyfile
           secret:

--- a/e2e-tests/limits/compare/statefulset_no-requests-no-limits-rs0.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-no-limits-rs0.yml
@@ -165,7 +165,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: no-requests-no-limits-mongodb-keyfile
           secret:

--- a/e2e-tests/limits/compare/statefulset_no-requests-rs0-increased-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-rs0-increased-oc.yml
@@ -170,7 +170,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: no-requests-mongodb-keyfile
           secret:

--- a/e2e-tests/limits/compare/statefulset_no-requests-rs0-increased.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-rs0-increased.yml
@@ -172,7 +172,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: no-requests-mongodb-keyfile
           secret:

--- a/e2e-tests/limits/compare/statefulset_no-requests-rs0-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-rs0-oc.yml
@@ -170,7 +170,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: no-requests-mongodb-keyfile
           secret:

--- a/e2e-tests/limits/compare/statefulset_no-requests-rs0.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-rs0.yml
@@ -172,7 +172,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: no-requests-mongodb-keyfile
           secret:

--- a/e2e-tests/liveness/compare/statefulset_liveness-rs0-changed-oc.yml
+++ b/e2e-tests/liveness/compare/statefulset_liveness-rs0-changed-oc.yml
@@ -207,7 +207,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: liveness-mongodb-keyfile
           secret:

--- a/e2e-tests/liveness/compare/statefulset_liveness-rs0-changed.yml
+++ b/e2e-tests/liveness/compare/statefulset_liveness-rs0-changed.yml
@@ -210,7 +210,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: liveness-mongodb-keyfile
           secret:

--- a/e2e-tests/liveness/compare/statefulset_liveness-rs0-oc.yml
+++ b/e2e-tests/liveness/compare/statefulset_liveness-rs0-oc.yml
@@ -159,7 +159,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: liveness-mongodb-keyfile
           secret:

--- a/e2e-tests/liveness/compare/statefulset_liveness-rs0.yml
+++ b/e2e-tests/liveness/compare/statefulset_liveness-rs0.yml
@@ -161,7 +161,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: liveness-mongodb-keyfile
           secret:

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-cfg-oc.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-cfg-oc.yml
@@ -292,7 +292,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: monitoring-mongodb-keyfile
           secret:

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-cfg.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-cfg.yml
@@ -294,7 +294,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: monitoring-mongodb-keyfile
           secret:

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-mongos-oc.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-mongos-oc.yml
@@ -298,7 +298,7 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext: {}
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: monitoring-mongodb-keyfile
           secret:

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-mongos.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-mongos.yml
@@ -300,7 +300,7 @@ spec:
       schedulerName: default-scheduler
       securityContext:
         fsGroup: 1001
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: monitoring-mongodb-keyfile
           secret:

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0-no-pmm-oc.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0-no-pmm-oc.yml
@@ -152,7 +152,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: monitoring-mongodb-keyfile
           secret:

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0-no-pmm.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0-no-pmm.yml
@@ -154,7 +154,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: monitoring-mongodb-keyfile
           secret:

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0-oc.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0-oc.yml
@@ -280,7 +280,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: monitoring-mongodb-keyfile
           secret:

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0.yml
@@ -282,7 +282,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: monitoring-mongodb-keyfile
           secret:

--- a/e2e-tests/non-voting/compare/statefulset_nonvoting-rs0-nv-oc.yml
+++ b/e2e-tests/non-voting/compare/statefulset_nonvoting-rs0-nv-oc.yml
@@ -173,7 +173,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: nonvoting-mongodb-keyfile
           secret:

--- a/e2e-tests/non-voting/compare/statefulset_nonvoting-rs0-nv.yml
+++ b/e2e-tests/non-voting/compare/statefulset_nonvoting-rs0-nv.yml
@@ -175,7 +175,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: nonvoting-mongodb-keyfile
           secret:

--- a/e2e-tests/one-pod/compare/statefulset_one-pod-rs0-oc.yml
+++ b/e2e-tests/one-pod/compare/statefulset_one-pod-rs0-oc.yml
@@ -214,7 +214,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: one-pod-mongodb-keyfile
           secret:

--- a/e2e-tests/one-pod/compare/statefulset_one-pod-rs0-secret-oc.yml
+++ b/e2e-tests/one-pod/compare/statefulset_one-pod-rs0-secret-oc.yml
@@ -214,7 +214,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: one-pod-mongodb-keyfile
           secret:

--- a/e2e-tests/one-pod/compare/statefulset_one-pod-rs0-secret.yml
+++ b/e2e-tests/one-pod/compare/statefulset_one-pod-rs0-secret.yml
@@ -217,7 +217,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: one-pod-mongodb-keyfile
           secret:

--- a/e2e-tests/one-pod/compare/statefulset_one-pod-rs0.yml
+++ b/e2e-tests/one-pod/compare/statefulset_one-pod-rs0.yml
@@ -217,7 +217,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: one-pod-mongodb-keyfile
           secret:

--- a/e2e-tests/pitr-physical/compare/statefulset_some-name-cfg-4-oc.yml
+++ b/e2e-tests/pitr-physical/compare/statefulset_some-name-cfg-4-oc.yml
@@ -221,7 +221,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/pitr-physical/compare/statefulset_some-name-cfg-oc.yml
+++ b/e2e-tests/pitr-physical/compare/statefulset_some-name-cfg-oc.yml
@@ -221,7 +221,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/pitr-physical/compare/statefulset_some-name-cfg.yml
+++ b/e2e-tests/pitr-physical/compare/statefulset_some-name-cfg.yml
@@ -224,7 +224,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/pitr-physical/compare/statefulset_some-name-mongos.yml
+++ b/e2e-tests/pitr-physical/compare/statefulset_some-name-mongos.yml
@@ -163,7 +163,7 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext: {}
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/pitr-physical/compare/statefulset_some-name-rs0-4-oc.yml
+++ b/e2e-tests/pitr-physical/compare/statefulset_some-name-rs0-4-oc.yml
@@ -215,7 +215,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/pitr-physical/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/pitr-physical/compare/statefulset_some-name-rs0-oc.yml
@@ -215,7 +215,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/pitr-physical/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/pitr-physical/compare/statefulset_some-name-rs0.yml
@@ -218,7 +218,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/pitr-physical/compare/statefulset_some-name-rs1-4-oc.yml
+++ b/e2e-tests/pitr-physical/compare/statefulset_some-name-rs1-4-oc.yml
@@ -215,7 +215,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/pitr-physical/compare/statefulset_some-name-rs1-oc.yml
+++ b/e2e-tests/pitr-physical/compare/statefulset_some-name-rs1-oc.yml
@@ -213,7 +213,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/pitr-physical/compare/statefulset_some-name-rs1.yml
+++ b/e2e-tests/pitr-physical/compare/statefulset_some-name-rs1.yml
@@ -218,7 +218,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/pitr-physical/compare/statefulset_some-name-rs2-4-oc.yml
+++ b/e2e-tests/pitr-physical/compare/statefulset_some-name-rs2-4-oc.yml
@@ -225,7 +225,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/pitr-physical/compare/statefulset_some-name-rs2-oc.yml
+++ b/e2e-tests/pitr-physical/compare/statefulset_some-name-rs2-oc.yml
@@ -223,7 +223,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/pitr-physical/compare/statefulset_some-name-rs2.yml
+++ b/e2e-tests/pitr-physical/compare/statefulset_some-name-rs2.yml
@@ -228,7 +228,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/pitr-sharded/compare/statefulset_some-name-cfg-4-oc.yml
+++ b/e2e-tests/pitr-sharded/compare/statefulset_some-name-cfg-4-oc.yml
@@ -222,7 +222,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/pitr-sharded/compare/statefulset_some-name-cfg-oc.yml
+++ b/e2e-tests/pitr-sharded/compare/statefulset_some-name-cfg-oc.yml
@@ -221,7 +221,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/pitr-sharded/compare/statefulset_some-name-cfg.yml
+++ b/e2e-tests/pitr-sharded/compare/statefulset_some-name-cfg.yml
@@ -225,7 +225,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/pitr-sharded/compare/statefulset_some-name-mongos-oc.yml
+++ b/e2e-tests/pitr-sharded/compare/statefulset_some-name-mongos-oc.yml
@@ -166,7 +166,7 @@ spec:
       runtimeClassName: container-rc
       schedulerName: default-scheduler
       securityContext: {}
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/pitr-sharded/compare/statefulset_some-name-mongos.yml
+++ b/e2e-tests/pitr-sharded/compare/statefulset_some-name-mongos.yml
@@ -168,7 +168,7 @@ spec:
       schedulerName: default-scheduler
       securityContext:
         fsGroup: 1001
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs0-4-oc.yml
+++ b/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs0-4-oc.yml
@@ -216,7 +216,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs0-oc.yml
@@ -215,7 +215,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs0.yml
@@ -219,7 +219,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs1-4-oc.yml
+++ b/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs1-4-oc.yml
@@ -215,7 +215,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs1-oc.yml
+++ b/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs1-oc.yml
@@ -213,7 +213,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs1.yml
+++ b/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs1.yml
@@ -218,7 +218,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs2-4-oc.yml
+++ b/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs2-4-oc.yml
@@ -225,7 +225,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs2-oc.yml
+++ b/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs2-oc.yml
@@ -223,7 +223,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs2.yml
+++ b/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs2.yml
@@ -228,7 +228,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/pitr/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/pitr/compare/statefulset_some-name-rs0-oc.yml
@@ -212,7 +212,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/pitr/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/pitr/compare/statefulset_some-name-rs0.yml
@@ -215,7 +215,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/rs-shard-migration/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/rs-shard-migration/compare/statefulset_some-name-rs0-oc.yml
@@ -164,7 +164,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/rs-shard-migration/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/rs-shard-migration/compare/statefulset_some-name-rs0.yml
@@ -166,7 +166,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/scheduled-backup/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/scheduled-backup/compare/statefulset_some-name-rs0-oc.yml
@@ -215,7 +215,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/scheduled-backup/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/scheduled-backup/compare/statefulset_some-name-rs0.yml
@@ -218,7 +218,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/security-context/compare/statefulset_sec-context-rs0-changed.yml
+++ b/e2e-tests/security-context/compare/statefulset_sec-context-rs0-changed.yml
@@ -222,7 +222,7 @@ spec:
           - 1003
       serviceAccount: percona-server-mongodb-operator-workload
       serviceAccountName: percona-server-mongodb-operator-workload
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: sec-context-mongodb-keyfile
           secret:

--- a/e2e-tests/security-context/compare/statefulset_sec-context-rs0.yml
+++ b/e2e-tests/security-context/compare/statefulset_sec-context-rs0.yml
@@ -173,7 +173,7 @@ spec:
           - 1003
       serviceAccount: percona-server-mongodb-operator-workload
       serviceAccountName: percona-server-mongodb-operator-workload
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: sec-context-mongodb-keyfile
           secret:

--- a/e2e-tests/service-per-pod/compare/statefulset_cluster-ip-rs0-oc.yml
+++ b/e2e-tests/service-per-pod/compare/statefulset_cluster-ip-rs0-oc.yml
@@ -199,7 +199,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: cluster-ip-mongodb-keyfile
           secret:

--- a/e2e-tests/service-per-pod/compare/statefulset_cluster-ip-rs0.yml
+++ b/e2e-tests/service-per-pod/compare/statefulset_cluster-ip-rs0.yml
@@ -202,7 +202,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: cluster-ip-mongodb-keyfile
           secret:

--- a/e2e-tests/service-per-pod/compare/statefulset_local-balancer-rs0-oc.yml
+++ b/e2e-tests/service-per-pod/compare/statefulset_local-balancer-rs0-oc.yml
@@ -199,7 +199,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: local-balancer-mongodb-keyfile
           secret:

--- a/e2e-tests/service-per-pod/compare/statefulset_local-balancer-rs0.yml
+++ b/e2e-tests/service-per-pod/compare/statefulset_local-balancer-rs0.yml
@@ -202,7 +202,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: local-balancer-mongodb-keyfile
           secret:

--- a/e2e-tests/service-per-pod/compare/statefulset_node-port-rs0-oc.yml
+++ b/e2e-tests/service-per-pod/compare/statefulset_node-port-rs0-oc.yml
@@ -199,7 +199,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: node-port-mongodb-keyfile
           secret:

--- a/e2e-tests/service-per-pod/compare/statefulset_node-port-rs0.yml
+++ b/e2e-tests/service-per-pod/compare/statefulset_node-port-rs0.yml
@@ -202,7 +202,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: node-port-mongodb-keyfile
           secret:

--- a/e2e-tests/smart-update/compare/statefulset_smart-update-rs0-arbiter-oc.yml
+++ b/e2e-tests/smart-update/compare/statefulset_smart-update-rs0-arbiter-oc.yml
@@ -162,7 +162,7 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext: {}
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: smart-update-mongodb-keyfile
           secret:

--- a/e2e-tests/smart-update/compare/statefulset_smart-update-rs0-arbiter.yml
+++ b/e2e-tests/smart-update/compare/statefulset_smart-update-rs0-arbiter.yml
@@ -164,7 +164,7 @@ spec:
       schedulerName: default-scheduler
       securityContext:
         fsGroup: 1001
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: smart-update-mongodb-keyfile
           secret:

--- a/e2e-tests/smart-update/compare/statefulset_smart-update-rs0-oc.yml
+++ b/e2e-tests/smart-update/compare/statefulset_smart-update-rs0-oc.yml
@@ -164,7 +164,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: smart-update-mongodb-keyfile
           secret:

--- a/e2e-tests/smart-update/compare/statefulset_smart-update-rs0.yml
+++ b/e2e-tests/smart-update/compare/statefulset_smart-update-rs0.yml
@@ -166,7 +166,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: smart-update-mongodb-keyfile
           secret:

--- a/e2e-tests/storage/compare/statefulset_emptydir-rs0-oc.yml
+++ b/e2e-tests/storage/compare/statefulset_emptydir-rs0-oc.yml
@@ -163,7 +163,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: emptydir-mongodb-keyfile
           secret:

--- a/e2e-tests/storage/compare/statefulset_emptydir-rs0.yml
+++ b/e2e-tests/storage/compare/statefulset_emptydir-rs0.yml
@@ -165,7 +165,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: emptydir-mongodb-keyfile
           secret:

--- a/e2e-tests/storage/compare/statefulset_hostpath-rs0-oc.yml
+++ b/e2e-tests/storage/compare/statefulset_hostpath-rs0-oc.yml
@@ -151,7 +151,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: hostpath-mongodb-keyfile
           secret:

--- a/e2e-tests/storage/compare/statefulset_hostpath-rs0.yml
+++ b/e2e-tests/storage/compare/statefulset_hostpath-rs0.yml
@@ -165,7 +165,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: hostpath-mongodb-keyfile
           secret:

--- a/e2e-tests/upgrade-consistency-sharded/compare/statefulset_some-name-cfg-1150-oc.yml
+++ b/e2e-tests/upgrade-consistency-sharded/compare/statefulset_some-name-cfg-1150-oc.yml
@@ -164,7 +164,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/upgrade-consistency-sharded/compare/statefulset_some-name-cfg-1150.yml
+++ b/e2e-tests/upgrade-consistency-sharded/compare/statefulset_some-name-cfg-1150.yml
@@ -176,7 +176,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/upgrade-consistency-sharded/compare/statefulset_some-name-rs0-1150-oc.yml
+++ b/e2e-tests/upgrade-consistency-sharded/compare/statefulset_some-name-rs0-1150-oc.yml
@@ -164,7 +164,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/upgrade-consistency-sharded/compare/statefulset_some-name-rs0-1150.yml
+++ b/e2e-tests/upgrade-consistency-sharded/compare/statefulset_some-name-rs0-1150.yml
@@ -179,7 +179,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1150-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1150-oc.yml
@@ -164,7 +164,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1150.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1150.yml
@@ -166,7 +166,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: some-name-mongodb-keyfile
           secret:

--- a/e2e-tests/version-service/compare/statefulset_minimal-cluster-rs0.yml
+++ b/e2e-tests/version-service/compare/statefulset_minimal-cluster-rs0.yml
@@ -164,7 +164,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: minimal-cluster-mongodb-keyfile
           secret:

--- a/e2e-tests/version-service/compare/statefulset_version-service-exact-rs0-oc.yml
+++ b/e2e-tests/version-service/compare/statefulset_version-service-exact-rs0-oc.yml
@@ -164,7 +164,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: version-service-exact-mongodb-keyfile
           secret:

--- a/e2e-tests/version-service/compare/statefulset_version-service-exact-rs0.yml
+++ b/e2e-tests/version-service/compare/statefulset_version-service-exact-rs0.yml
@@ -166,7 +166,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: version-service-exact-mongodb-keyfile
           secret:

--- a/e2e-tests/version-service/compare/statefulset_version-service-latest-rs0-oc.yml
+++ b/e2e-tests/version-service/compare/statefulset_version-service-latest-rs0-oc.yml
@@ -164,7 +164,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: version-service-latest-mongodb-keyfile
           secret:

--- a/e2e-tests/version-service/compare/statefulset_version-service-latest-rs0.yml
+++ b/e2e-tests/version-service/compare/statefulset_version-service-latest-rs0.yml
@@ -166,7 +166,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: version-service-latest-mongodb-keyfile
           secret:

--- a/e2e-tests/version-service/compare/statefulset_version-service-major-rs0-oc.yml
+++ b/e2e-tests/version-service/compare/statefulset_version-service-major-rs0-oc.yml
@@ -164,7 +164,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: version-service-major-mongodb-keyfile
           secret:

--- a/e2e-tests/version-service/compare/statefulset_version-service-major-rs0.yml
+++ b/e2e-tests/version-service/compare/statefulset_version-service-major-rs0.yml
@@ -166,7 +166,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: version-service-major-mongodb-keyfile
           secret:

--- a/e2e-tests/version-service/compare/statefulset_version-service-recommended-rs0-oc.yml
+++ b/e2e-tests/version-service/compare/statefulset_version-service-recommended-rs0-oc.yml
@@ -164,7 +164,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: version-service-recommended-mongodb-keyfile
           secret:

--- a/e2e-tests/version-service/compare/statefulset_version-service-recommended-rs0.yml
+++ b/e2e-tests/version-service/compare/statefulset_version-service-recommended-rs0.yml
@@ -166,7 +166,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: version-service-recommended-mongodb-keyfile
           secret:

--- a/e2e-tests/version-service/compare/statefulset_version-service-unreachable-rs0-oc.yml
+++ b/e2e-tests/version-service/compare/statefulset_version-service-unreachable-rs0-oc.yml
@@ -164,7 +164,7 @@ spec:
       securityContext: {}
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: version-service-unreachable-mongodb-keyfile
           secret:

--- a/e2e-tests/version-service/compare/statefulset_version-service-unreachable-rs0.yml
+++ b/e2e-tests/version-service/compare/statefulset_version-service-unreachable-rs0.yml
@@ -166,7 +166,7 @@ spec:
         fsGroup: 1001
       serviceAccount: default
       serviceAccountName: default
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: 60
       volumes:
         - name: version-service-unreachable-mongodb-keyfile
           secret:

--- a/pkg/apis/psmdb/v1/psmdb_defaults.go
+++ b/pkg/apis/psmdb/v1/psmdb_defaults.go
@@ -756,7 +756,7 @@ func (m *MultiAZ) reconcileOpts(cr *PerconaServerMongoDB) {
 
 	if m.TerminationGracePeriodSeconds == nil || (!cr.Spec.UnsafeConf && *m.TerminationGracePeriodSeconds < 30) {
 		m.TerminationGracePeriodSeconds = new(int64)
-		*m.TerminationGracePeriodSeconds = 30
+		*m.TerminationGracePeriodSeconds = 60
 	}
 
 	if m.PodDisruptionBudget == nil {

--- a/pkg/apis/psmdb/v1/psmdb_defaults.go
+++ b/pkg/apis/psmdb/v1/psmdb_defaults.go
@@ -754,6 +754,11 @@ func (m *MultiAZ) reconcileOpts(cr *PerconaServerMongoDB) {
 	m.reconcileAffinityOpts()
 	m.reconcileTopologySpreadConstraints(cr)
 
+	if m.TerminationGracePeriodSeconds == nil || (!cr.Spec.UnsafeConf && *m.TerminationGracePeriodSeconds < 30) {
+		m.TerminationGracePeriodSeconds = new(int64)
+		*m.TerminationGracePeriodSeconds = 30
+	}
+
 	if m.PodDisruptionBudget == nil {
 		defaultMaxUnavailable := intstr.FromInt(1)
 		m.PodDisruptionBudget = &PodDisruptionBudgetSpec{MaxUnavailable: &defaultMaxUnavailable}

--- a/pkg/apis/psmdb/v1/psmdb_defaults.go
+++ b/pkg/apis/psmdb/v1/psmdb_defaults.go
@@ -753,12 +753,12 @@ func (rs *ReplsetSpec) setSafeDefaults(log logr.Logger) {
 func (m *MultiAZ) reconcileOpts(cr *PerconaServerMongoDB) {
 	m.reconcileAffinityOpts()
 	m.reconcileTopologySpreadConstraints(cr)
-
-	if m.TerminationGracePeriodSeconds == nil || (!cr.Spec.UnsafeConf && *m.TerminationGracePeriodSeconds < 30) {
-		m.TerminationGracePeriodSeconds = new(int64)
-		*m.TerminationGracePeriodSeconds = 60
+	if cr.CompareVersion("1.15.0") >= 0 {
+		if m.TerminationGracePeriodSeconds == nil || (!cr.Spec.UnsafeConf && *m.TerminationGracePeriodSeconds < 30) {
+			m.TerminationGracePeriodSeconds = new(int64)
+			*m.TerminationGracePeriodSeconds = 60
+		}
 	}
-
 	if m.PodDisruptionBudget == nil {
 		defaultMaxUnavailable := intstr.FromInt(1)
 		m.PodDisruptionBudget = &PodDisruptionBudgetSpec{MaxUnavailable: &defaultMaxUnavailable}

--- a/pkg/controller/perconaservermongodb/connections.go
+++ b/pkg/controller/perconaservermongodb/connections.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
@@ -63,6 +64,10 @@ func (r *ReconcilePerconaServerMongoDB) mongosClientWithRole(ctx context.Context
 	return r.MongoClientProvider().Mongos(ctx, cr, role)
 }
 
-func (r *ReconcilePerconaServerMongoDB) standaloneClientWithRole(ctx context.Context, cr *api.PerconaServerMongoDB, role api.UserRole, host string) (mongo.Client, error) {
+func (r *ReconcilePerconaServerMongoDB) standaloneClientWithRole(ctx context.Context, cr *api.PerconaServerMongoDB, rs *api.ReplsetSpec, role api.UserRole, pod corev1.Pod) (mongo.Client, error) {
+	host, err := psmdb.MongoHost(ctx, r.client, cr, cr.Spec.ClusterServiceDNSMode, rs.Name, rs.Expose.Enabled, pod)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get mongo host")
+	}
 	return r.MongoClientProvider().Standalone(ctx, cr, role, host)
 }

--- a/pkg/controller/perconaservermongodb/status.go
+++ b/pkg/controller/perconaservermongodb/status.go
@@ -340,7 +340,7 @@ func (r *ReconcilePerconaServerMongoDB) mongosStatus(ctx context.Context, cr *ap
 		for _, cond := range pod.Status.Conditions {
 			switch cond.Type {
 			case corev1.ContainersReady:
-				if cond.Status == corev1.ConditionTrue {
+				if cond.Status == corev1.ConditionTrue && pod.DeletionTimestamp == nil {
 					status.Ready++
 				}
 			case corev1.PodScheduled:
@@ -357,7 +357,7 @@ func (r *ReconcilePerconaServerMongoDB) mongosStatus(ctx context.Context, cr *ap
 		status.Status = api.AppStateStopping
 	case cr.Spec.Pause:
 		status.Status = api.AppStatePaused
-	case status.Size > 0 && status.Size == status.Ready:
+	case status.Size > 0 && status.Size == status.Ready && status.Size == int(cr.Spec.Sharding.Mongos.Size):
 		status.Status = api.AppStateReady
 	}
 

--- a/pkg/psmdb/client.go
+++ b/pkg/psmdb/client.go
@@ -22,6 +22,9 @@ func MongoClient(ctx context.Context, k8sclient client.Client, cr *api.PerconaSe
 		return nil, errors.Wrapf(err, "get pods list for replset %s", rs.Name)
 	}
 
+	// `GetRSPods` returns truncated list of pods.
+	// If `rs.Size` is 0 or replicaset doesn't exist in the cr the list of pods will be empty.
+	// If there is empty pod list we should use `GetOutdatedRSPods` which returns list of pods without truncating it.
 	if len(pods.Items) == 0 {
 		pods, err = GetOutdatedRSPods(ctx, k8sclient, cr, rs.Name)
 		if err != nil {

--- a/pkg/psmdb/client.go
+++ b/pkg/psmdb/client.go
@@ -22,6 +22,13 @@ func MongoClient(ctx context.Context, k8sclient client.Client, cr *api.PerconaSe
 		return nil, errors.Wrapf(err, "get pods list for replset %s", rs.Name)
 	}
 
+	if len(pods.Items) == 0 {
+		pods, err = GetOutdatedRSPods(ctx, k8sclient, cr, rs.Name)
+		if err != nil {
+			return nil, errors.Wrapf(err, "get outdated pods list for replset %s", rs.Name)
+		}
+	}
+
 	rsAddrs, err := GetReplsetAddrs(ctx, k8sclient, cr, cr.Spec.ClusterServiceDNSMode, rs.Name, false, pods.Items)
 	if err != nil {
 		return nil, errors.Wrap(err, "get replset addr")

--- a/pkg/psmdb/getters.go
+++ b/pkg/psmdb/getters.go
@@ -37,10 +37,12 @@ func MongosLabels(cr *api.PerconaServerMongoDB) map[string]string {
 	return lbls
 }
 
+// GetRSPods returns truncated list of replicaset pods to the size of `rs.Size`.
 func GetRSPods(ctx context.Context, k8sclient client.Client, cr *api.PerconaServerMongoDB, rsName string) (corev1.PodList, error) {
 	return getRSPods(ctx, k8sclient, cr, rsName, true)
 }
 
+// GetOutdatedRSPods does the same as GetRSPods but doesn't truncate the list of pods
 func GetOutdatedRSPods(ctx context.Context, k8sclient client.Client, cr *api.PerconaServerMongoDB, rsName string) (corev1.PodList, error) {
 	return getRSPods(ctx, k8sclient, cr, rsName, false)
 }

--- a/pkg/psmdb/mongo/fake/client.go
+++ b/pkg/psmdb/mongo/fake/client.go
@@ -128,6 +128,10 @@ func (c *fakeMongoClient) StepDown(ctx context.Context, force bool) error {
 	return nil
 }
 
+func (c *fakeMongoClient) Freeze(ctx context.Context, seconds int) error {
+	return nil
+}
+
 func (c *fakeMongoClient) IsMaster(ctx context.Context) (*mongo.IsMasterResp, error) {
 	return nil, nil
 }

--- a/pkg/psmdb/mongo/fake/client.go
+++ b/pkg/psmdb/mongo/fake/client.go
@@ -124,7 +124,7 @@ func (c *fakeMongoClient) RSBuildInfo(ctx context.Context) (mongo.BuildInfo, err
 	return mongo.BuildInfo{}, nil
 }
 
-func (c *fakeMongoClient) StepDown(ctx context.Context, force bool) error {
+func (c *fakeMongoClient) StepDown(ctx context.Context, seconds int, force bool) error {
 	return nil
 }
 

--- a/pkg/psmdb/mongo/mongo.go
+++ b/pkg/psmdb/mongo/mongo.go
@@ -50,7 +50,7 @@ type Client interface {
 	ListShard(ctx context.Context) (ShardList, error)
 	RemoveShard(ctx context.Context, shard string) (ShardRemoveResp, error)
 	RSBuildInfo(ctx context.Context) (BuildInfo, error)
-	StepDown(ctx context.Context, force bool) error
+	StepDown(ctx context.Context, seconds int, force bool) error
 	Freeze(ctx context.Context, seconds int) error
 	IsMaster(ctx context.Context) (*IsMasterResp, error)
 	GetUserInfo(ctx context.Context, username string) (*User, error)
@@ -489,10 +489,10 @@ func (client *mongoClient) RSBuildInfo(ctx context.Context) (BuildInfo, error) {
 	return bi, nil
 }
 
-func (client *mongoClient) StepDown(ctx context.Context, force bool) error {
+func (client *mongoClient) StepDown(ctx context.Context, seconds int, force bool) error {
 	resp := OKResponse{}
 
-	res := client.Database("admin").RunCommand(ctx, bson.D{{Key: "replSetStepDown", Value: 60}, {Key: "force", Value: force}})
+	res := client.Database("admin").RunCommand(ctx, bson.D{{Key: "replSetStepDown", Value: seconds}, {Key: "force", Value: force}})
 	err := res.Err()
 	if err != nil {
 		cErr, ok := err.(mongo.CommandError)


### PR DESCRIPTION
[![K8SPSMDB-980](https://badgen.net/badge/JIRA/K8SPSMDB-980/green)](https://jira.percona.com/browse/K8SPSMDB-980) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://jira.percona.com/browse/K8SPSMDB-980

**DESCRIPTION**
---
This pull request includes multiple fixes.

The first one is to avoid returning when the `deleteRSPods` function fails. This function resizes replsets. If we have multiple replsets, returning on a single failed call will not resize the other replsets. This can lead to statefulset resize scenarios such as `1->3, 3->1...`.

The second one is to sort the pod list in the `deleteRSPods` method. Here we check if the first pod in the list is primary. Getting an unsorted list will lead to unexpected behavior.

The third one is to use replset size instead of statefulset size while truncating the pod list in the `GetRSPods` function. In some occasions, the statefulset size does not have time to be updated until the `replSetReconfig` call. That means that `rs.Size` and `sts.Spec.Replicas` are different and will lead to inserting pods, which are going to be deleted, into the configuration.

These fixes are already fixing the problem. But on very rare occasions we still get the `ReplicaSetNoPrimary` error, because there can be scenarios when there is no time for the primary to be assigned in a termination grace period.

So, we should force the first pod to become primary. Only after that should we start resizing the replica set.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?