### PR TITLE
K8SPSMDB-948: Multi arch build

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4.1.1
       - uses: actions/setup-go@v5
         with:
-          go-version: '^1.17'
+          go-version: '^1.21'
       - run: go install mvdan.cc/sh/v3/cmd/shfmt@latest
       - run: $(go env GOPATH)/bin/shfmt -f . | grep -v 'vendor' | xargs $(go env GOPATH)/bin/shfmt -bn -ci -s -w
       - name: suggester / shfmt

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,5 +1,13 @@
 name: Scan docker
 on: [pull_request]
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: docker.io
+
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: perconalab/percona-server-mongodb-operator
+
 jobs:
   build:
     name: Build
@@ -7,16 +15,42 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.1.1
-      - name: Build an image from Dockerfile
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build an image from Dockerfile (linux/arm64)
         run: |
-          export IMAGE=perconalab/percona-server-mongodb-operator:${{ github.sha }}
+          export IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-arm64
           export DOCKER_PUSH=0
           export DOCKER_SQUASH=0
+          export DOCKER_DEFAULT_PLATFORM='linux/arm64'
           ./e2e-tests/build
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.16.1
         with:
-          image-ref: 'docker.io/perconalab/percona-server-mongodb-operator:${{ github.sha }}'
+          image-ref: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-arm64'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'
+
+      - name: Build an image from Dockerfile (linux/amd64)
+        run: |
+          export IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-amd64
+          export DOCKER_PUSH=0
+          export DOCKER_SQUASH=0
+          export DOCKER_DEFAULT_PLATFORM='linux/amd64'
+          ./e2e-tests/build
+
+      - name: Run Trivy vulnerability scanner image (linux/amd64)
+        uses: aquasecurity/trivy-action@0.14.0
+        with:
+          image-ref: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}-amd64'
           format: 'table'
           exit-code: '1'
           ignore-unfixed: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: '^1.19'
+          go-version: '^1.21'
       - uses: actions/checkout@v4.1.1
       - name: go test
         run: go test -v ./...

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -323,6 +323,7 @@ EOF
                                 docker login -u '${USER}' -p '${PASS}'
                                 export RELEASE=0
                                 export IMAGE=\$DOCKER_TAG
+                                docker buildx create --use
                                 ./e2e-tests/build
                                 docker logout
                             "
@@ -349,7 +350,7 @@ EOF
                             -v $WORKSPACE/src/github.com/percona/percona-server-mongodb-operator:/go/src/github.com/percona/percona-server-mongodb-operator \
                             -w /go/src/github.com/percona/percona-server-mongodb-operator \
                             -e GOFLAGS='-buildvcs=false' \
-                            golang:1.19 sh -c '
+                            golang:1.21 sh -c '
                                 go install github.com/google/go-licenses@v1.0.0;
                                 /go/bin/go-licenses csv github.com/percona/percona-server-mongodb-operator/cmd/manager \
                                     | cut -d , -f 3 \
@@ -377,7 +378,7 @@ EOF
                             -v $WORKSPACE/src/github.com/percona/percona-server-mongodb-operator:/go/src/github.com/percona/percona-server-mongodb-operator \
                             -w /go/src/github.com/percona/percona-server-mongodb-operator \
                             -e GOFLAGS='-buildvcs=false' \
-                            golang:1.19 sh -c 'go build -v -o percona-server-mongodb-operator github.com/percona/percona-server-mongodb-operator/cmd/manager'
+                            golang:1.21 sh -c 'go build -v -o percona-server-mongodb-operator github.com/percona/percona-server-mongodb-operator/cmd/manager'
                     "
                 '''
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -7,17 +7,16 @@ ARG GIT_COMMIT
 ARG GIT_BRANCH
 ARG GO_LDFLAGS
 ARG GOOS=linux
-ARG GOARCH=amd64
 ARG CGO_ENABLED=0
 
 RUN go mod download \
     && mkdir -p build/_output/bin \
-    && GOOS=$GOOS GOARCH=$GOARCH CGO_ENABLED=$CGO_ENABLED GO_LDFLAGS=$GO_LDFLAGS \
+    && GOOS=$GOOS CGO_ENABLED=$CGO_ENABLED GO_LDFLAGS=$GO_LDFLAGS \
        go build -ldflags "-w -s -X main.GitCommit=$GIT_COMMIT -X main.GitBranch=$GIT_BRANCH" \
            -o build/_output/bin/percona-server-mongodb-operator \
                cmd/manager/main.go \
     && cp -r build/_output/bin/percona-server-mongodb-operator /usr/local/bin/percona-server-mongodb-operator \
-    && GOOS=$GOOS GOARCH=$GOARCH CGO_ENABLED=$CGO_ENABLED GO_LDFLAGS=$GO_LDFLAGS \
+    && GOOS=$GOOS CGO_ENABLED=$CGO_ENABLED GO_LDFLAGS=$GO_LDFLAGS \
        go build -ldflags "-w -s -X main.GitCommit=$GIT_COMMIT -X main.GitBranch=$GIT_BRANCH" \
            -o build/_output/bin/mongodb-healthcheck \
                cmd/mongodb-healthcheck/main.go \

--- a/e2e-tests/build
+++ b/e2e-tests/build
@@ -14,6 +14,11 @@ fi
 if [[ ${DOCKER_SQUASH:-1} == 1 ]]; then
 	squash="--squash"
 fi
+if [[ ${DOCKER_PUSH:-1} == 1 ]]; then
+	imgresult="--push=true"
+else
+	imgresult="--load"
+fi
 
 build_operator() {
 	if [ "${RELEASE:-1}" = 0 ]; then
@@ -21,21 +26,19 @@ build_operator() {
 	fi
 
 	export IMAGE
-	export DOCKER_DEFAULT_PLATFORM=${DOCKER_DEFAULT_PLATFORM:-linux/amd64}
+	export DOCKER_DEFAULT_PLATFORM=${DOCKER_DEFAULT_PLATFORM:-"linux/amd64,linux/arm64"}
 	export GO_LDFLAGS="-w -s -trimpath $GO_LDFLAGS"
 	pushd ${src_dir}
-	docker build \
+	docker buildx build \
+		--platform $DOCKER_DEFAULT_PLATFORM \
 		--build-arg GIT_COMMIT=$GIT_COMMIT \
 		--build-arg GIT_BRANCH=$GIT_BRANCH \
 		--build-arg GO_LDFLAGS="$GO_LDFLAGS" \
+		$imgresult \
 		$squash \
 		$no_cache \
 		-t "${IMAGE}" -f build/Dockerfile .
 	popd
-
-	if [ "${DOCKER_PUSH:-1}" = 1 ]; then
-		docker push ${IMAGE}
-	fi
 }
 
 until docker ps; do sleep 1; done


### PR DESCRIPTION
[![K8SPSMDB-948](https://badgen.net/badge/JIRA/K8SPSMDB-948/green)](https://jira.percona.com/browse/K8SPSMDB-948) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**

https://jira.percona.com/browse/K8SPSMDB-948
https://forums.percona.com/t/mongo-operator-and-arm/24326

**Cause:**

Multi arch image.

**Solution:**

Hello, 

This small changes allows to build PSMDB for different architectures.


```shell
make build DOCKER_DEFAULT_PLATFORM=linux/amd64,linux/arm64 IMAGE=ghcr.io/sergelogvinov/percona-server-mongodb-operator:v1.14.0
```

the result image: ghcr.io/sergelogvinov/percona-server-mongodb-operator:v1.14.0

In my opinion, it is better to make refactoring of files: Dockerfile, e2e-tests/build to speedup the build.
Also you need to have buildkit in your CI/CD (jenkins) machine. Github Action already has everything that we need for it. 

PS. I can make github action for you (build/push releases to github registry).

Thanks.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-948]: https://perconadev.atlassian.net/browse/K8SPSMDB-948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ