### PR TITLE
K8SPSMDB-991 - Add PMM_AGENT_PATHS_TEMPDIR env var for pmm-agent sidecar

### DIFF
--- a/e2e-tests/default-cr/run
+++ b/e2e-tests/default-cr/run
@@ -110,7 +110,17 @@ function main() {
 			"spec": {"pmm":{"enabled":false}}
 		}'
 	sleep 120
+
+	if [[ -n ${OPENSHIFT} ]]; then
+		oc adm policy remove-scc-from-user privileged -z pmm-server
+		if [ -n "$OPERATOR_NS" ]; then
+			oc delete clusterrolebinding pmm-psmdb-operator-cluster-wide
+		else
+			oc delete rolebinding pmm-psmdb-operator-namespace-only
+		fi
+	fi
 	helm uninstall monitoring
+
 	wait_cluster_consistency $cluster
 
 	desc 'enabling arbiter'

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-cfg-oc.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-cfg-oc.yml
@@ -213,8 +213,6 @@ spec:
               value: push
             - name: PMM_ADMIN_CUSTOM_PARAMS
               value: --enable-all-collectors --environment=dev-mongod
-            - name: PMM_AGENT_PATHS_TEMPDIR
-              value: /tmp
             - name: PMM_AGENT_SERVER_USERNAME
               value: api_key
             - name: PMM_AGENT_SERVER_PASSWORD
@@ -234,6 +232,8 @@ spec:
               value: "true"
             - name: PMM_AGENT_SIDECAR_SLEEP
               value: "5"
+            - name: PMM_AGENT_PATHS_TEMPDIR
+              value: /tmp
           imagePullPolicy: Always
           lifecycle:
             preStop:

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-cfg-oc.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-cfg-oc.yml
@@ -213,6 +213,8 @@ spec:
               value: push
             - name: PMM_ADMIN_CUSTOM_PARAMS
               value: --enable-all-collectors --environment=dev-mongod
+            - name: PMM_AGENT_PATHS_TEMPDIR
+              value: /data/db/pmm2/tmp
             - name: PMM_AGENT_SERVER_USERNAME
               value: api_key
             - name: PMM_AGENT_SERVER_PASSWORD

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-cfg-oc.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-cfg-oc.yml
@@ -214,7 +214,7 @@ spec:
             - name: PMM_ADMIN_CUSTOM_PARAMS
               value: --enable-all-collectors --environment=dev-mongod
             - name: PMM_AGENT_PATHS_TEMPDIR
-              value: /data/db/pmm2/tmp
+              value: /tmp
             - name: PMM_AGENT_SERVER_USERNAME
               value: api_key
             - name: PMM_AGENT_SERVER_PASSWORD

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-cfg.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-cfg.yml
@@ -214,6 +214,8 @@ spec:
               value: push
             - name: PMM_ADMIN_CUSTOM_PARAMS
               value: --enable-all-collectors --environment=dev-mongod
+            - name: PMM_AGENT_PATHS_TEMPDIR
+              value: /data/db/pmm2/tmp
             - name: PMM_AGENT_SERVER_USERNAME
               value: api_key
             - name: PMM_AGENT_SERVER_PASSWORD

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-cfg.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-cfg.yml
@@ -214,8 +214,6 @@ spec:
               value: push
             - name: PMM_ADMIN_CUSTOM_PARAMS
               value: --enable-all-collectors --environment=dev-mongod
-            - name: PMM_AGENT_PATHS_TEMPDIR
-              value: /tmp
             - name: PMM_AGENT_SERVER_USERNAME
               value: api_key
             - name: PMM_AGENT_SERVER_PASSWORD
@@ -235,6 +233,8 @@ spec:
               value: "true"
             - name: PMM_AGENT_SIDECAR_SLEEP
               value: "5"
+            - name: PMM_AGENT_PATHS_TEMPDIR
+              value: /tmp
           imagePullPolicy: Always
           lifecycle:
             preStop:

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-cfg.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-cfg.yml
@@ -215,7 +215,7 @@ spec:
             - name: PMM_ADMIN_CUSTOM_PARAMS
               value: --enable-all-collectors --environment=dev-mongod
             - name: PMM_AGENT_PATHS_TEMPDIR
-              value: /data/db/pmm2/tmp
+              value: /tmp
             - name: PMM_AGENT_SERVER_USERNAME
               value: api_key
             - name: PMM_AGENT_SERVER_PASSWORD

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-mongos-oc.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-mongos-oc.yml
@@ -215,8 +215,6 @@ spec:
               value: push
             - name: PMM_ADMIN_CUSTOM_PARAMS
               value: --environment=dev-mongos
-            - name: PMM_AGENT_PATHS_TEMPDIR
-              value: /tmp
             - name: PMM_AGENT_SERVER_USERNAME
               value: api_key
             - name: PMM_AGENT_SERVER_PASSWORD
@@ -236,6 +234,8 @@ spec:
               value: "true"
             - name: PMM_AGENT_SIDECAR_SLEEP
               value: "5"
+            - name: PMM_AGENT_PATHS_TEMPDIR
+              value: /tmp
           imagePullPolicy: Always
           lifecycle:
             preStop:

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-mongos-oc.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-mongos-oc.yml
@@ -215,6 +215,8 @@ spec:
               value: push
             - name: PMM_ADMIN_CUSTOM_PARAMS
               value: --environment=dev-mongos
+            - name: PMM_AGENT_PATHS_TEMPDIR
+              value: /data/db/pmm2/tmp
             - name: PMM_AGENT_SERVER_USERNAME
               value: api_key
             - name: PMM_AGENT_SERVER_PASSWORD

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-mongos-oc.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-mongos-oc.yml
@@ -216,7 +216,7 @@ spec:
             - name: PMM_ADMIN_CUSTOM_PARAMS
               value: --environment=dev-mongos
             - name: PMM_AGENT_PATHS_TEMPDIR
-              value: /data/db/pmm2/tmp
+              value: /tmp
             - name: PMM_AGENT_SERVER_USERNAME
               value: api_key
             - name: PMM_AGENT_SERVER_PASSWORD

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-mongos.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-mongos.yml
@@ -216,8 +216,6 @@ spec:
               value: push
             - name: PMM_ADMIN_CUSTOM_PARAMS
               value: --environment=dev-mongos
-            - name: PMM_AGENT_PATHS_TEMPDIR
-              value: /tmp
             - name: PMM_AGENT_SERVER_USERNAME
               value: api_key
             - name: PMM_AGENT_SERVER_PASSWORD
@@ -237,6 +235,8 @@ spec:
               value: "true"
             - name: PMM_AGENT_SIDECAR_SLEEP
               value: "5"
+            - name: PMM_AGENT_PATHS_TEMPDIR
+              value: /tmp
           imagePullPolicy: Always
           lifecycle:
             preStop:

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-mongos.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-mongos.yml
@@ -216,6 +216,8 @@ spec:
               value: push
             - name: PMM_ADMIN_CUSTOM_PARAMS
               value: --environment=dev-mongos
+            - name: PMM_AGENT_PATHS_TEMPDIR
+              value: /data/db/pmm2/tmp
             - name: PMM_AGENT_SERVER_USERNAME
               value: api_key
             - name: PMM_AGENT_SERVER_PASSWORD

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-mongos.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-mongos.yml
@@ -217,7 +217,7 @@ spec:
             - name: PMM_ADMIN_CUSTOM_PARAMS
               value: --environment=dev-mongos
             - name: PMM_AGENT_PATHS_TEMPDIR
-              value: /data/db/pmm2/tmp
+              value: /tmp
             - name: PMM_AGENT_SERVER_USERNAME
               value: api_key
             - name: PMM_AGENT_SERVER_PASSWORD

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0-oc.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0-oc.yml
@@ -202,7 +202,7 @@ spec:
             - name: PMM_ADMIN_CUSTOM_PARAMS
               value: --enable-all-collectors --environment=dev-mongod
             - name: PMM_AGENT_PATHS_TEMPDIR
-              value: /data/db/pmm2/tmp
+              value: /tmp
             - name: PMM_AGENT_SERVER_USERNAME
               value: api_key
             - name: PMM_AGENT_SERVER_PASSWORD

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0-oc.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0-oc.yml
@@ -201,8 +201,6 @@ spec:
               value: push
             - name: PMM_ADMIN_CUSTOM_PARAMS
               value: --enable-all-collectors --environment=dev-mongod
-            - name: PMM_AGENT_PATHS_TEMPDIR
-              value: /tmp
             - name: PMM_AGENT_SERVER_USERNAME
               value: api_key
             - name: PMM_AGENT_SERVER_PASSWORD
@@ -222,6 +220,8 @@ spec:
               value: "true"
             - name: PMM_AGENT_SIDECAR_SLEEP
               value: "5"
+            - name: PMM_AGENT_PATHS_TEMPDIR
+              value: /tmp
           imagePullPolicy: Always
           lifecycle:
             preStop:

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0-oc.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0-oc.yml
@@ -201,6 +201,8 @@ spec:
               value: push
             - name: PMM_ADMIN_CUSTOM_PARAMS
               value: --enable-all-collectors --environment=dev-mongod
+            - name: PMM_AGENT_PATHS_TEMPDIR
+              value: /data/db/pmm2/tmp
             - name: PMM_AGENT_SERVER_USERNAME
               value: api_key
             - name: PMM_AGENT_SERVER_PASSWORD

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0.yml
@@ -202,8 +202,6 @@ spec:
               value: push
             - name: PMM_ADMIN_CUSTOM_PARAMS
               value: --enable-all-collectors --environment=dev-mongod
-            - name: PMM_AGENT_PATHS_TEMPDIR
-              value: /tmp
             - name: PMM_AGENT_SERVER_USERNAME
               value: api_key
             - name: PMM_AGENT_SERVER_PASSWORD
@@ -223,6 +221,8 @@ spec:
               value: "true"
             - name: PMM_AGENT_SIDECAR_SLEEP
               value: "5"
+            - name: PMM_AGENT_PATHS_TEMPDIR
+              value: /tmp
           imagePullPolicy: Always
           lifecycle:
             preStop:

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0.yml
@@ -203,7 +203,7 @@ spec:
             - name: PMM_ADMIN_CUSTOM_PARAMS
               value: --enable-all-collectors --environment=dev-mongod
             - name: PMM_AGENT_PATHS_TEMPDIR
-              value: /data/db/pmm2/tmp
+              value: /tmp
             - name: PMM_AGENT_SERVER_USERNAME
               value: api_key
             - name: PMM_AGENT_SERVER_PASSWORD

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0.yml
@@ -202,6 +202,8 @@ spec:
               value: push
             - name: PMM_ADMIN_CUSTOM_PARAMS
               value: --enable-all-collectors --environment=dev-mongod
+            - name: PMM_AGENT_PATHS_TEMPDIR
+              value: /data/db/pmm2/tmp
             - name: PMM_AGENT_SERVER_USERNAME
               value: api_key
             - name: PMM_AGENT_SERVER_PASSWORD

--- a/e2e-tests/monitoring-2-0/run
+++ b/e2e-tests/monitoring-2-0/run
@@ -114,7 +114,12 @@ get_qan_values mongodb "dev-mongod" admin:admin
 get_qan_values mongodb "dev-mongos" admin:admin
 
 if [[ -n ${OPENSHIFT} ]]; then
-	oc adm policy remove-scc-from-user privileged -z percona-server-mongodb-operator
+	oc adm policy remove-scc-from-user privileged -z pmm-server
+	if [ -n "$OPERATOR_NS" ]; then
+		oc delete clusterrolebinding pmm-psmdb-operator-cluster-wide
+	else
+		oc delete rolebinding pmm-psmdb-operator-namespace-only
+	fi
 fi
 
 if [[ $(kubectl_bin logs monitoring-rs0-0 pmm-client | grep -c 'cannot auto discover databases and collections') != 0 ]]; then

--- a/pkg/psmdb/pmm.go
+++ b/pkg/psmdb/pmm.go
@@ -254,7 +254,7 @@ func pmmAgentEnvs(spec api.PMMSpec, secret *corev1.Secret, customLogin bool, cus
 		},
 		{
 			Name:  "PMM_AGENT_PATHS_TEMPDIR",
-			Value: "/data/db/pmm2/tmp",
+			Value: "/tmp",
 		},
 	}
 

--- a/pkg/psmdb/pmm.go
+++ b/pkg/psmdb/pmm.go
@@ -252,10 +252,6 @@ func pmmAgentEnvs(spec api.PMMSpec, secret *corev1.Secret, customLogin bool, cus
 			Name:  "PMM_ADMIN_CUSTOM_PARAMS",
 			Value: customAdminParams,
 		},
-		{
-			Name:  "PMM_AGENT_PATHS_TEMPDIR",
-			Value: "/tmp",
-		},
 	}
 
 	if customLogin {
@@ -374,6 +370,17 @@ func AddPMMContainer(ctx context.Context, cr *api.PerconaServerMongoDB, secret *
 			{
 				Name:  "PMM_AGENT_SIDECAR_SLEEP",
 				Value: "5",
+			},
+		}
+		pmmC.Env = append(pmmC.Env, sidecarEnvs...)
+	}
+	if cr.CompareVersion("1.15.0") >= 0 {
+		// PMM team moved temp directory to /usr/local/percona/pmm2/tmp
+		// but it doesn't work on OpenShift so we set it back to /tmp
+		sidecarEnvs := []corev1.EnvVar{
+			{
+				Name:  "PMM_AGENT_PATHS_TEMPDIR",
+				Value: "/tmp",
 			},
 		}
 		pmmC.Env = append(pmmC.Env, sidecarEnvs...)

--- a/pkg/psmdb/pmm.go
+++ b/pkg/psmdb/pmm.go
@@ -252,6 +252,10 @@ func pmmAgentEnvs(spec api.PMMSpec, secret *corev1.Secret, customLogin bool, cus
 			Name:  "PMM_ADMIN_CUSTOM_PARAMS",
 			Value: customAdminParams,
 		},
+		{
+			Name:  "PMM_AGENT_PATHS_TEMPDIR",
+			Value: "/tmp/pmm-agent",
+		},
 	}
 
 	if customLogin {

--- a/pkg/psmdb/pmm.go
+++ b/pkg/psmdb/pmm.go
@@ -254,7 +254,7 @@ func pmmAgentEnvs(spec api.PMMSpec, secret *corev1.Secret, customLogin bool, cus
 		},
 		{
 			Name:  "PMM_AGENT_PATHS_TEMPDIR",
-			Value: "/tmp/pmm-agent",
+			Value: "/data/db/pmm2/tmp",
 		},
 	}
 


### PR DESCRIPTION
[![K8SPSMDB-991](https://badgen.net/badge/JIRA/K8SPSMDB-991/green)](https://jira.percona.com/browse/K8SPSMDB-991) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
*In `2.39` PMM changed to use `/usr/local/percona/pmm2/tmp` as a temp directory for pbm-agent which is failing in openshift because of permissions.*

**Solution:**
*We will set `PMM_AGENT_PATHS_TEMPDIR` back under `/tmp`*

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?
- [x] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are the manifests (crd/bundle) regenerated if needed?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported MongoDB version?
- [x] Does the change support oldest and newest supported Kubernetes version?