### PR TITLE
K8SPSMDB-1011: Fix broken username change

### DIFF
--- a/e2e-tests/users/run
+++ b/e2e-tests/users/run
@@ -128,6 +128,17 @@ check_mongo_auth "$user:$pass@$cluster-0.$cluster.$namespace"
 check_mongo_auth "$user:$pass@$cluster-1.$cluster.$namespace"
 check_mongo_auth "$user:$pass@$cluster-2.$cluster.$namespace"
 
+desc 'update monitor user username'
+patch_secret "some-users" "MONGODB_CLUSTER_MONITOR_USER" "$(echo -n "$newmonitorusername" | base64)"
+sleep 35
+wait_cluster_consistency $psmdb
+sleep 15
+user=$(getSecretData "some-users" "MONGODB_CLUSTER_MONITOR_USER")
+pass=$(getSecretData "some-users" "MONGODB_CLUSTER_MONITOR_PASSWORD")
+check_mongo_auth "$user:$pass@$cluster-0.$cluster.$namespace"
+check_mongo_auth "$user:$pass@$cluster-1.$cluster.$namespace"
+check_mongo_auth "$user:$pass@$cluster-2.$cluster.$namespace"
+
 desc 'secret without userAdmin'
 kubectl_bin apply -f "${test_dir}/conf/secrets.yml"
 sleep 25


### PR DESCRIPTION
[![K8SPSMDB-1011](https://badgen.net/badge/JIRA/K8SPSMDB-1011/green)](https://jira.percona.com/browse/K8SPSMDB-1011) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
When usernames get changed, mongos crashes.

**Cause:**
When doing liveness/readiness probes, password was read from secret file while username was read from env var. Since the only way for env var to be updated is with a pod restart, mongos pods read old username thus start to fail.

**Solution:**
Read username from secret file rather than env var in mongos, just like we do for password.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?
- [x] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported MongoDB version?
- [x] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-1011]: https://perconadev.atlassian.net/browse/K8SPSMDB-1011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ