### PR TITLE
CLOUD-833 - Add release and after-release targets to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,14 @@ $(DEPLOYDIR)/crd.yaml: kustomize generate
 	$(KUSTOMIZE) build config/crd/ > $(DEPLOYDIR)/crd.yaml
 	cp $(DEPLOYDIR)/crd.yaml ./e2e-tests/version-service/conf/crd.yaml
 
+.PHONY: $(DEPLOYDIR)/operator.yaml
+$(DEPLOYDIR)/operator.yaml:
+	sed -i "/^      containers:/,/^        image:/{s#image: .*#image: $(IMAGE_TAG_BASE):$(VERSION)#}" deploy/operator.yaml
+
+.PHONY: $(DEPLOYDIR)/cw-operator.yaml
+$(DEPLOYDIR)/cw-operator.yaml:
+	sed -i "/^      containers:/,/^        image:/{s#image: .*#image: $(IMAGE_TAG_BASE):$(VERSION)#}" deploy/cw-operator.yaml
+
 $(DEPLOYDIR)/bundle.yaml: $(DEPLOYDIR)/crd.yaml $(DEPLOYDIR)/rbac.yaml $(DEPLOYDIR)/operator.yaml  ## Generate deploy/bundle.yaml
 	cat $(DEPLOYDIR)/crd.yaml > $(DEPLOYDIR)/bundle.yaml; echo "---" >> $(DEPLOYDIR)/bundle.yaml; cat $(DEPLOYDIR)/rbac.yaml >> $(DEPLOYDIR)/bundle.yaml; echo "---" >> $(DEPLOYDIR)/bundle.yaml; cat $(DEPLOYDIR)/operator.yaml >> $(DEPLOYDIR)/bundle.yaml
 
@@ -72,3 +80,31 @@ controller-gen: ## Download controller-gen locally if necessary.
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 kustomize: ## Download kustomize locally if necessary.
 	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@v4.5.3)
+
+# Prepare release
+CERT_MANAGER_VER := $(shell grep -Eo "cert-manager v.*" go.mod|grep -Eo "[0-9]+\.[0-9]+\.[0-9]+")
+release: manifests
+	sed -i "/CERT_MANAGER_VER/s/CERT_MANAGER_VER=\".*/CERT_MANAGER_VER=\"$(CERT_MANAGER_VER)\"/" e2e-tests/functions
+	sed -i \
+		-e "s/crVersion: .*/crVersion: $(VERSION)/" \
+		-e "/^spec:/,/^  image:/{s#image: .*#image: percona/percona-server-mongodb:@@SET_TAG@@#}" deploy/cr-minimal.yaml
+	sed -i \
+		-e "s/crVersion: .*/crVersion: $(VERSION)/" \
+		-e "/^spec:/,/^  image:/{s#image: .*#image: percona/percona-server-mongodb:@@SET_TAG@@#}" \
+		-e "/^  backup:/,/^    image:/{s#image: .*#image: percona/percona-backup-mongodb:@@SET_TAG@@#}" \
+		-e "/^  pmm:/,/^    image:/{s#image: .*#image: percona/pmm-client:@@SET_TAG@@#}" deploy/cr.yaml
+
+# Prepare main branch after release
+MAJOR_VER := $(shell grep -oE "crVersion: .*" deploy/cr.yaml|grep -oE "[0-9]+\.[0-9]+\.[0-9]+"|cut -d'.' -f1)
+MINOR_VER := $(shell grep -oE "crVersion: .*" deploy/cr.yaml|grep -oE "[0-9]+\.[0-9]+\.[0-9]+"|cut -d'.' -f2)
+NEXT_VER ?= $(MAJOR_VER).$$(($(MINOR_VER) + 1)).0
+after-release: manifests
+	sed -i "/Version = \"/s/Version = \".*/Version = \"$(NEXT_VER)\"/" version/version.go
+	sed -i \
+		-e "s/crVersion: .*/crVersion: $(NEXT_VER)/" \
+		-e "/^spec:/,/^  image:/{s#image: .*#image: perconalab/percona-server-mongodb-operator:main-mongod6.0#}" deploy/cr-minimal.yaml
+	sed -i \
+		-e "s/crVersion: .*/crVersion: $(NEXT_VER)/" \
+		-e "/^spec:/,/^  image:/{s#image: .*#image: perconalab/percona-server-mongodb-operator:main-mongod6.0#}" \
+		-e "/^  backup:/,/^    image:/{s#image: .*#image: perconalab/percona-server-mongodb-operator:main-backup#}" \
+		-e "/^  pmm:/,/^    image:/{s#image: .*#image: perconalab/pmm-client:dev-latest#}" deploy/cr.yaml


### PR DESCRIPTION
[![CLOUD-833](https://badgen.net/badge/JIRA/CLOUD-833/green)](https://jira.percona.com/browse/CLOUD-833) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
Manual steps need to be taken to prepare release branch and also to prepare main branch after release branch is merged.

**Solution:**
With this manifests will be prepared but also next version and main images set in cr.yaml. What we need to still do manually is set specific database/backup and other images before the release since each product has it's own.

Prepare release example:
`make release VERSION=1.16.0 IMAGE_TAG_BASE=percona/percona-server-mongodb-operator`

Prepare main branch after release example:
`make after-release VERSION=main IMAGE_TAG_BASE=perconalab/percona-server-mongodb-operator`
this above will automatically generate next version.

also works:
`make after-release NEXT_VER=1.17.0 IMAGE=perconalab/percona-server-mongodb-operator:main`

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[CLOUD-833]: https://perconadev.atlassian.net/browse/CLOUD-833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ