### PR TITLE
K8SPSMDB-985: All PBM backup nodes in the status

### DIFF
--- a/config/crd/bases/psmdb.percona.com_perconaservermongodbbackups.yaml
+++ b/config/crd/bases/psmdb.percona.com_perconaservermongodbbackups.yaml
@@ -105,6 +105,10 @@ spec:
                 type: string
               pbmPod:
                 type: string
+              pbmPods:
+                additionalProperties:
+                  type: string
+                type: object
               replsetNames:
                 items:
                   type: string

--- a/config/crd/bases/psmdb.percona.com_perconaservermongodbrestores.yaml
+++ b/config/crd/bases/psmdb.percona.com_perconaservermongodbrestores.yaml
@@ -75,6 +75,10 @@ spec:
                     type: string
                   pbmPod:
                     type: string
+                  pbmPods:
+                    additionalProperties:
+                      type: string
+                    type: object
                   replsetNames:
                     items:
                       type: string

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -104,6 +104,10 @@ spec:
                 type: string
               pbmPod:
                 type: string
+              pbmPods:
+                additionalProperties:
+                  type: string
+                type: object
               replsetNames:
                 items:
                   type: string
@@ -234,6 +238,10 @@ spec:
                     type: string
                   pbmPod:
                     type: string
+                  pbmPods:
+                    additionalProperties:
+                      type: string
+                    type: object
                   replsetNames:
                     items:
                       type: string

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -104,6 +104,10 @@ spec:
                 type: string
               pbmPod:
                 type: string
+              pbmPods:
+                additionalProperties:
+                  type: string
+                type: object
               replsetNames:
                 items:
                   type: string
@@ -234,6 +238,10 @@ spec:
                     type: string
                   pbmPod:
                     type: string
+                  pbmPods:
+                    additionalProperties:
+                      type: string
+                    type: object
                   replsetNames:
                     items:
                       type: string

--- a/deploy/cw-bundle.yaml
+++ b/deploy/cw-bundle.yaml
@@ -104,6 +104,10 @@ spec:
                 type: string
               pbmPod:
                 type: string
+              pbmPods:
+                additionalProperties:
+                  type: string
+                type: object
               replsetNames:
                 items:
                   type: string
@@ -234,6 +238,10 @@ spec:
                     type: string
                   pbmPod:
                     type: string
+                  pbmPods:
+                    additionalProperties:
+                      type: string
+                    type: object
                   replsetNames:
                     items:
                       type: string

--- a/e2e-tests/version-service/conf/crd.yaml
+++ b/e2e-tests/version-service/conf/crd.yaml
@@ -104,6 +104,10 @@ spec:
                 type: string
               pbmPod:
                 type: string
+              pbmPods:
+                additionalProperties:
+                  type: string
+                type: object
               replsetNames:
                 items:
                   type: string
@@ -234,6 +238,10 @@ spec:
                     type: string
                   pbmPod:
                     type: string
+                  pbmPods:
+                    additionalProperties:
+                      type: string
+                    type: object
                   replsetNames:
                     items:
                       type: string

--- a/pkg/apis/psmdb/v1/perconaservermongodbbackup_types.go
+++ b/pkg/apis/psmdb/v1/perconaservermongodbbackup_types.go
@@ -47,6 +47,7 @@ type PerconaServerMongoDBBackupStatus struct {
 	ReplsetNames         []string                `json:"replsetNames,omitempty"`
 	PBMname              string                  `json:"pbmName,omitempty"`
 	PBMPod               string                  `json:"pbmPod,omitempty"`
+	// PBMPods              map[string]string       `json:"pbmPods,omitempty"`
 	Error                string                  `json:"error,omitempty"`
 	LatestRestorableTime *metav1.Time            `json:"latestRestorableTime,omitempty"`
 }

--- a/pkg/apis/psmdb/v1/perconaservermongodbbackup_types.go
+++ b/pkg/apis/psmdb/v1/perconaservermongodbbackup_types.go
@@ -47,7 +47,7 @@ type PerconaServerMongoDBBackupStatus struct {
 	ReplsetNames         []string                `json:"replsetNames,omitempty"`
 	PBMname              string                  `json:"pbmName,omitempty"`
 	PBMPod               string                  `json:"pbmPod,omitempty"`
-	// PBMPods              map[string]string       `json:"pbmPods,omitempty"`
+	PBMPods              map[string]string       `json:"pbmPods,omitempty"`
 	Error                string                  `json:"error,omitempty"`
 	LatestRestorableTime *metav1.Time            `json:"latestRestorableTime,omitempty"`
 }

--- a/pkg/apis/psmdb/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/psmdb/v1/zz_generated.deepcopy.go
@@ -955,6 +955,13 @@ func (in *PerconaServerMongoDBBackupStatus) DeepCopyInto(out *PerconaServerMongo
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.PBMPods != nil {
+		in, out := &in.PBMPods, &out.PBMPods
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.LatestRestorableTime != nil {
 		in, out := &in.LatestRestorableTime, &out.LatestRestorableTime
 		*out = (*in).DeepCopy()

--- a/pkg/controller/perconaservermongodbbackup/backup.go
+++ b/pkg/controller/perconaservermongodbbackup/backup.go
@@ -177,11 +177,11 @@ func (b *Backup) Status(ctx context.Context, cr *api.PerconaServerMongoDBBackup,
 	}
 	status.PBMPod = node
 
-	// nodes, err := b.pbm.Nodes(ctx, rsNames)
-	// if err != nil {
-	// 	return status, nil
-	// }
-	// status.PBMPods = nodes
+	nodes, err := b.pbm.Nodes(ctx, rsNames)
+	if err != nil {
+		return status, nil
+	}
+	status.PBMPods = nodes
 
 	return status, nil
 }

--- a/pkg/controller/perconaservermongodbbackup/backup.go
+++ b/pkg/controller/perconaservermongodbbackup/backup.go
@@ -125,7 +125,7 @@ func (b *Backup) Start(ctx context.Context, k8sclient client.Client, cluster *ap
 }
 
 // Status return backup status
-func (b *Backup) Status(ctx context.Context, cr *api.PerconaServerMongoDBBackup) (api.PerconaServerMongoDBBackupStatus, error) {
+func (b *Backup) Status(ctx context.Context, cr *api.PerconaServerMongoDBBackup, rsNames []string) (api.PerconaServerMongoDBBackupStatus, error) {
 	status := cr.Status
 
 	meta, err := b.pbm.GetBackupMeta(ctx, cr.Status.PBMname)
@@ -176,6 +176,12 @@ func (b *Backup) Status(ctx context.Context, cr *api.PerconaServerMongoDBBackup)
 		return status, nil
 	}
 	status.PBMPod = node
+
+	// nodes, err := b.pbm.Nodes(ctx, rsNames)
+	// if err != nil {
+	// 	return status, nil
+	// }
+	// status.PBMPods = nodes
 
 	return status, nil
 }

--- a/pkg/controller/perconaservermongodbbackup/perconaservermongodbbackup_controller.go
+++ b/pkg/controller/perconaservermongodbbackup/perconaservermongodbbackup_controller.go
@@ -233,8 +233,13 @@ func (r *ReconcilePerconaServerMongoDBBackup) reconcile(
 		return bcp.Start(ctx, r.client, cluster, cr)
 	}
 
+	rsNames := make([]string, 0, len(cluster.Spec.Replsets))
+	for _, rs := range cluster.Spec.Replsets {
+		rsNames = append(rsNames, rs.Name)
+	}
+
 	time.Sleep(5 * time.Second)
-	return bcp.Status(ctx, cr)
+	return bcp.Status(ctx, cr, rsNames)
 }
 
 func (r *ReconcilePerconaServerMongoDBBackup) getPBMStorage(ctx context.Context, cr *psmdbv1.PerconaServerMongoDBBackup) (storage.Storage, error) {


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
Backup status showed only a node from zeroth replica set, but we need to have nodes from all the replica sets on which the backup was made.

**Solution:**
Add `status.pbmPods` map that will hold replica set with a corresponding instance on which the backup  was performed.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
