### PR TITLE
CLOUD-820 Update README to mention documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,69 +9,59 @@
 ![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/percona/percona-server-mongodb-operator)
 [![Go Report Card](https://goreportcard.com/badge/github.com/percona/percona-server-mongodb-operator)](https://goreportcard.com/report/github.com/percona/percona-server-mongodb-operator)
 
-[Percona Server for MongoDB](https://www.percona.com/software/mongodb/percona-server-for-mongodb) (PSMDB) is an open-source enterprise MongoDB solution that helps you to ensure data availability for your applications while improving security and simplifying the development of new applications in the most demanding public, private, and hybrid cloud environments.
+[Percona Operator for MongoDB](https://github.com/percona/percona-server-mongodb-operator) automates the creation, modification, or deletion of items in your Percona Server for MongoDB environment. The Operator contains the necessary Kubernetes settings to maintain a consistent Percona Server for MongoDB instance, be it a replica set or a sharded cluster.
 
-Based on our best practices for deployment and configuration, [Percona Operator for MongoDB](https://www.percona.com/doc/kubernetes-operator-for-psmongodb/index.html) contains everything you need to quickly and consistently deploy and scale Percona Server for MongoDB instances into a Kubernetes cluster on-premises or in the cloud. It provides the following capabilities:
+Based on our best practices for deployment and configuration, Percona Operator for MongoDB contains everything you need to quickly and consistently deploy and scale Percona Server for MongoDB instances into a Kubernetes cluster on-premises or in the cloud. It provides the following features to keep your Percona Server for MongoDB deployment healthy:
 
 - Easy deployment with no single point of failure
 - Sharding support
 - Scheduled and manual backups
 - Integrated monitoring with [Percona Monitoring and Management](https://www.percona.com/software/database-tools/percona-monitoring-and-management)
-- Smart Update to keep your database software up to date automatically
-- Automated Password Rotation – use the standard Kubernetes API to enforce password rotation policies for system user
+- Smart update to keep your database software up to date automatically
+- Automated password rotation – use the standard Kubernetes API to enforce password rotation policies for system user
 - Private container image registries
+
+You interact with Percona Operator mostly via the command line tool. If you feel more comfortable with operating the Operator and database clusters via the web interface, there is [Percona Everest](https://docs.percona.com/everest/index.html) - an open-source web-based database provisioning tool available for you. It automates day-to-day database management operations for you, reducing the overall administrative overhead. [Get started with Percona Everest](https://docs.percona.com/everest/quickstart-guide/quick-install.html).
 
 # Architecture
 
-Percona Operators are based on the [Operator SDK](https://github.com/operator-framework/operator-sdk) and leverage Kubernetes primitives to follow best CNCF practices.
+Percona Operators are based on the [Operator SDK](https://github.com/operator-framework/operator-sdk) and leverage Kubernetes primitives to follow best [CNCF](https://www.cncf.io/) practices.
 
-Please read more about architecture and design decisions [here](https://www.percona.com/doc/kubernetes-operator-for-psmongodb/architecture.html).
+ Learn more about [architecture and design decisions](https://www.percona.com/doc/kubernetes-operator-for-psmongodb/architecture.html).
+
+## Documentation
+
+To learn more about the Operator, check the [Percona Operator for MongoDB documentation](https://docs.percona.com/percona-operator-for-mongodb/index.html). 
 
 # Quickstart installation
 
-## Helm
+Ready to try out the Operator? Check the [Quickstart tutorial](https://docs.percona.com/percona-operator-for-mongodb/quickstart.html) for easy-to follow steps. 
 
-Install the Operator:
-
-```bash
-helm install my-op percona/psmdb-operator
-```
-
-Install Percona Server for MongoDB:
-
-```bash
-helm install my-db percona/psmdb-db
-```
-
-See more details in:
-
-- [Helm installation documentation](https://www.percona.com/doc/kubernetes-operator-for-psmongodb/helm.html)
-- [Operator helm chart parameter reference](https://github.com/percona/percona-helm-charts/blob/main/charts/psmdb-operator)
-- [Percona Server for MongoDB helm chart parameters reference](https://github.com/percona/percona-helm-charts/blob/main/charts/psmdb-db)
+Below is one of the ways to deploy the Operator using `kubectl`.
 
 ## kubectl
 
-It usually takes two steps to deploy Percona Server for MongoDB on Kubernetes:
-
-Deploy the operator from `deploy/bundle.yaml`:
+1. Deploy the operator from `deploy/bundle.yaml`:
 
 ```sh
 kubectl apply --server-side -f https://raw.githubusercontent.com/percona/percona-server-mongodb-operator/main/deploy/bundle.yaml
 ```
 
-Deploy the database cluster itself from `deploy/cr.yaml
+2. Deploy the database cluster itself from `deploy/cr.yaml
 
 ```sh
 kubectl apply -f https://raw.githubusercontent.com/percona/percona-server-mongodb-operator/main/deploy/cr-minimal.yaml
 ```
 
-See full documentation with examples and various advanced cases on [percona.com](https://www.percona.com/doc/kubernetes-operator-for-psmongodb/index.html).
-
 # Contributing
 
 Percona welcomes and encourages community contributions to help improve Percona Kubernetes Operator for Percona Server for MongoDB.
 
-See the [Contribution Guide](CONTRIBUTING.md) and [Building and Testing Guide](e2e-tests/README.md) for more information.
+See the [Contribution Guide](CONTRIBUTING.md) and [Building and Testing Guide](e2e-tests/README.md) for more information on how you can contribute.
+
+## Communication
+
+We would love to hear from you! Reach out to us on [Forum](https://forums.percona.com/c/mongodb/percona-kubernetes-operator-for-mongodb/29) with your questions, feedback and ideas
 
 # Join Percona Kubernetes Squad!                                                                           
 ```                                                                                     
@@ -99,4 +89,6 @@ We have an experimental public roadmap which can be found [here](https://github.
 
 # Submitting Bug Reports
 
-If you find a bug in Percona Docker Images or in one of the related projects, please submit a report to that project's [JIRA](https://jira.percona.com/projects/K8SPSMDB/issues/K8SPSMDB-555?filter=allopenissues) issue tracker. Learn more about submitting bugs, new features ideas and improvements in the [Contribution Guide](CONTRIBUTING.md).
+If you find a bug in Percona Docker Images or in one of the related projects, please submit a report to that project's [JIRA](https://jira.percona.com/projects/K8SPSMDB/issues/K8SPSMDB-555?filter=allopenissues) issue tracker or [create a GitHub issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/creating-an-issue#creating-an-issue-from-a-repository) in this repository.
+
+Learn more about submitting bugs, new features ideas and improvements in the [Contribution Guide](CONTRIBUTING.md).


### PR DESCRIPTION
[![CLOUD-820](https://badgen.net/badge/JIRA/CLOUD-820/green)](https://jira.percona.com/browse/CLOUD-820) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

modified:   README.md

**CHANGE DESCRIPTION**
---
**Problem:** 
READMEs across all Operators are misaligned, having different structure, content and lacking links to Documentation

*Short explanation of the problem.*
Update README to mention documentation

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are the manifests (crd/bundle) regenerated if needed?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[CLOUD-820]: https://perconadev.atlassian.net/browse/CLOUD-820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ