### PR TITLE
K8SPSMDB-1055: return `ErrNoOplogsForPITR` on empty `oplog.Timeline`

### DIFF
--- a/pkg/psmdb/backup/pbm.go
+++ b/pkg/psmdb/backup/pbm.go
@@ -462,7 +462,12 @@ func (b *pbmC) GetLatestTimelinePITR(ctx context.Context) (oplog.Timeline, error
 		return oplog.Timeline{}, ErrNoOplogsForPITR
 	}
 
-	return timelines[len(timelines)-1], nil
+	tl := timelines[len(timelines)-1]
+	if tl.Start == 0 || tl.End == 0 {
+		return oplog.Timeline{}, ErrNoOplogsForPITR
+	}
+
+	return tl, nil
 }
 
 // PITRGetChunkContains returns a pitr slice chunk that belongs to the


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/K8SPSMDB-1055

**DESCRIPTION**
---
**Problem:**
*The first values of `.status.latestRestorableTime` in `psmdb-backup` are `1970-01-01T00:00:00`. This is an incorrect value that shouldn't be set by the operator.*

**Cause:**
*`oplog.PITRGetValidTimelines` sometimes returns a list with empty `oplog.Timeline` (`End` and `Start` values are set to 0). Because of this, `GetLatestTimelinePITR` returns an empty timeline, resulting in `.Status.LatestRestorableTime` getting a value of `1970-01-01T00:00:00`.*

**Solution:**
*Operator should return `ErrNoOplogsForPITR` error on empty `oplog.Timeline` in the `GetLatestTimelinePITR` method.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
