### PR TITLE
K8SPSMDB-1018 - Fix upgrade-consistency test to work with new image

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -1040,6 +1040,7 @@ cat_config() {
 	cat "$1" \
 		| yq eval '(.spec | select(.image == null)).image = "'"$IMAGE_MONGOD"'"' \
 		| yq eval '(.spec | select(has("pmm"))).pmm.image = "'"$IMAGE_PMM_CLIENT"'"' \
+		| yq eval '(.spec | select(has("initImage"))).initImage = "'"$IMAGE"'"' \
 		| yq eval '(.spec | select(has("backup"))).backup.image = "'"$IMAGE_BACKUP"'"' \
 		| yq eval '.spec.upgradeOptions.apply="Never"'
 }

--- a/e2e-tests/upgrade-consistency-sharded/compare/statefulset_some-name-cfg-1160-oc.yml
+++ b/e2e-tests/upgrade-consistency-sharded/compare/statefulset_some-name-cfg-1160-oc.yml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations: {}
-  generation: 3
+  generation: 2
   labels:
     app.kubernetes.io/component: mongod
     app.kubernetes.io/instance: some-name

--- a/e2e-tests/upgrade-consistency-sharded/compare/statefulset_some-name-cfg-1160.yml
+++ b/e2e-tests/upgrade-consistency-sharded/compare/statefulset_some-name-cfg-1160.yml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations: {}
-  generation: 3
+  generation: 2
   labels:
     app.kubernetes.io/component: cfg
     app.kubernetes.io/instance: some-name

--- a/e2e-tests/upgrade-consistency-sharded/compare/statefulset_some-name-rs0-1160-oc.yml
+++ b/e2e-tests/upgrade-consistency-sharded/compare/statefulset_some-name-rs0-1160-oc.yml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations: {}
-  generation: 3
+  generation: 2
   labels:
     app.kubernetes.io/component: mongod
     app.kubernetes.io/instance: some-name

--- a/e2e-tests/upgrade-consistency-sharded/compare/statefulset_some-name-rs0-1160.yml
+++ b/e2e-tests/upgrade-consistency-sharded/compare/statefulset_some-name-rs0-1160.yml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations: {}
-  generation: 3
+  generation: 2
   labels:
     app.kubernetes.io/component: mongod
     app.kubernetes.io/instance: some-name

--- a/e2e-tests/upgrade-consistency-sharded/conf/some-name.yml
+++ b/e2e-tests/upgrade-consistency-sharded/conf/some-name.yml
@@ -10,8 +10,7 @@ spec:
   #platform: openshift
   image:
   imagePullPolicy: Always
-  # TODO: remove initImage after 1.18.0 release
-  initImage: perconalab/percona-server-mongodb-operator:main
+  initImage: -init
   allowUnsafeConfigurations: false
   updateStrategy: SmartUpdate
   secrets:

--- a/e2e-tests/upgrade-consistency-sharded/conf/some-name.yml
+++ b/e2e-tests/upgrade-consistency-sharded/conf/some-name.yml
@@ -10,6 +10,8 @@ spec:
   #platform: openshift
   image:
   imagePullPolicy: Always
+  # TODO: remove initImage after 1.18.0 release
+  initImage: perconalab/percona-server-mongodb-operator:main
   allowUnsafeConfigurations: false
   updateStrategy: SmartUpdate
   secrets:

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1160-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1160-oc.yml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations: {}
-  generation: 3
+  generation: 2
   labels:
     app.kubernetes.io/component: mongod
     app.kubernetes.io/instance: some-name

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1160.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1160.yml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations: {}
-  generation: 3
+  generation: 2
   labels:
     app.kubernetes.io/component: mongod
     app.kubernetes.io/instance: some-name

--- a/e2e-tests/upgrade-consistency/conf/some-name-rs0.yml
+++ b/e2e-tests/upgrade-consistency/conf/some-name-rs0.yml
@@ -7,8 +7,7 @@ spec:
   #platform: openshift
   image:
   imagePullPolicy: Always
-  # TODO: remove initImage after 1.18.0 release
-  initImage: perconalab/percona-server-mongodb-operator:main
+  initImage: -init
   allowUnsafeConfigurations: false
   backup:
     enabled: false

--- a/e2e-tests/upgrade-consistency/conf/some-name-rs0.yml
+++ b/e2e-tests/upgrade-consistency/conf/some-name-rs0.yml
@@ -7,6 +7,8 @@ spec:
   #platform: openshift
   image:
   imagePullPolicy: Always
+  # TODO: remove initImage after 1.18.0 release
+  initImage: perconalab/percona-server-mongodb-operator:main
   allowUnsafeConfigurations: false
   backup:
     enabled: false


### PR DESCRIPTION
[![K8SPSMDB-1018](https://badgen.net/badge/JIRA/K8SPSMDB-1018/green)](https://jira.percona.com/browse/K8SPSMDB-1018) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
*There was a bugfix [here](https://github.com/percona/percona-server-mongodb-operator/pull/1382) for new PSMDB images and numactl support, but when it was fixed the `upgrade-consistency` tests stopped working because old docker images don't have numactl.*

**Solution:**
*Temporarily set initImage to perconalab `main` operator image.*

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?
- [x] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are the manifests (crd/bundle) regenerated if needed?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported MongoDB version?
- [x] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-1018]: https://perconadev.atlassian.net/browse/K8SPSMDB-1018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ