### PR TITLE
K8SPSMDB-1029: add `--quiet` to mongod by default

### DIFF
--- a/e2e-tests/arbiter/compare/statefulset_arbiter-clusterip-rs0-arbiter-oc.yml
+++ b/e2e-tests/arbiter/compare/statefulset_arbiter-clusterip-rs0-arbiter-oc.yml
@@ -65,6 +65,7 @@ spec:
         - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
         - --wiredTigerIndexPrefixCompression=true
         - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
         command:
         - /opt/percona/ps-entry.sh
         env:

--- a/e2e-tests/arbiter/compare/statefulset_arbiter-clusterip-rs0-arbiter.yml
+++ b/e2e-tests/arbiter/compare/statefulset_arbiter-clusterip-rs0-arbiter.yml
@@ -65,6 +65,7 @@ spec:
         - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
         - --wiredTigerIndexPrefixCompression=true
         - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
         command:
         - /opt/percona/ps-entry.sh
         env:

--- a/e2e-tests/arbiter/compare/statefulset_arbiter-rs0-arbiter-oc.yml
+++ b/e2e-tests/arbiter/compare/statefulset_arbiter-rs0-arbiter-oc.yml
@@ -66,7 +66,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/arbiter/compare/statefulset_arbiter-rs0-arbiter-oc.yml
+++ b/e2e-tests/arbiter/compare/statefulset_arbiter-rs0-arbiter-oc.yml
@@ -66,6 +66,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/arbiter/compare/statefulset_arbiter-rs0-arbiter.yml
+++ b/e2e-tests/arbiter/compare/statefulset_arbiter-rs0-arbiter.yml
@@ -66,7 +66,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/arbiter/compare/statefulset_arbiter-rs0-arbiter.yml
+++ b/e2e-tests/arbiter/compare/statefulset_arbiter-rs0-arbiter.yml
@@ -66,6 +66,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/data-at-rest-encryption/compare/statefulset_some-name-cfg-oc.yml
+++ b/e2e-tests/data-at-rest-encryption/compare/statefulset_some-name-cfg-oc.yml
@@ -53,6 +53,7 @@ spec:
             - --configsvr
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/data-at-rest-encryption/compare/statefulset_some-name-cfg-oc.yml
+++ b/e2e-tests/data-at-rest-encryption/compare/statefulset_some-name-cfg-oc.yml
@@ -53,7 +53,7 @@ spec:
             - --configsvr
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/data-at-rest-encryption/compare/statefulset_some-name-cfg.yml
+++ b/e2e-tests/data-at-rest-encryption/compare/statefulset_some-name-cfg.yml
@@ -53,6 +53,7 @@ spec:
             - --configsvr
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/data-at-rest-encryption/compare/statefulset_some-name-cfg.yml
+++ b/e2e-tests/data-at-rest-encryption/compare/statefulset_some-name-cfg.yml
@@ -53,7 +53,7 @@ spec:
             - --configsvr
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/data-at-rest-encryption/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/data-at-rest-encryption/compare/statefulset_some-name-rs0-oc.yml
@@ -54,6 +54,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/data-at-rest-encryption/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/data-at-rest-encryption/compare/statefulset_some-name-rs0-oc.yml
@@ -54,7 +54,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/data-at-rest-encryption/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/data-at-rest-encryption/compare/statefulset_some-name-rs0.yml
@@ -54,6 +54,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/data-at-rest-encryption/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/data-at-rest-encryption/compare/statefulset_some-name-rs0.yml
@@ -54,7 +54,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/demand-backup-eks-credentials/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/demand-backup-eks-credentials/compare/statefulset_some-name-rs0.yml
@@ -55,7 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/demand-backup-eks-credentials/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/demand-backup-eks-credentials/compare/statefulset_some-name-rs0.yml
@@ -55,6 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/demand-backup-physical-sharded/compare/statefulset_some-name-rs0_restore_sharded-oc.yml
+++ b/e2e-tests/demand-backup-physical-sharded/compare/statefulset_some-name-rs0_restore_sharded-oc.yml
@@ -57,7 +57,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/physical-restore-ps-entry.sh
           env:

--- a/e2e-tests/demand-backup-physical-sharded/compare/statefulset_some-name-rs0_restore_sharded-oc.yml
+++ b/e2e-tests/demand-backup-physical-sharded/compare/statefulset_some-name-rs0_restore_sharded-oc.yml
@@ -57,6 +57,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/physical-restore-ps-entry.sh
           env:

--- a/e2e-tests/demand-backup-physical-sharded/compare/statefulset_some-name-rs0_restore_sharded.yml
+++ b/e2e-tests/demand-backup-physical-sharded/compare/statefulset_some-name-rs0_restore_sharded.yml
@@ -57,7 +57,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/physical-restore-ps-entry.sh
           env:

--- a/e2e-tests/demand-backup-physical-sharded/compare/statefulset_some-name-rs0_restore_sharded.yml
+++ b/e2e-tests/demand-backup-physical-sharded/compare/statefulset_some-name-rs0_restore_sharded.yml
@@ -57,6 +57,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/physical-restore-ps-entry.sh
           env:

--- a/e2e-tests/demand-backup-physical/compare/statefulset_some-name-rs0_restore-arbiter-nv-oc.yml
+++ b/e2e-tests/demand-backup-physical/compare/statefulset_some-name-rs0_restore-arbiter-nv-oc.yml
@@ -56,7 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/physical-restore-ps-entry.sh
           env:

--- a/e2e-tests/demand-backup-physical/compare/statefulset_some-name-rs0_restore-arbiter-nv-oc.yml
+++ b/e2e-tests/demand-backup-physical/compare/statefulset_some-name-rs0_restore-arbiter-nv-oc.yml
@@ -56,6 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/physical-restore-ps-entry.sh
           env:

--- a/e2e-tests/demand-backup-physical/compare/statefulset_some-name-rs0_restore-arbiter-nv.yml
+++ b/e2e-tests/demand-backup-physical/compare/statefulset_some-name-rs0_restore-arbiter-nv.yml
@@ -56,7 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/physical-restore-ps-entry.sh
           env:

--- a/e2e-tests/demand-backup-physical/compare/statefulset_some-name-rs0_restore-arbiter-nv.yml
+++ b/e2e-tests/demand-backup-physical/compare/statefulset_some-name-rs0_restore-arbiter-nv.yml
@@ -56,6 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/physical-restore-ps-entry.sh
           env:

--- a/e2e-tests/demand-backup-physical/compare/statefulset_some-name-rs0_restore-oc.yml
+++ b/e2e-tests/demand-backup-physical/compare/statefulset_some-name-rs0_restore-oc.yml
@@ -56,7 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/physical-restore-ps-entry.sh
           env:

--- a/e2e-tests/demand-backup-physical/compare/statefulset_some-name-rs0_restore-oc.yml
+++ b/e2e-tests/demand-backup-physical/compare/statefulset_some-name-rs0_restore-oc.yml
@@ -56,6 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/physical-restore-ps-entry.sh
           env:

--- a/e2e-tests/demand-backup-physical/compare/statefulset_some-name-rs0_restore.yml
+++ b/e2e-tests/demand-backup-physical/compare/statefulset_some-name-rs0_restore.yml
@@ -56,7 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/physical-restore-ps-entry.sh
           env:

--- a/e2e-tests/demand-backup-physical/compare/statefulset_some-name-rs0_restore.yml
+++ b/e2e-tests/demand-backup-physical/compare/statefulset_some-name-rs0_restore.yml
@@ -56,6 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/physical-restore-ps-entry.sh
           env:

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs0-4-oc.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs0-4-oc.yml
@@ -56,7 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs0-4-oc.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs0-4-oc.yml
@@ -56,6 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs0-oc.yml
@@ -56,7 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs0-oc.yml
@@ -56,6 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs0.yml
@@ -56,7 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs0.yml
@@ -56,6 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs1-oc.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs1-oc.yml
@@ -56,7 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs1-oc.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs1-oc.yml
@@ -56,6 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs1.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs1.yml
@@ -56,7 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs1.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs1.yml
@@ -56,6 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs2-oc.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs2-oc.yml
@@ -56,7 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs2-oc.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs2-oc.yml
@@ -56,6 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs2.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs2.yml
@@ -56,7 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs2.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs2.yml
@@ -56,6 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/demand-backup/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/demand-backup/compare/statefulset_some-name-rs0-oc.yml
@@ -55,7 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/demand-backup/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/demand-backup/compare/statefulset_some-name-rs0-oc.yml
@@ -55,6 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/demand-backup/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/demand-backup/compare/statefulset_some-name-rs0.yml
@@ -55,7 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/demand-backup/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/demand-backup/compare/statefulset_some-name-rs0.yml
@@ -55,6 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0-4-oc.yml
+++ b/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0-4-oc.yml
@@ -56,7 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0-4-oc.yml
+++ b/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0-4-oc.yml
@@ -56,6 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0-oc.yml
@@ -56,7 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0-oc.yml
@@ -56,6 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0.yml
@@ -56,7 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0.yml
@@ -56,6 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/init-deploy/compare/statefulset_another-name-rs0-4-oc.yml
+++ b/e2e-tests/init-deploy/compare/statefulset_another-name-rs0-4-oc.yml
@@ -56,7 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/init-deploy/compare/statefulset_another-name-rs0-4-oc.yml
+++ b/e2e-tests/init-deploy/compare/statefulset_another-name-rs0-4-oc.yml
@@ -56,6 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/init-deploy/compare/statefulset_another-name-rs0-oc.yml
+++ b/e2e-tests/init-deploy/compare/statefulset_another-name-rs0-oc.yml
@@ -56,7 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/init-deploy/compare/statefulset_another-name-rs0-oc.yml
+++ b/e2e-tests/init-deploy/compare/statefulset_another-name-rs0-oc.yml
@@ -56,6 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/init-deploy/compare/statefulset_another-name-rs0.yml
+++ b/e2e-tests/init-deploy/compare/statefulset_another-name-rs0.yml
@@ -56,7 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/init-deploy/compare/statefulset_another-name-rs0.yml
+++ b/e2e-tests/init-deploy/compare/statefulset_another-name-rs0.yml
@@ -56,6 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/init-deploy/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/init-deploy/compare/statefulset_some-name-rs0-oc.yml
@@ -55,7 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/init-deploy/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/init-deploy/compare/statefulset_some-name-rs0-oc.yml
@@ -55,6 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/init-deploy/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/init-deploy/compare/statefulset_some-name-rs0.yml
@@ -55,7 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/init-deploy/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/init-deploy/compare/statefulset_some-name-rs0.yml
@@ -55,6 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/limits/compare/statefulset_no-limits-rs0-increased-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-rs0-increased-oc.yml
@@ -66,7 +66,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/limits/compare/statefulset_no-limits-rs0-increased-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-rs0-increased-oc.yml
@@ -66,6 +66,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/limits/compare/statefulset_no-limits-rs0-increased.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-rs0-increased.yml
@@ -66,7 +66,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/limits/compare/statefulset_no-limits-rs0-increased.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-rs0-increased.yml
@@ -66,6 +66,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/limits/compare/statefulset_no-limits-rs0-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-rs0-oc.yml
@@ -66,7 +66,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/limits/compare/statefulset_no-limits-rs0-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-rs0-oc.yml
@@ -66,6 +66,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/limits/compare/statefulset_no-limits-rs0.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-rs0.yml
@@ -66,7 +66,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/limits/compare/statefulset_no-limits-rs0.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-rs0.yml
@@ -66,6 +66,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/limits/compare/statefulset_no-requests-no-limits-rs0-increased-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-no-limits-rs0-increased-oc.yml
@@ -66,7 +66,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/limits/compare/statefulset_no-requests-no-limits-rs0-increased-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-no-limits-rs0-increased-oc.yml
@@ -66,6 +66,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/limits/compare/statefulset_no-requests-no-limits-rs0-increased.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-no-limits-rs0-increased.yml
@@ -66,7 +66,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/limits/compare/statefulset_no-requests-no-limits-rs0-increased.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-no-limits-rs0-increased.yml
@@ -66,6 +66,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/limits/compare/statefulset_no-requests-no-limits-rs0-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-no-limits-rs0-oc.yml
@@ -66,7 +66,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/limits/compare/statefulset_no-requests-no-limits-rs0-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-no-limits-rs0-oc.yml
@@ -66,6 +66,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/limits/compare/statefulset_no-requests-no-limits-rs0.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-no-limits-rs0.yml
@@ -66,7 +66,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/limits/compare/statefulset_no-requests-no-limits-rs0.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-no-limits-rs0.yml
@@ -66,6 +66,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/limits/compare/statefulset_no-requests-rs0-increased-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-rs0-increased-oc.yml
@@ -67,7 +67,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/limits/compare/statefulset_no-requests-rs0-increased-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-rs0-increased-oc.yml
@@ -67,6 +67,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/limits/compare/statefulset_no-requests-rs0-increased.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-rs0-increased.yml
@@ -67,7 +67,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/limits/compare/statefulset_no-requests-rs0-increased.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-rs0-increased.yml
@@ -67,6 +67,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/limits/compare/statefulset_no-requests-rs0-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-rs0-oc.yml
@@ -67,7 +67,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/limits/compare/statefulset_no-requests-rs0-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-rs0-oc.yml
@@ -67,6 +67,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/limits/compare/statefulset_no-requests-rs0.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-rs0.yml
@@ -67,7 +67,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/limits/compare/statefulset_no-requests-rs0.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-rs0.yml
@@ -67,6 +67,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/liveness/compare/statefulset_liveness-rs0-changed-oc.yml
+++ b/e2e-tests/liveness/compare/statefulset_liveness-rs0-changed-oc.yml
@@ -55,7 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/liveness/compare/statefulset_liveness-rs0-changed-oc.yml
+++ b/e2e-tests/liveness/compare/statefulset_liveness-rs0-changed-oc.yml
@@ -55,6 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/liveness/compare/statefulset_liveness-rs0-changed.yml
+++ b/e2e-tests/liveness/compare/statefulset_liveness-rs0-changed.yml
@@ -55,7 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/liveness/compare/statefulset_liveness-rs0-changed.yml
+++ b/e2e-tests/liveness/compare/statefulset_liveness-rs0-changed.yml
@@ -55,6 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/liveness/compare/statefulset_liveness-rs0-oc.yml
+++ b/e2e-tests/liveness/compare/statefulset_liveness-rs0-oc.yml
@@ -55,7 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/liveness/compare/statefulset_liveness-rs0-oc.yml
+++ b/e2e-tests/liveness/compare/statefulset_liveness-rs0-oc.yml
@@ -55,6 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/liveness/compare/statefulset_liveness-rs0.yml
+++ b/e2e-tests/liveness/compare/statefulset_liveness-rs0.yml
@@ -55,7 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/liveness/compare/statefulset_liveness-rs0.yml
+++ b/e2e-tests/liveness/compare/statefulset_liveness-rs0.yml
@@ -55,6 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-cfg-oc.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-cfg-oc.yml
@@ -67,6 +67,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-cfg-oc.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-cfg-oc.yml
@@ -67,7 +67,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-cfg.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-cfg.yml
@@ -67,6 +67,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-cfg.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-cfg.yml
@@ -67,7 +67,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0-no-pmm-oc.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0-no-pmm-oc.yml
@@ -55,7 +55,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0-no-pmm-oc.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0-no-pmm-oc.yml
@@ -55,6 +55,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0-no-pmm.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0-no-pmm.yml
@@ -55,7 +55,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0-no-pmm.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0-no-pmm.yml
@@ -55,6 +55,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0-oc.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0-oc.yml
@@ -55,7 +55,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0-oc.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0-oc.yml
@@ -55,6 +55,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0.yml
@@ -55,7 +55,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0.yml
@@ -55,6 +55,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/one-pod/compare/statefulset_one-pod-rs0-oc.yml
+++ b/e2e-tests/one-pod/compare/statefulset_one-pod-rs0-oc.yml
@@ -66,6 +66,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/one-pod/compare/statefulset_one-pod-rs0-oc.yml
+++ b/e2e-tests/one-pod/compare/statefulset_one-pod-rs0-oc.yml
@@ -66,7 +66,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/one-pod/compare/statefulset_one-pod-rs0-secret-oc.yml
+++ b/e2e-tests/one-pod/compare/statefulset_one-pod-rs0-secret-oc.yml
@@ -66,6 +66,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/one-pod/compare/statefulset_one-pod-rs0-secret-oc.yml
+++ b/e2e-tests/one-pod/compare/statefulset_one-pod-rs0-secret-oc.yml
@@ -66,7 +66,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/one-pod/compare/statefulset_one-pod-rs0-secret.yml
+++ b/e2e-tests/one-pod/compare/statefulset_one-pod-rs0-secret.yml
@@ -66,6 +66,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/one-pod/compare/statefulset_one-pod-rs0-secret.yml
+++ b/e2e-tests/one-pod/compare/statefulset_one-pod-rs0-secret.yml
@@ -66,7 +66,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/one-pod/compare/statefulset_one-pod-rs0.yml
+++ b/e2e-tests/one-pod/compare/statefulset_one-pod-rs0.yml
@@ -66,6 +66,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/one-pod/compare/statefulset_one-pod-rs0.yml
+++ b/e2e-tests/one-pod/compare/statefulset_one-pod-rs0.yml
@@ -66,7 +66,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/pitr-physical/compare/statefulset_some-name-rs0-4-oc.yml
+++ b/e2e-tests/pitr-physical/compare/statefulset_some-name-rs0-4-oc.yml
@@ -56,7 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/pitr-physical/compare/statefulset_some-name-rs0-4-oc.yml
+++ b/e2e-tests/pitr-physical/compare/statefulset_some-name-rs0-4-oc.yml
@@ -56,6 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/pitr-physical/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/pitr-physical/compare/statefulset_some-name-rs0-oc.yml
@@ -56,7 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/pitr-physical/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/pitr-physical/compare/statefulset_some-name-rs0-oc.yml
@@ -56,6 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/pitr-physical/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/pitr-physical/compare/statefulset_some-name-rs0.yml
@@ -56,7 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/pitr-physical/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/pitr-physical/compare/statefulset_some-name-rs0.yml
@@ -56,6 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/pitr-physical/compare/statefulset_some-name-rs1-4-oc.yml
+++ b/e2e-tests/pitr-physical/compare/statefulset_some-name-rs1-4-oc.yml
@@ -56,7 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/pitr-physical/compare/statefulset_some-name-rs1-4-oc.yml
+++ b/e2e-tests/pitr-physical/compare/statefulset_some-name-rs1-4-oc.yml
@@ -56,6 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/pitr-physical/compare/statefulset_some-name-rs1-oc.yml
+++ b/e2e-tests/pitr-physical/compare/statefulset_some-name-rs1-oc.yml
@@ -56,7 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/pitr-physical/compare/statefulset_some-name-rs1-oc.yml
+++ b/e2e-tests/pitr-physical/compare/statefulset_some-name-rs1-oc.yml
@@ -56,6 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/pitr-physical/compare/statefulset_some-name-rs1.yml
+++ b/e2e-tests/pitr-physical/compare/statefulset_some-name-rs1.yml
@@ -56,7 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/pitr-physical/compare/statefulset_some-name-rs1.yml
+++ b/e2e-tests/pitr-physical/compare/statefulset_some-name-rs1.yml
@@ -56,6 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/pitr-physical/compare/statefulset_some-name-rs2-4-oc.yml
+++ b/e2e-tests/pitr-physical/compare/statefulset_some-name-rs2-4-oc.yml
@@ -56,7 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/pitr-physical/compare/statefulset_some-name-rs2-4-oc.yml
+++ b/e2e-tests/pitr-physical/compare/statefulset_some-name-rs2-4-oc.yml
@@ -56,6 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/pitr-physical/compare/statefulset_some-name-rs2-oc.yml
+++ b/e2e-tests/pitr-physical/compare/statefulset_some-name-rs2-oc.yml
@@ -56,7 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/pitr-physical/compare/statefulset_some-name-rs2-oc.yml
+++ b/e2e-tests/pitr-physical/compare/statefulset_some-name-rs2-oc.yml
@@ -56,6 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/pitr-physical/compare/statefulset_some-name-rs2.yml
+++ b/e2e-tests/pitr-physical/compare/statefulset_some-name-rs2.yml
@@ -56,7 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/pitr-physical/compare/statefulset_some-name-rs2.yml
+++ b/e2e-tests/pitr-physical/compare/statefulset_some-name-rs2.yml
@@ -56,6 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs0-4-oc.yml
+++ b/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs0-4-oc.yml
@@ -56,7 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs0-4-oc.yml
+++ b/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs0-4-oc.yml
@@ -56,6 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs0-oc.yml
@@ -56,7 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs0-oc.yml
@@ -56,6 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs0.yml
@@ -56,7 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs0.yml
@@ -56,6 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs1-4-oc.yml
+++ b/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs1-4-oc.yml
@@ -56,7 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs1-4-oc.yml
+++ b/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs1-4-oc.yml
@@ -56,6 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs1-oc.yml
+++ b/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs1-oc.yml
@@ -56,7 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs1-oc.yml
+++ b/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs1-oc.yml
@@ -56,6 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs1.yml
+++ b/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs1.yml
@@ -56,7 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs1.yml
+++ b/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs1.yml
@@ -56,6 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs2-4-oc.yml
+++ b/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs2-4-oc.yml
@@ -56,7 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs2-4-oc.yml
+++ b/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs2-4-oc.yml
@@ -56,6 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs2-oc.yml
+++ b/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs2-oc.yml
@@ -56,7 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs2-oc.yml
+++ b/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs2-oc.yml
@@ -56,6 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs2.yml
+++ b/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs2.yml
@@ -56,7 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs2.yml
+++ b/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs2.yml
@@ -56,6 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/pitr/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/pitr/compare/statefulset_some-name-rs0-oc.yml
@@ -55,7 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/pitr/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/pitr/compare/statefulset_some-name-rs0-oc.yml
@@ -55,6 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/pitr/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/pitr/compare/statefulset_some-name-rs0.yml
@@ -55,7 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/pitr/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/pitr/compare/statefulset_some-name-rs0.yml
@@ -55,6 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/rs-shard-migration/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/rs-shard-migration/compare/statefulset_some-name-rs0-oc.yml
@@ -55,7 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/rs-shard-migration/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/rs-shard-migration/compare/statefulset_some-name-rs0-oc.yml
@@ -55,6 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/rs-shard-migration/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/rs-shard-migration/compare/statefulset_some-name-rs0.yml
@@ -55,7 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/rs-shard-migration/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/rs-shard-migration/compare/statefulset_some-name-rs0.yml
@@ -55,6 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/scheduled-backup/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/scheduled-backup/compare/statefulset_some-name-rs0-oc.yml
@@ -55,7 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/scheduled-backup/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/scheduled-backup/compare/statefulset_some-name-rs0-oc.yml
@@ -55,6 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/scheduled-backup/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/scheduled-backup/compare/statefulset_some-name-rs0.yml
@@ -55,7 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/scheduled-backup/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/scheduled-backup/compare/statefulset_some-name-rs0.yml
@@ -55,6 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/security-context/compare/statefulset_sec-context-rs0-changed.yml
+++ b/e2e-tests/security-context/compare/statefulset_sec-context-rs0-changed.yml
@@ -56,7 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/security-context/compare/statefulset_sec-context-rs0-changed.yml
+++ b/e2e-tests/security-context/compare/statefulset_sec-context-rs0-changed.yml
@@ -56,6 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/security-context/compare/statefulset_sec-context-rs0.yml
+++ b/e2e-tests/security-context/compare/statefulset_sec-context-rs0.yml
@@ -56,7 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/security-context/compare/statefulset_sec-context-rs0.yml
+++ b/e2e-tests/security-context/compare/statefulset_sec-context-rs0.yml
@@ -56,6 +56,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/service-per-pod/compare/statefulset_cluster-ip-rs0-oc.yml
+++ b/e2e-tests/service-per-pod/compare/statefulset_cluster-ip-rs0-oc.yml
@@ -54,6 +54,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/service-per-pod/compare/statefulset_cluster-ip-rs0-oc.yml
+++ b/e2e-tests/service-per-pod/compare/statefulset_cluster-ip-rs0-oc.yml
@@ -54,7 +54,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/service-per-pod/compare/statefulset_cluster-ip-rs0.yml
+++ b/e2e-tests/service-per-pod/compare/statefulset_cluster-ip-rs0.yml
@@ -54,6 +54,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/service-per-pod/compare/statefulset_cluster-ip-rs0.yml
+++ b/e2e-tests/service-per-pod/compare/statefulset_cluster-ip-rs0.yml
@@ -54,7 +54,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/service-per-pod/compare/statefulset_local-balancer-rs0-oc.yml
+++ b/e2e-tests/service-per-pod/compare/statefulset_local-balancer-rs0-oc.yml
@@ -54,6 +54,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/service-per-pod/compare/statefulset_local-balancer-rs0-oc.yml
+++ b/e2e-tests/service-per-pod/compare/statefulset_local-balancer-rs0-oc.yml
@@ -54,7 +54,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/service-per-pod/compare/statefulset_local-balancer-rs0.yml
+++ b/e2e-tests/service-per-pod/compare/statefulset_local-balancer-rs0.yml
@@ -54,6 +54,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/service-per-pod/compare/statefulset_local-balancer-rs0.yml
+++ b/e2e-tests/service-per-pod/compare/statefulset_local-balancer-rs0.yml
@@ -54,7 +54,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/service-per-pod/compare/statefulset_node-port-rs0-oc.yml
+++ b/e2e-tests/service-per-pod/compare/statefulset_node-port-rs0-oc.yml
@@ -54,6 +54,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/service-per-pod/compare/statefulset_node-port-rs0-oc.yml
+++ b/e2e-tests/service-per-pod/compare/statefulset_node-port-rs0-oc.yml
@@ -54,7 +54,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/service-per-pod/compare/statefulset_node-port-rs0.yml
+++ b/e2e-tests/service-per-pod/compare/statefulset_node-port-rs0.yml
@@ -54,6 +54,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/service-per-pod/compare/statefulset_node-port-rs0.yml
+++ b/e2e-tests/service-per-pod/compare/statefulset_node-port-rs0.yml
@@ -54,7 +54,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/smart-update/compare/statefulset_smart-update-rs0-arbiter-oc.yml
+++ b/e2e-tests/smart-update/compare/statefulset_smart-update-rs0-arbiter-oc.yml
@@ -55,7 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/smart-update/compare/statefulset_smart-update-rs0-arbiter-oc.yml
+++ b/e2e-tests/smart-update/compare/statefulset_smart-update-rs0-arbiter-oc.yml
@@ -55,6 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/smart-update/compare/statefulset_smart-update-rs0-arbiter.yml
+++ b/e2e-tests/smart-update/compare/statefulset_smart-update-rs0-arbiter.yml
@@ -55,7 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/smart-update/compare/statefulset_smart-update-rs0-arbiter.yml
+++ b/e2e-tests/smart-update/compare/statefulset_smart-update-rs0-arbiter.yml
@@ -55,6 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/smart-update/compare/statefulset_smart-update-rs0-oc.yml
+++ b/e2e-tests/smart-update/compare/statefulset_smart-update-rs0-oc.yml
@@ -55,7 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/smart-update/compare/statefulset_smart-update-rs0-oc.yml
+++ b/e2e-tests/smart-update/compare/statefulset_smart-update-rs0-oc.yml
@@ -55,6 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/smart-update/compare/statefulset_smart-update-rs0.yml
+++ b/e2e-tests/smart-update/compare/statefulset_smart-update-rs0.yml
@@ -55,7 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/smart-update/compare/statefulset_smart-update-rs0.yml
+++ b/e2e-tests/smart-update/compare/statefulset_smart-update-rs0.yml
@@ -55,6 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/storage/compare/statefulset_emptydir-rs0-oc.yml
+++ b/e2e-tests/storage/compare/statefulset_emptydir-rs0-oc.yml
@@ -66,7 +66,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/storage/compare/statefulset_emptydir-rs0-oc.yml
+++ b/e2e-tests/storage/compare/statefulset_emptydir-rs0-oc.yml
@@ -66,6 +66,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/storage/compare/statefulset_emptydir-rs0.yml
+++ b/e2e-tests/storage/compare/statefulset_emptydir-rs0.yml
@@ -66,7 +66,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/storage/compare/statefulset_emptydir-rs0.yml
+++ b/e2e-tests/storage/compare/statefulset_emptydir-rs0.yml
@@ -66,6 +66,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/storage/compare/statefulset_hostpath-rs0-oc.yml
+++ b/e2e-tests/storage/compare/statefulset_hostpath-rs0-oc.yml
@@ -54,6 +54,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/storage/compare/statefulset_hostpath-rs0-oc.yml
+++ b/e2e-tests/storage/compare/statefulset_hostpath-rs0-oc.yml
@@ -54,7 +54,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/storage/compare/statefulset_hostpath-rs0.yml
+++ b/e2e-tests/storage/compare/statefulset_hostpath-rs0.yml
@@ -66,7 +66,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/storage/compare/statefulset_hostpath-rs0.yml
+++ b/e2e-tests/storage/compare/statefulset_hostpath-rs0.yml
@@ -66,6 +66,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1140-oc.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1140-oc.yml
@@ -55,7 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1140-oc.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1140-oc.yml
@@ -55,6 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1150-oc.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1150-oc.yml
@@ -55,7 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1150-oc.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1150-oc.yml
@@ -55,6 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1160-oc.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1160-oc.yml
@@ -55,7 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1160-oc.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1160-oc.yml
@@ -55,6 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1140-oc.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1140-oc.yml
@@ -55,7 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1140-oc.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1140-oc.yml
@@ -55,6 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1140.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1140.yml
@@ -68,7 +68,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1140.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1140.yml
@@ -68,6 +68,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1150-oc.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1150-oc.yml
@@ -55,7 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1150-oc.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1150-oc.yml
@@ -55,6 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1150.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1150.yml
@@ -68,7 +68,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1150.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1150.yml
@@ -68,6 +68,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1160-oc.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1160-oc.yml
@@ -55,7 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1160-oc.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1160-oc.yml
@@ -55,6 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1160.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1160.yml
@@ -68,7 +68,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1160.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1160.yml
@@ -68,6 +68,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1140-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1140-oc.yml
@@ -55,7 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1140-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1140-oc.yml
@@ -55,6 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1140.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1140.yml
@@ -55,7 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1140.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1140.yml
@@ -55,6 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1150-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1150-oc.yml
@@ -55,7 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1150-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1150-oc.yml
@@ -55,6 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1150.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1150.yml
@@ -55,7 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1150.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1150.yml
@@ -55,6 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1160-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1160-oc.yml
@@ -55,7 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1160-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1160-oc.yml
@@ -55,6 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1160.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1160.yml
@@ -55,7 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1160.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1160.yml
@@ -55,6 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/version-service/compare/statefulset_version-service-exact-rs0-oc.yml
+++ b/e2e-tests/version-service/compare/statefulset_version-service-exact-rs0-oc.yml
@@ -55,7 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/version-service/compare/statefulset_version-service-exact-rs0-oc.yml
+++ b/e2e-tests/version-service/compare/statefulset_version-service-exact-rs0-oc.yml
@@ -55,6 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/version-service/compare/statefulset_version-service-exact-rs0.yml
+++ b/e2e-tests/version-service/compare/statefulset_version-service-exact-rs0.yml
@@ -55,7 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/version-service/compare/statefulset_version-service-exact-rs0.yml
+++ b/e2e-tests/version-service/compare/statefulset_version-service-exact-rs0.yml
@@ -55,6 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/version-service/compare/statefulset_version-service-latest-rs0-oc.yml
+++ b/e2e-tests/version-service/compare/statefulset_version-service-latest-rs0-oc.yml
@@ -55,7 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/version-service/compare/statefulset_version-service-latest-rs0-oc.yml
+++ b/e2e-tests/version-service/compare/statefulset_version-service-latest-rs0-oc.yml
@@ -55,6 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/version-service/compare/statefulset_version-service-latest-rs0.yml
+++ b/e2e-tests/version-service/compare/statefulset_version-service-latest-rs0.yml
@@ -55,7 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/version-service/compare/statefulset_version-service-latest-rs0.yml
+++ b/e2e-tests/version-service/compare/statefulset_version-service-latest-rs0.yml
@@ -55,6 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/version-service/compare/statefulset_version-service-major-rs0-oc.yml
+++ b/e2e-tests/version-service/compare/statefulset_version-service-major-rs0-oc.yml
@@ -55,7 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/version-service/compare/statefulset_version-service-major-rs0-oc.yml
+++ b/e2e-tests/version-service/compare/statefulset_version-service-major-rs0-oc.yml
@@ -55,6 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/version-service/compare/statefulset_version-service-major-rs0.yml
+++ b/e2e-tests/version-service/compare/statefulset_version-service-major-rs0.yml
@@ -55,7 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/version-service/compare/statefulset_version-service-major-rs0.yml
+++ b/e2e-tests/version-service/compare/statefulset_version-service-major-rs0.yml
@@ -55,6 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/version-service/compare/statefulset_version-service-recommended-rs0-oc.yml
+++ b/e2e-tests/version-service/compare/statefulset_version-service-recommended-rs0-oc.yml
@@ -55,7 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/version-service/compare/statefulset_version-service-recommended-rs0-oc.yml
+++ b/e2e-tests/version-service/compare/statefulset_version-service-recommended-rs0-oc.yml
@@ -55,6 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/version-service/compare/statefulset_version-service-recommended-rs0.yml
+++ b/e2e-tests/version-service/compare/statefulset_version-service-recommended-rs0.yml
@@ -55,7 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/version-service/compare/statefulset_version-service-recommended-rs0.yml
+++ b/e2e-tests/version-service/compare/statefulset_version-service-recommended-rs0.yml
@@ -55,6 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/version-service/compare/statefulset_version-service-unreachable-rs0-oc.yml
+++ b/e2e-tests/version-service/compare/statefulset_version-service-unreachable-rs0-oc.yml
@@ -55,7 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/version-service/compare/statefulset_version-service-unreachable-rs0-oc.yml
+++ b/e2e-tests/version-service/compare/statefulset_version-service-unreachable-rs0-oc.yml
@@ -55,6 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/version-service/compare/statefulset_version-service-unreachable-rs0.yml
+++ b/e2e-tests/version-service/compare/statefulset_version-service-unreachable-rs0.yml
@@ -55,7 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
-        - --quiet
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/version-service/compare/statefulset_version-service-unreachable-rs0.yml
+++ b/e2e-tests/version-service/compare/statefulset_version-service-unreachable-rs0.yml
@@ -55,6 +55,7 @@ spec:
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
             - --config=/etc/mongodb-config/mongod.conf
+        - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/pkg/psmdb/container.go
+++ b/pkg/psmdb/container.go
@@ -268,6 +268,10 @@ func containerArgs(ctx context.Context, cr *api.PerconaServerMongoDB, replset *a
 		args = append(args, fmt.Sprintf("--config=%s/mongod.conf", mongodConfigDir))
 	}
 
+	if cr.CompareVersion("1.16.0") >= 0 {
+		args = append(args, "--quiet")
+	}
+
 	return args
 }
 


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/K8SPSMDB-1029

**CHANGE DESCRIPTION**
---
**Problem:**
*Short explanation of the problem.*

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
