### PR TITLE
K8SPSMDB-1039 fix deletion from server inventory on pod termination

### DIFF
--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-cfg-oc.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-cfg-oc.yml
@@ -241,7 +241,7 @@ spec:
                 command:
                   - bash
                   - -c
-                  - pmm-admin inventory remove node --force $(pmm-admin status --json | python -c "import sys, json; print(json.load(sys.stdin)['pmm_agent_status']['node_id'])")
+                  - pmm-admin unregister --force
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-cfg.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-cfg.yml
@@ -242,7 +242,7 @@ spec:
                 command:
                   - bash
                   - -c
-                  - pmm-admin inventory remove node --force $(pmm-admin status --json | python -c "import sys, json; print(json.load(sys.stdin)['pmm_agent_status']['node_id'])")
+                  - pmm-admin unregister --force
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-mongos-oc.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-mongos-oc.yml
@@ -243,7 +243,7 @@ spec:
                 command:
                   - bash
                   - -c
-                  - pmm-admin inventory remove node --force $(pmm-admin status --json | python -c "import sys, json; print(json.load(sys.stdin)['pmm_agent_status']['node_id'])")
+                  - pmm-admin unregister --force
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-mongos.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-mongos.yml
@@ -244,7 +244,7 @@ spec:
                 command:
                   - bash
                   - -c
-                  - pmm-admin inventory remove node --force $(pmm-admin status --json | python -c "import sys, json; print(json.load(sys.stdin)['pmm_agent_status']['node_id'])")
+                  - pmm-admin unregister --force
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0-oc.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0-oc.yml
@@ -229,7 +229,7 @@ spec:
                 command:
                   - bash
                   - -c
-                  - pmm-admin inventory remove node --force $(pmm-admin status --json | python -c "import sys, json; print(json.load(sys.stdin)['pmm_agent_status']['node_id'])")
+                  - pmm-admin unregister --force
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0.yml
@@ -230,7 +230,7 @@ spec:
                 command:
                   - bash
                   - -c
-                  - pmm-admin inventory remove node --force $(pmm-admin status --json | python -c "import sys, json; print(json.load(sys.stdin)['pmm_agent_status']['node_id'])")
+                  - pmm-admin unregister --force
           livenessProbe:
             failureThreshold: 3
             httpGet:

--- a/e2e-tests/monitoring-2-0/run
+++ b/e2e-tests/monitoring-2-0/run
@@ -6,6 +6,25 @@ test_dir=$(realpath $(dirname $0))
 . ${test_dir}/../functions
 set_debug
 
+get_node_id_from_pmm() {
+    local -a nodeList=()
+    for instance in $(kubectl_bin get pods --no-headers -l app.kubernetes.io/name=percona-server-mongodb --output=custom-columns='NAME:.metadata.name'); do
+        nodeList+=($(kubectl_bin exec -n "$namespace" $instance -c pmm-client -- pmm-admin status --json | jq -r '.pmm_agent_status.node_id'))
+    done
+
+    echo "${nodeList[@]}"
+}
+
+does_node_id_exists() {
+    local -a nodeList=("$@")
+    local -a nodeList_from_pmm=()
+    for node_id in "${nodeList[@]}"; do
+    nodeList_from_pmm+=($(kubectl_bin exec -n "${namespace}" monitoring-0 -- pmm-admin --server-url=https://admin:admin@$(get_service_ip monitoring-service)/ --server-insecure-tls inventory list nodes --node-type=CONTAINER_NODE | grep $node_id | awk '{print $4}'))
+    done
+
+   echo "${nodeList_from_pmm[@]}"
+}
+
 deploy_cert_manager
 create_infra $namespace
 
@@ -92,6 +111,28 @@ sleep 90
 desc 'check QAN data'
 get_qan_values mongodb "dev-mongod" admin:admin
 get_qan_values mongodb "dev-mongos" admin:admin
+
+nodeList=($(get_node_id_from_pmm))
+nodeList_from_pmm=($(does_node_id_exists "${nodeList[@]}"))
+for node_id in "${nodeList_from_pmm[@]}"; do
+    if [ -z "$node_id" ]; then
+        echo "Can't get $node_id node_id from PMM server"
+        exit 1
+    fi
+done
+
+kubectl_bin patch psmdb ${cluster} --type json -p='[{"op":"add","path":"/spec/pause","value":true}]'
+wait_for_delete "pod/${cluster}-mongos-0"
+wait_for_delete "pod/${cluster}-rs0-0"
+wait_for_delete "pod/${cluster}-cfg-0"
+
+does_node_id_exists_in_pmm=($(does_node_id_exists "${nodeList[@]}"))
+for instance in "${does_node_id_exists_in_pmm[@]}"; do
+    if [ -n "$instance" ]; then
+        echo "The $instance pod was not deleted from server inventory"
+        exit 1
+    fi
+done
 
 if [[ -n ${OPENSHIFT} ]]; then
 	oc adm policy remove-scc-from-user privileged -z pmm-server

--- a/e2e-tests/monitoring-2-0/run
+++ b/e2e-tests/monitoring-2-0/run
@@ -115,10 +115,10 @@ get_qan_values mongodb "dev-mongos" admin:admin
 nodeList=($(get_node_id_from_pmm))
 nodeList_from_pmm=($(does_node_id_exists "${nodeList[@]}"))
 for node_id in "${nodeList_from_pmm[@]}"; do
-    if [ -z "$node_id" ]; then
-        echo "Can't get $node_id node_id from PMM server"
-        exit 1
-    fi
+	if [ -z "$node_id" ]; then
+		echo "Can't get $node_id node_id from PMM server"
+		exit 1
+	fi
 done
 
 kubectl_bin patch psmdb ${cluster} --type json -p='[{"op":"add","path":"/spec/pause","value":true}]'

--- a/e2e-tests/monitoring-2-0/run
+++ b/e2e-tests/monitoring-2-0/run
@@ -128,10 +128,10 @@ wait_for_delete "pod/${cluster}-cfg-0"
 
 does_node_id_exists_in_pmm=($(does_node_id_exists "${nodeList[@]}"))
 for instance in "${does_node_id_exists_in_pmm[@]}"; do
-    if [ -n "$instance" ]; then
-        echo "The $instance pod was not deleted from server inventory"
-        exit 1
-    fi
+	if [ -n "$instance" ]; then
+		echo "The $instance pod was not deleted from server inventory"
+		exit 1
+	fi
 done
 
 if [[ -n ${OPENSHIFT} ]]; then

--- a/e2e-tests/monitoring-2-0/run
+++ b/e2e-tests/monitoring-2-0/run
@@ -7,10 +7,10 @@ test_dir=$(realpath $(dirname $0))
 set_debug
 
 get_node_id_from_pmm() {
-    local -a nodeList=()
-    for instance in $(kubectl_bin get pods --no-headers -l app.kubernetes.io/name=percona-server-mongodb --output=custom-columns='NAME:.metadata.name'); do
-        nodeList+=($(kubectl_bin exec -n "$namespace" $instance -c pmm-client -- pmm-admin status --json | jq -r '.pmm_agent_status.node_id'))
-    done
+	local -a nodeList=()
+	for instance in $(kubectl_bin get pods --no-headers -l app.kubernetes.io/name=percona-server-mongodb --output=custom-columns='NAME:.metadata.name'); do
+		nodeList+=($(kubectl_bin exec -n "$namespace" $instance -c pmm-client -- pmm-admin status --json | jq -r '.pmm_agent_status.node_id'))
+	done
 
     echo "${nodeList[@]}"
 }

--- a/e2e-tests/monitoring-2-0/run
+++ b/e2e-tests/monitoring-2-0/run
@@ -16,11 +16,11 @@ get_node_id_from_pmm() {
 }
 
 does_node_id_exists() {
-    local -a nodeList=("$@")
-    local -a nodeList_from_pmm=()
-    for node_id in "${nodeList[@]}"; do
-    nodeList_from_pmm+=($(kubectl_bin exec -n "${namespace}" monitoring-0 -- pmm-admin --server-url=https://admin:admin@$(get_service_ip monitoring-service)/ --server-insecure-tls inventory list nodes --node-type=CONTAINER_NODE | grep $node_id | awk '{print $4}'))
-    done
+	local -a nodeList=("$@")
+	local -a nodeList_from_pmm=()
+	for node_id in "${nodeList[@]}"; do
+		nodeList_from_pmm+=($(kubectl_bin exec -n "${namespace}" monitoring-0 -- pmm-admin --server-url=https://admin:admin@$(get_service_ip monitoring-service)/ --server-insecure-tls inventory list nodes --node-type=CONTAINER_NODE | grep $node_id | awk '{print $4}'))
+	done
 
    echo "${nodeList_from_pmm[@]}"
 }

--- a/e2e-tests/monitoring-2-0/run
+++ b/e2e-tests/monitoring-2-0/run
@@ -12,7 +12,7 @@ get_node_id_from_pmm() {
 		nodeList+=($(kubectl_bin exec -n "$namespace" $instance -c pmm-client -- pmm-admin status --json | jq -r '.pmm_agent_status.node_id'))
 	done
 
-    echo "${nodeList[@]}"
+	echo "${nodeList[@]}"
 }
 
 does_node_id_exists() {

--- a/e2e-tests/monitoring-2-0/run
+++ b/e2e-tests/monitoring-2-0/run
@@ -22,7 +22,7 @@ does_node_id_exists() {
 		nodeList_from_pmm+=($(kubectl_bin exec -n "${namespace}" monitoring-0 -- pmm-admin --server-url=https://admin:admin@$(get_service_ip monitoring-service)/ --server-insecure-tls inventory list nodes --node-type=CONTAINER_NODE | grep $node_id | awk '{print $4}'))
 	done
 
-   echo "${nodeList_from_pmm[@]}"
+	echo "${nodeList_from_pmm[@]}"
 }
 
 deploy_cert_manager

--- a/pkg/psmdb/pmm.go
+++ b/pkg/psmdb/pmm.go
@@ -386,5 +386,19 @@ func AddPMMContainer(ctx context.Context, cr *api.PerconaServerMongoDB, secret *
 		pmmC.Env = append(pmmC.Env, sidecarEnvs...)
 	}
 
+	if cr.CompareVersion("1.16.0") >= 0 {
+		pmmC.Lifecycle = &corev1.Lifecycle{
+			PreStop: &corev1.LifecycleHandler{
+				Exec: &corev1.ExecAction{
+					Command: []string{
+						"bash",
+						"-c",
+						"pmm-admin unregister --force",
+					},
+				},
+			},
+		}
+	}
+
 	return &pmmC
 }


### PR DESCRIPTION
[![K8SPSMDB-1039](https://badgen.net/badge/JIRA/K8SPSMDB-1039/green)](https://jira.percona.com/browse/K8SPSMDB-1039) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

* use 'pmm-admin unregister' command to the instance from server inventory on pod termination

**CHANGE DESCRIPTION**
---
**Problem:**
*Short explanation of the problem.*

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-1039]: https://perconadev.atlassian.net/browse/K8SPSMDB-1039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ