### PR TITLE
K8SPSMDB-886 - Add cluster wide run for PR tests and fix some tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -244,6 +244,7 @@ pipeline {
     environment {
         CLOUDSDK_CORE_DISABLE_PROMPTS = 1
         CLEAN_NAMESPACE = 1
+        OPERATOR_NS = 'psmdb-operator'
         GIT_SHORT_COMMIT = sh(script: 'git rev-parse --short HEAD', , returnStdout: true).trim()
         VERSION = "${env.GIT_BRANCH}-${env.GIT_SHORT_COMMIT}"
         CLUSTER_NAME = sh(script: "echo jen-psmdb-${env.CHANGE_ID}-${GIT_SHORT_COMMIT}-${env.BUILD_NUMBER} | tr '[:upper:]' '[:lower:]'", , returnStdout: true).trim()

--- a/e2e-tests/custom-replset-name/conf/backup-aws-s3.yml
+++ b/e2e-tests/custom-replset-name/conf/backup-aws-s3.yml
@@ -1,7 +1,0 @@
-apiVersion: psmdb.percona.com/v1
-kind: PerconaServerMongoDBBackup
-metadata:
-  name: backup-aws-s3
-spec:
-  psmdbCluster: some-name
-  storageName: aws-s3

--- a/e2e-tests/custom-replset-name/conf/backup-gcp-cs.yml
+++ b/e2e-tests/custom-replset-name/conf/backup-gcp-cs.yml
@@ -1,7 +1,0 @@
-apiVersion: psmdb.percona.com/v1
-kind: PerconaServerMongoDBBackup
-metadata:
-  name: backup-gcp-cs
-spec:
-  psmdbCluster: some-name
-  storageName: gcp-cs

--- a/e2e-tests/custom-replset-name/run
+++ b/e2e-tests/custom-replset-name/run
@@ -6,8 +6,7 @@ set -o xtrace
 test_dir=$(realpath $(dirname $0))
 . ${test_dir}/../functions
 
-create_namespace $namespace
-deploy_operator
+create_infra $namespace
 apply_s3_storage_secrets
 deploy_minio
 
@@ -42,31 +41,11 @@ wait_backup_agent $cluster-shard5-2
 wait_backup_agent $cluster-shard7-0
 wait_backup_agent $cluster-shard7-1
 wait_backup_agent $cluster-shard7-2
-backup_name_aws="backup-aws-s3"
 backup_name_minio="backup-minio"
-backup_name_gcp="backup-gcp-cs"
 
 desc 'run backups'
 run_backup minio
 wait_backup "$backup_name_minio"
-
-if [ -z "$SKIP_BACKUPS_TO_AWS_GCP_AZURE" ]; then
-	run_backup aws-s3
-	run_backup gcp-cs
-
-	wait_backup "$backup_name_aws"
-	wait_backup "$backup_name_gcp"
-fi
-
-if [ -z "$SKIP_BACKUPS_TO_AWS_GCP_AZURE" ]; then
-	desc 'check backup and restore -- aws-s3'
-	run_restore $backup_name_aws 3 1 "-mongos"
-	wait_restore $backup_name_aws $cluster "ready"
-
-	desc 'check backup and restore -- gcp-cs'
-	run_restore $backup_name_gcp 3 1 "-mongos"
-	wait_restore $backup_name_gcp $cluster "ready"
-fi
 
 desc 'check backup and restore -- minio'
 run_restore $backup_name_minio 3 1 "-mongos"

--- a/e2e-tests/expose-sharded/run
+++ b/e2e-tests/expose-sharded/run
@@ -112,7 +112,7 @@ function main() {
 	wait_for_running $cluster-rs0 3
 	wait_for_running $cluster-cfg 3 "false"
 	wait_for_running $cluster-mongos 3
-	wait_cluster_consistency "${cluster}" 3
+	wait_cluster_consistency "${cluster}"
 
 	desc 'check if service and statefulset created with expected config'
 	compare_kubectl statefulset/$cluster-rs0
@@ -141,7 +141,7 @@ function main() {
 	wait_for_running $cluster-rs0 3
 	wait_for_running $cluster-cfg 3 "false"
 	wait_for_running $cluster-mongos 3
-	wait_cluster_consistency "${cluster}" 3
+	wait_cluster_consistency "${cluster}"
 
 	run_mongos \
 		'use myApp\n db.test.insert({ x: 100501 })' \
@@ -159,7 +159,7 @@ function main() {
 	wait_for_running $cluster-rs0 3
 	wait_for_running $cluster-cfg 3 "false"
 	wait_for_running $cluster-mongos 3
-	wait_cluster_consistency "${cluster}" 3
+	wait_cluster_consistency "${cluster}"
 
 	run_mongos \
 		'use myApp\n db.test.insert({ x: 100502 })' \
@@ -190,7 +190,7 @@ function main() {
 	wait_for_running $cluster-rs0 3
 	wait_for_running $cluster-cfg 3 "false"
 	wait_for_running $cluster-mongos 3
-	wait_cluster_consistency "${cluster}" 3
+	wait_cluster_consistency "${cluster}"
 
 	run_mongos \
 		'use myApp\n db.test.insert({ x: 100504 })' \
@@ -207,7 +207,7 @@ function main() {
 	wait_for_running $cluster-rs0 3
 	wait_for_running $cluster-cfg 3 "false"
 	wait_for_running $cluster-mongos 3
-	wait_cluster_consistency "${cluster}" 3
+	wait_cluster_consistency "${cluster}"
 
 	run_mongos \
 		'use myApp\n db.test.insert({ x: 100505 })' \

--- a/e2e-tests/multi-cluster-service/run
+++ b/e2e-tests/multi-cluster-service/run
@@ -98,7 +98,7 @@ desc 'check if all 3 Pods started'
 wait_for_running $cluster-rs0 3
 wait_for_running $cluster-cfg 3 "false"
 wait_for_running $cluster-mongos 3
-wait_cluster_consistency "${cluster}" 3
+wait_cluster_consistency "${cluster}"
 
 desc "enable MCS"
 kubectl_bin patch psmdb ${cluster} --type json -p='[{"op":"add","path":"/spec/multiCluster/enabled","value":true}]'
@@ -106,7 +106,7 @@ kubectl_bin patch psmdb ${cluster} --type json -p='[{"op":"add","path":"/spec/mu
 desc "check if ServiceExport objects are created"
 wait_service_export
 wait_service_import
-wait_cluster_consistency "${cluster}" 3
+wait_cluster_consistency "${cluster}"
 
 desc "delete cluster membership"
 gcloud container fleet memberships delete $k8s_cluster_name --quiet

--- a/e2e-tests/operator-self-healing-chaos/run
+++ b/e2e-tests/operator-self-healing-chaos/run
@@ -18,7 +18,7 @@ setup_cluster() {
 
 	# check if all 3 Pods started
 	wait_for_running "$cluster" 3
-	wait_cluster_consistency "${cluster/-rs0/}" 3
+	wait_cluster_consistency "${cluster/-rs0/}"
 }
 
 fail_pod() {
@@ -61,7 +61,7 @@ fail_pod() {
 	# check scale down
 	wait_for_delete pod/$cluster-3
 	wait_for_running "$cluster" 3
-	wait_cluster_consistency "${cluster/-rs0/}" 3
+	wait_cluster_consistency "${cluster/-rs0/}"
 }
 
 kill_pod() {
@@ -87,7 +87,7 @@ kill_pod() {
 
 	# check scale up
 	wait_for_running "$cluster" 5
-	wait_cluster_consistency "${cluster/-rs0/}" 5
+	wait_cluster_consistency "${cluster/-rs0/}"
 }
 
 network_loss() {
@@ -108,7 +108,7 @@ network_loss() {
 
 	# check scale up
 	wait_for_running "$cluster" 5
-	wait_cluster_consistency "${cluster/-rs0/}" 5
+	wait_cluster_consistency "${cluster/-rs0/}"
 }
 
 main() {

--- a/e2e-tests/pitr-physical/run
+++ b/e2e-tests/pitr-physical/run
@@ -69,7 +69,7 @@ check_recovery() {
 		| if [ -z "$restore_date" ]; then $sed -e "/date:/d"; else $sed -e "s/date:/date: $restore_date/"; fi \
 		| kubectl_bin apply -f -
 
-	wait_restore "$backup_name" "$cluster_name"
+	wait_restore "$backup_name" "$cluster_name" "ready" "1" "1000"
 	echo
 	set -o xtrace
 

--- a/e2e-tests/rs-shard-migration/run
+++ b/e2e-tests/rs-shard-migration/run
@@ -35,7 +35,7 @@ function main() {
 	sleep 10
 	wait_for_running "${cluster}-rs0" "${CLUSTER_SIZE}" "false"
 	wait_for_running "${cluster}-cfg" "${CLUSTER_SIZE}" "false"
-	wait_cluster_consistency "${cluster}" "${CLUSTER_SIZE}"
+	wait_cluster_consistency "${cluster}"
 
 	if [[ $(kubectl_bin get statefulset/${cluster}-mongos -o jsonpath='{.status.readyReplicas}') -lt 1 ]]; then
 		echo "Mongos hasn't been properly started. Exiting..."
@@ -62,7 +62,7 @@ function main() {
 	kubectl_bin patch psmdb/${cluster} --type json -p='[{"op":"remove","path":"/spec/sharding"}]'
 	sleep 20
 	wait_for_running "${cluster}-rs0" "${CLUSTER_SIZE}" "true"
-	wait_cluster_consistency "${cluster}" "${CLUSTER_SIZE}"
+	wait_cluster_consistency "${cluster}"
 	simple_data_check "${cluster}-rs0" "${CLUSTER_SIZE}"
 
 	if [[ -n "$(get_shard_parameter ${cluster} ${namespace} lastCommitedOpTime)" ]] \

--- a/e2e-tests/smart-update/run
+++ b/e2e-tests/smart-update/run
@@ -17,7 +17,7 @@ function check_pod_update() {
 		sleep 1
 		echo -n .
 		let retry+=1
-		img=$(kubectl get pod/${pod_name} -o jsonpath='{.spec.containers[0].image}')
+		img=$(kubectl get pod/${pod_name} -o jsonpath='{.spec.containers[0].image}' || echo "ERROR_GETTING_POD")
 		if [ "${img}" == "${IMAGE_MONGOD_TO_UPDATE}" ]; then
 			echo "OK: Image ${img} was updated for pod ${pod_name}!"
 			break

--- a/e2e-tests/upgrade-sharded/run
+++ b/e2e-tests/upgrade-sharded/run
@@ -86,7 +86,7 @@ function check_applied_images() {
 
 	case "${updated_image}" in
 		"operator")
-			if [[ ${TARGET_IMAGE} == $(kubectl_bin get pod --selector=name="${OPERATOR_NAME}" -o jsonpath='{.items[*].spec.containers[?(@.name == "'"${OPERATOR_NAME}"'")].image}') &&
+			if [[ ${TARGET_IMAGE} == $(kubectl_bin get pod ${OPERATOR_NS:+-n $OPERATOR_NS} --selector=name="${OPERATOR_NAME}" -o jsonpath='{.items[*].spec.containers[?(@.name == "'"${OPERATOR_NAME}"'")].image}') &&
 			${IMAGE_BACKUP} == $(kubectl_bin get psmdb "${cluster}" -o jsonpath='{.spec.backup.image}') &&
 			${IMAGE_PMM} == $(kubectl_bin get psmdb "${cluster}" -o jsonpath='{.spec.pmm.image}') &&
 			${IMAGE_MONGOD} == $(kubectl_bin get psmdb "${cluster}" -o jsonpath='{.spec.image}') ]]; then
@@ -97,7 +97,7 @@ function check_applied_images() {
 			fi
 			;;
 		"all")
-			if [[ ${TARGET_IMAGE} == $(kubectl_bin get pod --selector=name="${OPERATOR_NAME}" -o jsonpath='{.items[*].spec.containers[?(@.name == "'"${OPERATOR_NAME}"'")].image}') &&
+			if [[ ${TARGET_IMAGE} == $(kubectl_bin get pod ${OPERATOR_NS:+-n $OPERATOR_NS} --selector=name="${OPERATOR_NAME}" -o jsonpath='{.items[*].spec.containers[?(@.name == "'"${OPERATOR_NAME}"'")].image}') &&
 			${TARGET_IMAGE_BACKUP} == $(kubectl_bin get psmdb "${cluster}" -o jsonpath='{.spec.backup.image}') &&
 			${TARGET_IMAGE_PMM} == $(kubectl_bin get psmdb "${cluster}" -o jsonpath='{.spec.pmm.image}') &&
 			${TARGET_IMAGE_MONGOD} == $(kubectl_bin get psmdb "${cluster}" -o jsonpath='{.spec.image}') ]]; then
@@ -179,7 +179,7 @@ function main() {
 	desc 'check if all Pods started'
 	wait_for_running "${cluster}-rs0" "${CLUSTER_SIZE}" "false"
 	wait_for_running "${cluster}-cfg" "${CLUSTER_SIZE}" "false"
-	wait_cluster_consistency "${cluster}" "${CLUSTER_SIZE}"
+	wait_cluster_consistency "${cluster}"
 
 	desc 'create user myApp'
 	run_mongos 'db.createUser({user: "myApp", pwd: "myPass", roles: [{ db: "myApp", role: "readWrite" }]})' \
@@ -223,7 +223,7 @@ function main() {
 	desc 'check images and generation after operator upgrade'
 	wait_for_running "${cluster}-rs0" "${CLUSTER_SIZE}" "false"
 	wait_for_running "${cluster}-cfg" "${CLUSTER_SIZE}" "false"
-	wait_cluster_consistency "${cluster}" "${CLUSTER_SIZE}"
+	wait_cluster_consistency "${cluster}"
 
 	check_applied_images "operator"
 	compare_generation "1" "statefulset" "${cluster}-rs0"
@@ -244,7 +244,7 @@ function main() {
 	desc 'check cluster after full upgrade'
 	wait_for_running "${cluster}-rs0" "${CLUSTER_SIZE}" "false"
 	wait_for_running "${cluster}-cfg" "${CLUSTER_SIZE}" "false"
-	wait_cluster_consistency "${cluster}" "${CLUSTER_SIZE}"
+	wait_cluster_consistency "${cluster}"
 	simple_data_check "${cluster}" "${CLUSTER_SIZE}" 1 "-mongos"
 	check_applied_images "all"
 	compare_generation "2" "statefulset" "${cluster}-rs0"

--- a/e2e-tests/upgrade/run
+++ b/e2e-tests/upgrade/run
@@ -88,7 +88,7 @@ function check_applied_images() {
 
 	case "${updated_image}" in
 		"operator")
-			if [[ ${TARGET_IMAGE} == $(kubectl_bin get pod --selector=name="${OPERATOR_NAME}" -o jsonpath='{.items[*].spec.containers[?(@.name == "'"${OPERATOR_NAME}"'")].image}') &&
+			if [[ ${TARGET_IMAGE} == $(kubectl_bin get pod ${OPERATOR_NS:+-n $OPERATOR_NS} --selector=name="${OPERATOR_NAME}" -o jsonpath='{.items[*].spec.containers[?(@.name == "'"${OPERATOR_NAME}"'")].image}') &&
 			${IMAGE_BACKUP} == $(kubectl_bin get psmdb "${cluster}" -o jsonpath='{.spec.backup.image}') &&
 			${IMAGE_PMM} == $(kubectl_bin get psmdb "${cluster}" -o jsonpath='{.spec.pmm.image}') &&
 			${IMAGE_MONGOD} == $(kubectl_bin get psmdb "${cluster}" -o jsonpath='{.spec.image}') ]]; then
@@ -99,7 +99,7 @@ function check_applied_images() {
 			fi
 			;;
 		"all")
-			if [[ ${TARGET_IMAGE} == $(kubectl_bin get pod --selector=name="${OPERATOR_NAME}" -o jsonpath='{.items[*].spec.containers[?(@.name == "'"${OPERATOR_NAME}"'")].image}') &&
+			if [[ ${TARGET_IMAGE} == $(kubectl_bin get pod ${OPERATOR_NS:+-n $OPERATOR_NS} --selector=name="${OPERATOR_NAME}" -o jsonpath='{.items[*].spec.containers[?(@.name == "'"${OPERATOR_NAME}"'")].image}') &&
 			${TARGET_IMAGE_BACKUP} == $(kubectl_bin get psmdb "${cluster}" -o jsonpath='{.spec.backup.image}') &&
 			${TARGET_IMAGE_PMM} == $(kubectl_bin get psmdb "${cluster}" -o jsonpath='{.spec.pmm.image}') &&
 			${TARGET_IMAGE_MONGOD} == $(kubectl_bin get psmdb "${cluster}" -o jsonpath='{.spec.image}') ]]; then
@@ -184,7 +184,7 @@ function main() {
 	kubectl_bin rollout status deployment/"${OPERATOR_NAME}" ${OPERATOR_NS:+-n $OPERATOR_NS}
 
 	desc 'wait for operator upgrade'
-	until [[ $(kubectl_bin get pods --selector=name="${OPERATOR_NAME}" \
+	until [[ $(kubectl_bin get pods ${OPERATOR_NS:+-n $OPERATOR_NS} --selector=name="${OPERATOR_NAME}" \
 		-o custom-columns='NAME:.metadata.name,IMAGE:.spec.containers[0].image' \
 		| grep -vc 'NAME' | awk '{print $1}') -eq 1 ]]; do
 		sleep 5
@@ -209,7 +209,7 @@ function main() {
 
 	desc 'check cluster after full upgrade'
 	wait_for_running "${cluster}-rs0" "${CLUSTER_SIZE}"
-	wait_cluster_consistency "${cluster}" "${CLUSTER_SIZE}"
+	wait_cluster_consistency "${cluster}"
 	simple_data_check "${cluster}-rs0" "${CLUSTER_SIZE}"
 	check_applied_images "all"
 	compare_generation "2" "statefulset" "${cluster}-rs0"


### PR DESCRIPTION
[![K8SPSMDB-886](https://badgen.net/badge/JIRA/K8SPSMDB-886/green)](https://jira.percona.com/browse/K8SPSMDB-886) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
1. Change PR tests to run with cluster wide mode enabled
2. Some tests were calling `wait_cluster_consistency` function with non-existing/old second parameter for cluster size
3. Some tests were not checking things correctly in cluster wide mode`

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?