### PR TITLE
K8SPSMDB-1064 - Minor fix in pitr-sharded test for sporadic failure

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -1456,7 +1456,7 @@ get_latest_restorable_time() {
 		sleep 5
 		timestamp=$(kubectl exec "$cluster-0" -c backup-agent -- pbm status -o json | jq '.backups.pitrChunks.pitrChunks | last | .range.end')
 		timeout=$((timeout + 5))
-		if [[ $timeout -gt 30 ]]; then
+		if [[ $timeout -gt 50 ]]; then
 			echo "Error: timeout waiting for timestamp"
 			exit 1
 		fi

--- a/e2e-tests/pitr-sharded/run
+++ b/e2e-tests/pitr-sharded/run
@@ -64,7 +64,7 @@ check_recovery() {
 		| if [ -z "$restore_date" ]; then $sed -e "/date:/d"; else $sed -e "s/date:/date: $restore_date/"; fi \
 		| kubectl_bin apply -f -
 
-	wait_restore "$backup_name" "$cluster_name"
+	wait_restore "$backup_name" "$cluster_name" "ready" 1
 	echo
 	set -o xtrace
 
@@ -104,7 +104,7 @@ main() {
 	desc 'check if all 3 Pods started'
 	wait_for_running $cluster-rs0 3
 	wait_for_running $cluster-cfg 3 "false"
-	sleep 10
+	wait_cluster_consistency $cluster
 
 	desc 'check if statefulset created with expected config'
 	compare_kubectl statefulset/$cluster-rs0


### PR DESCRIPTION
[![K8SPSMDB-1064](https://badgen.net/badge/JIRA/K8SPSMDB-1064/green)](https://jira.percona.com/browse/K8SPSMDB-1064) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
*Test is sporadically failing because backup is started on non ready cluster.*

**Solution:**
*Wait for cluster readyness before starting backup*

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?
- [x] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported MongoDB version?
- [x] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-1064]: https://perconadev.atlassian.net/browse/K8SPSMDB-1064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ