### PR TITLE
K8SPSMDB-886 - Fix init-deploy test for 6.0 and remove some minikube tests

### DIFF
--- a/e2e-tests/init-deploy/compare/backup-60.json
+++ b/e2e-tests/init-deploy/compare/backup-60.json
@@ -39,9 +39,11 @@
           "convertToCapped",
           "createCollection",
           "createIndex",
+          "createSearchIndexes",
           "dropCollection",
           "find",
-          "insert"
+          "insert",
+          "updateSearchIndex"
         ]
       },
       {
@@ -59,6 +61,7 @@
           "createCollection",
           "createIndex",
           "createRole",
+          "createSearchIndexes",
           "createUser",
           "dbStats",
           "dropCollection",
@@ -73,6 +76,7 @@
           "revokeRole",
           "setAuthenticationRestriction",
           "startBackup",
+          "updateSearchIndex",
           "viewRole",
           "viewUser"
         ]
@@ -88,9 +92,11 @@
           "convertToCapped",
           "createCollection",
           "createIndex",
+          "createSearchIndexes",
           "dropCollection",
           "find",
-          "insert"
+          "insert",
+          "updateSearchIndex"
         ]
       },
       {
@@ -113,11 +119,13 @@
           "convertToCapped",
           "createCollection",
           "createIndex",
+          "createSearchIndexes",
           "dropCollection",
           "find",
           "insert",
           "remove",
-          "update"
+          "update",
+          "updateSearchIndex"
         ]
       },
       {
@@ -132,19 +140,23 @@
           "convertToCapped",
           "createCollection",
           "createIndex",
+          "createSearchIndexes",
           "dbHash",
           "dbStats",
           "dropCollection",
           "dropIndex",
+          "dropSearchIndex",
           "find",
           "insert",
           "killCursors",
           "listCollections",
           "listIndexes",
+          "listSearchIndexes",
           "planCacheRead",
           "remove",
           "renameCollectionSameDB",
-          "update"
+          "update",
+          "updateSearchIndex"
         ]
       },
       {
@@ -158,9 +170,11 @@
           "convertToCapped",
           "createCollection",
           "createIndex",
+          "createSearchIndexes",
           "dropCollection",
           "find",
-          "insert"
+          "insert",
+          "updateSearchIndex"
         ]
       },
       {
@@ -175,19 +189,23 @@
           "convertToCapped",
           "createCollection",
           "createIndex",
+          "createSearchIndexes",
           "dbHash",
           "dbStats",
           "dropCollection",
           "dropIndex",
+          "dropSearchIndex",
           "find",
           "insert",
           "killCursors",
           "listCollections",
           "listIndexes",
+          "listSearchIndexes",
           "planCacheRead",
           "remove",
           "renameCollectionSameDB",
-          "update"
+          "update",
+          "updateSearchIndex"
         ]
       },
       {
@@ -197,6 +215,7 @@
         },
         "actions": [
           "createIndex",
+          "createSearchIndexes",
           "find"
         ]
       },
@@ -211,9 +230,11 @@
           "convertToCapped",
           "createCollection",
           "createIndex",
+          "createSearchIndexes",
           "dropCollection",
           "find",
-          "insert"
+          "insert",
+          "updateSearchIndex"
         ]
       },
       {
@@ -247,6 +268,7 @@
           "convertToCapped",
           "createCollection",
           "createIndex",
+          "createSearchIndexes",
           "dbHash",
           "dbStats",
           "dropCollection",
@@ -258,7 +280,9 @@
           "killCursors",
           "listCollections",
           "listIndexes",
-          "planCacheRead"
+          "listSearchIndexes",
+          "planCacheRead",
+          "updateSearchIndex"
         ]
       },
       {
@@ -286,6 +310,7 @@
           "killCursors",
           "listCollections",
           "listIndexes",
+          "listSearchIndexes",
           "planCacheRead"
         ]
       },
@@ -315,6 +340,7 @@
           "convertToCapped",
           "createCollection",
           "createIndex",
+          "createSearchIndexes",
           "dbHash",
           "dbStats",
           "dropCollection",
@@ -326,7 +352,9 @@
           "killCursors",
           "listCollections",
           "listIndexes",
-          "planCacheRead"
+          "listSearchIndexes",
+          "planCacheRead",
+          "updateSearchIndex"
         ]
       },
       {
@@ -340,9 +368,11 @@
           "convertToCapped",
           "createCollection",
           "createIndex",
+          "createSearchIndexes",
           "dropCollection",
           "find",
-          "insert"
+          "insert",
+          "updateSearchIndex"
         ]
       },
       {
@@ -356,9 +386,11 @@
           "convertToCapped",
           "createCollection",
           "createIndex",
+          "createSearchIndexes",
           "dropCollection",
           "find",
-          "insert"
+          "insert",
+          "updateSearchIndex"
         ]
       },
       {
@@ -375,6 +407,7 @@
           "killCursors",
           "listCollections",
           "listIndexes",
+          "listSearchIndexes",
           "planCacheRead"
         ]
       },
@@ -389,9 +422,11 @@
           "convertToCapped",
           "createCollection",
           "createIndex",
+          "createSearchIndexes",
           "dropCollection",
           "find",
-          "insert"
+          "insert",
+          "updateSearchIndex"
         ]
       },
       {

--- a/e2e-tests/init-deploy/compare/clusterAdmin-60.json
+++ b/e2e-tests/init-deploy/compare/clusterAdmin-60.json
@@ -78,6 +78,7 @@
           "killCursors",
           "listCollections",
           "listIndexes",
+          "listSearchIndexes",
           "moveChunk",
           "planCacheRead",
           "refineCollectionShardKey",
@@ -102,6 +103,7 @@
           "killCursors",
           "listCollections",
           "listIndexes",
+          "listSearchIndexes",
           "planCacheRead"
         ]
       },
@@ -138,6 +140,7 @@
           "killCursors",
           "listCollections",
           "listIndexes",
+          "listSearchIndexes",
           "moveChunk",
           "planCacheRead",
           "refineCollectionShardKey",
@@ -186,6 +189,7 @@
           "killCursors",
           "listCollections",
           "listIndexes",
+          "listSearchIndexes",
           "planCacheRead"
         ]
       },
@@ -203,6 +207,7 @@
           "killCursors",
           "listCollections",
           "listIndexes",
+          "listSearchIndexes",
           "planCacheRead"
         ]
       },
@@ -220,6 +225,7 @@
           "killCursors",
           "listCollections",
           "listIndexes",
+          "listSearchIndexes",
           "planCacheRead"
         ]
       },

--- a/e2e-tests/init-deploy/compare/clusterMonitor-60.json
+++ b/e2e-tests/init-deploy/compare/clusterMonitor-60.json
@@ -67,6 +67,7 @@
           "killCursors",
           "listCollections",
           "listIndexes",
+          "listSearchIndexes",
           "planCacheRead"
         ]
       },
@@ -84,6 +85,7 @@
           "killCursors",
           "listCollections",
           "listIndexes",
+          "listSearchIndexes",
           "planCacheRead"
         ]
       },
@@ -117,6 +119,7 @@
           "killCursors",
           "listCollections",
           "listIndexes",
+          "listSearchIndexes",
           "planCacheRead"
         ]
       },
@@ -152,6 +155,7 @@
           "killCursors",
           "listCollections",
           "listIndexes",
+          "listSearchIndexes",
           "planCacheRead"
         ]
       },

--- a/e2e-tests/init-deploy/compare/userAdmin-60.json
+++ b/e2e-tests/init-deploy/compare/userAdmin-60.json
@@ -47,6 +47,7 @@
           "killCursors",
           "listCollections",
           "listIndexes",
+          "listSearchIndexes",
           "planCacheRead"
         ]
       },
@@ -64,6 +65,7 @@
           "killCursors",
           "listCollections",
           "listIndexes",
+          "listSearchIndexes",
           "planCacheRead"
         ]
       },
@@ -76,13 +78,16 @@
           "changeStream",
           "collStats",
           "createIndex",
+          "createSearchIndexes",
           "dbHash",
           "dbStats",
           "dropIndex",
+          "dropSearchIndex",
           "find",
           "killCursors",
           "listCollections",
           "listIndexes",
+          "listSearchIndexes",
           "planCacheRead"
         ]
       },
@@ -95,13 +100,16 @@
           "changeStream",
           "collStats",
           "createIndex",
+          "createSearchIndexes",
           "dbHash",
           "dbStats",
           "dropIndex",
+          "dropSearchIndex",
           "find",
           "killCursors",
           "listCollections",
           "listIndexes",
+          "listSearchIndexes",
           "planCacheRead"
         ]
       },
@@ -119,6 +127,7 @@
           "killCursors",
           "listCollections",
           "listIndexes",
+          "listSearchIndexes",
           "planCacheRead"
         ]
       },

--- a/e2e-tests/run-minikube.csv
+++ b/e2e-tests/run-minikube.csv
@@ -1,10 +1,7 @@
 arbiter
-balancer
-custom-replset-name
 default-cr
 demand-backup
 demand-backup-physical
-finalizer
 limits
 liveness
 mongod-major-upgrade


### PR DESCRIPTION
[![K8SPSMDB-886](https://badgen.net/badge/JIRA/K8SPSMDB-886/green)](https://jira.percona.com/browse/K8SPSMDB-886) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
*Short explanation of the problem.*

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?