### PR TITLE
K8SPSMDB-948 by default build only 'linux/amd64' arch

### DIFF
--- a/e2e-tests/build
+++ b/e2e-tests/build
@@ -14,6 +14,7 @@ fi
 if [[ ${DOCKER_SQUASH:-1} == 1 ]]; then
 	squash="--squash"
 fi
+
 if [[ ${DOCKER_PUSH:-1} == 1 ]]; then
 	imgresult="--push=true"
 else
@@ -26,16 +27,25 @@ build_operator() {
 	fi
 
 	export IMAGE
-	export DOCKER_DEFAULT_PLATFORM=${DOCKER_DEFAULT_PLATFORM:-"linux/amd64,linux/arm64"}
+	export DOCKER_DEFAULT_PLATFORM=${DOCKER_DEFAULT_PLATFORM:-"linux/amd64"}
 	export GO_LDFLAGS="-w -s -trimpath $GO_LDFLAGS"
+
+	if echo "$DOCKER_DEFAULT_PLATFORM" | grep -q ','; then
+		if [ "${DOCKER_PUSH:-1}" = 0 ]; then
+			echo "'docker $build_command' doesn't support DOCKER_PUSH=0 option in case of multi-arch builds, please use DOCKER_PUSH=1"
+			exit 1
+		fi
+	fi
+
 	pushd ${src_dir}
 	docker buildx build \
 		--platform $DOCKER_DEFAULT_PLATFORM \
 		--build-arg GIT_COMMIT=$GIT_COMMIT \
 		--build-arg GIT_BRANCH=$GIT_BRANCH \
 		--build-arg GO_LDFLAGS="$GO_LDFLAGS" \
-		$imgresult \
+		--progress plain \
 		$squash \
+		$imgresult \
 		$no_cache \
 		-t "${IMAGE}" -f build/Dockerfile .
 	popd


### PR DESCRIPTION
[![K8SPSMDB-948](https://badgen.net/badge/JIRA/K8SPSMDB-948/green)](https://jira.percona.com/browse/K8SPSMDB-948) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

* if the use wants to build different arch or multi-arch
      build DOCKER_DEFAULT_PLATFORM env var should be set
      
 Jenkins job PR is https://github.com/Percona-Lab/jenkins-pipelines/pull/2554, test build https://cloud.cd.percona.com/view/PSMDB/job/psmdb-docker-build/1695/ 

**CHANGE DESCRIPTION**
---
**Problem:**
*Short explanation of the problem.*

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-948]: https://perconadev.atlassian.net/browse/K8SPSMDB-948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ