### PR TITLE
K8SPSMDB-1024 fixed variable scope and make sure it always get sets

### DIFF
--- a/build/pbm-entry.sh
+++ b/build/pbm-entry.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
+PBM_MONGODB_URI="mongodb://${PBM_AGENT_MONGODB_USERNAME}:${PBM_AGENT_MONGODB_PASSWORD}@localhost:${PBM_MONGODB_PORT}/?replicaSet=${PBM_MONGODB_REPLSET}"
+
 MONGO_SSL_DIR=/etc/mongodb-ssl
 if [[ -f "${MONGO_SSL_DIR}/tls.crt" ]] && [[ -f "${MONGO_SSL_DIR}/tls.key" ]]; then
-	cat "${MONGO_SSL_DIR}/tls.key" "${MONGO_SSL_DIR}/tls.crt" >/tmp/tls.pem
 	PBM_MONGODB_URI="${PBM_MONGODB_URI}&tls=true&tlsCertificateKeyFile=%2Ftmp%2Ftls.pem&tlsCAFile=${MONGO_SSL_DIR}%2Fca.crt&tlsInsecure=true"
-else
-	PBM_MONGODB_URI="mongodb://${PBM_AGENT_MONGODB_USERNAME}:${PBM_AGENT_MONGODB_PASSWORD}@localhost:${PBM_MONGODB_PORT}/?replicaSet=${PBM_MONGODB_REPLSET}"
+	cat "${MONGO_SSL_DIR}/tls.key" "${MONGO_SSL_DIR}/tls.crt" >/tmp/tls.pem
 fi
 
 export PBM_MONGODB_URI

--- a/build/pbm-entry.sh
+++ b/build/pbm-entry.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-PBM_MONGODB_URI="mongodb://${PBM_AGENT_MONGODB_USERNAME}:${PBM_AGENT_MONGODB_PASSWORD}@localhost:${PBM_MONGODB_PORT}/?replicaSet=${PBM_MONGODB_REPLSET}"
-
 MONGO_SSL_DIR=/etc/mongodb-ssl
 if [[ -f "${MONGO_SSL_DIR}/tls.crt" ]] && [[ -f "${MONGO_SSL_DIR}/tls.key" ]]; then
 	cat "${MONGO_SSL_DIR}/tls.key" "${MONGO_SSL_DIR}/tls.crt" >/tmp/tls.pem
 	PBM_MONGODB_URI="${PBM_MONGODB_URI}&tls=true&tlsCertificateKeyFile=%2Ftmp%2Ftls.pem&tlsCAFile=${MONGO_SSL_DIR}%2Fca.crt&tlsInsecure=true"
+else
+	PBM_MONGODB_URI="mongodb://${PBM_AGENT_MONGODB_USERNAME}:${PBM_AGENT_MONGODB_PASSWORD}@localhost:${PBM_MONGODB_PORT}/?replicaSet=${PBM_MONGODB_REPLSET}"
 fi
 
 export PBM_MONGODB_URI

--- a/build/pbm-entry.sh
+++ b/build/pbm-entry.sh
@@ -5,7 +5,7 @@ PBM_MONGODB_URI="mongodb://${PBM_AGENT_MONGODB_USERNAME}:${PBM_AGENT_MONGODB_PAS
 MONGO_SSL_DIR=/etc/mongodb-ssl
 if [[ -f "${MONGO_SSL_DIR}/tls.crt" ]] && [[ -f "${MONGO_SSL_DIR}/tls.key" ]]; then
 	PBM_MONGODB_URI="${PBM_MONGODB_URI}&tls=true&tlsCertificateKeyFile=%2Ftmp%2Ftls.pem&tlsCAFile=${MONGO_SSL_DIR}%2Fca.crt&tlsInsecure=true"
-	cat "${MONGO_SSL_DIR}/tls.key" "${MONGO_SSL_DIR}/tls.crt" >/tmp/tls.pem
+	cat "${MONGO_SSL_DIR}/tls.key" "${MONGO_SSL_DIR}/tls.crt" > /tmp/tls.pem
 fi
 
 export PBM_MONGODB_URI


### PR DESCRIPTION
[![K8SPSMDB-1024](https://badgen.net/badge/JIRA/K8SPSMDB-1024/green)](https://jira.percona.com/browse/K8SPSMDB-1024) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
*pbm-entry script is having a variable scope issue. 

**Cause:**
*pbm-entry script is having a variable scope issue where the needed env does not get updated by the script. Instead, it keeps the initial value from the previous line even after being updated through the if statement. 

**Solution:**
* The solution is to move the line where it's piping to a file after the variable gets set.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly? No I don't have one yet. I don't know where to create.
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)? No, it will not break anything, instead it's making sure it does what's intented.
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?N/A

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change? N/A
- [ ] Are unit tests added where appropriate? N/A
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)? N/A

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version? yes, It does
- [ ] Does the change support oldest and newest supported Kubernetes version? yes, it does