### PR TITLE
K8SPSMDB-1050 change labels which were depricated

### DIFF
--- a/pkg/apis/psmdb/v1/psmdb_defaults.go
+++ b/pkg/apis/psmdb/v1/psmdb_defaults.go
@@ -783,10 +783,10 @@ func (m *MultiAZ) reconcileOpts(cr *PerconaServerMongoDB) {
 }
 
 var affinityValidTopologyKeys = map[string]struct{}{
-	AffinityOff:                                {},
-	"kubernetes.io/hostname":                   {},
-	"failure-domain.beta.kubernetes.io/zone":   {},
-	"failure-domain.beta.kubernetes.io/region": {},
+	AffinityOff:                     {},
+	"kubernetes.io/hostname":        {},
+	"topology.kubernetes.io/zone":   {},
+	"topology.kubernetes.io/region": {},
 }
 
 var defaultAffinityTopologyKey = "kubernetes.io/hostname"

--- a/pkg/apis/psmdb/v1/psmdb_defaults.go
+++ b/pkg/apis/psmdb/v1/psmdb_defaults.go
@@ -768,7 +768,7 @@ func (rs *ReplsetSpec) setSafeDefaults(log logr.Logger) {
 }
 
 func (m *MultiAZ) reconcileOpts(cr *PerconaServerMongoDB) {
-	m.reconcileAffinityOpts()
+	m.reconcileAffinityOpts(cr)
 	m.reconcileTopologySpreadConstraints(cr)
 	if cr.CompareVersion("1.15.0") >= 0 {
 		if m.TerminationGracePeriodSeconds == nil || (!cr.Spec.UnsafeConf && *m.TerminationGracePeriodSeconds < 30) {
@@ -798,7 +798,16 @@ const AffinityOff = "none"
 // - if topology key is set and the value not the one of `affinityValidTopologyKeys` - set to `defaultAffinityTopologyKey`
 // - if topology key set to valuse of `AffinityOff` - disable the affinity at all
 // - if `Advanced` affinity is set - leave everything as it is and set topology key to nil (Advanced options has a higher priority)
-func (m *MultiAZ) reconcileAffinityOpts() {
+func (m *MultiAZ) reconcileAffinityOpts(cr *PerconaServerMongoDB) {
+
+	if cr.CompareVersion("1.16.0") < 0 {
+		affinityValidTopologyKeys = map[string]struct{}{
+			AffinityOff:                                {},
+			"kubernetes.io/hostname":                   {},
+			"failure-domain.beta.kubernetes.io/zone":   {},
+			"failure-domain.beta.kubernetes.io/region": {},
+		}
+	}
 	switch {
 	case m.Affinity == nil:
 		m.Affinity = &PodAffinity{


### PR DESCRIPTION
[![K8SPSMDB-1050](https://badgen.net/badge/JIRA/K8SPSMDB-1050/green)](https://jira.percona.com/browse/K8SPSMDB-1050) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
*Short explanation of the problem.*
Labels were depricated and I changed them to new ones.
failure-domain.beta.kubernetes.io/region
failure-domain.beta.kubernetes.io/zone

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-1050]: https://perconadev.atlassian.net/browse/K8SPSMDB-1050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ