### PR TITLE
K8SPSMDB-992 - Add rbac rules for finalizers (fix issuing certs with cert-manager in OpenShift)

### DIFF
--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -17464,10 +17464,13 @@ rules:
   resources:
   - perconaservermongodbs
   - perconaservermongodbs/status
+  - perconaservermongodbs/finalizers
   - perconaservermongodbbackups
   - perconaservermongodbbackups/status
+  - perconaservermongodbbackups/finalizers
   - perconaservermongodbrestores
   - perconaservermongodbrestores/status
+  - perconaservermongodbrestores/finalizers
   verbs:
   - get
   - list

--- a/deploy/cw-bundle.yaml
+++ b/deploy/cw-bundle.yaml
@@ -17464,10 +17464,13 @@ rules:
   resources:
   - perconaservermongodbs
   - perconaservermongodbs/status
+  - perconaservermongodbs/finalizers
   - perconaservermongodbbackups
   - perconaservermongodbbackups/status
+  - perconaservermongodbbackups/finalizers
   - perconaservermongodbrestores
   - perconaservermongodbrestores/status
+  - perconaservermongodbrestores/finalizers
   verbs:
   - get
   - list

--- a/deploy/cw-rbac.yaml
+++ b/deploy/cw-rbac.yaml
@@ -8,10 +8,13 @@ rules:
   resources:
   - perconaservermongodbs
   - perconaservermongodbs/status
+  - perconaservermongodbs/finalizers
   - perconaservermongodbbackups
   - perconaservermongodbbackups/status
+  - perconaservermongodbbackups/finalizers
   - perconaservermongodbrestores
   - perconaservermongodbrestores/status
+  - perconaservermongodbrestores/finalizers
   verbs:
   - get
   - list

--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -8,10 +8,13 @@ rules:
   resources:
   - perconaservermongodbs
   - perconaservermongodbs/status
+  - perconaservermongodbs/finalizers
   - perconaservermongodbbackups
   - perconaservermongodbbackups/status
+  - perconaservermongodbbackups/finalizers
   - perconaservermongodbrestores
   - perconaservermongodbrestores/status
+  - perconaservermongodbrestores/finalizers
   verbs:
   - get
   - list


### PR DESCRIPTION
[![K8SPSMDB-992](https://badgen.net/badge/JIRA/K8SPSMDB-992/green)](https://jira.percona.com/browse/K8SPSMDB-992) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
*On OpenShift we started getting issue while issuing certificates with cert-manager: `"errorVerbose": "issuers.cert-manager.io \"my-cluster-name-psmdb-ca-issuer\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on:`*

**Cause:**
*Possibly OpenShift enabled `OwnerReferencesPermissionEnforcement`*

**Solution:**
*Update rbac to add finalizers under resources.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?