### PR TITLE
K8SPSMDB-1065: Fix checking oplog slicing locks

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -1460,11 +1460,10 @@ get_latest_restorable_time() {
 	# "pbm-agent status" can return different timestamp in first few seconds
 	# we need to get it twice to be sure that timestamp was not changed
 	until [[ $first_timestamp != "" && $first_timestamp != "null" && $first_timestamp == $second_timestamp ]]; do
+		first_timestamp=$(kubectl_bin exec "$cluster-0" -c backup-agent -- pbm status -o json | jq '.backups.pitrChunks.pitrChunks | last | .range.end')
 		sleep 5
 		if [[ $first_timestamp != "" && $first_timestamp != "null" ]]; then
 			second_timestamp=$(kubectl_bin exec "$cluster-0" -c backup-agent -- pbm status -o json | jq '.backups.pitrChunks.pitrChunks | last | .range.end')
-		else
-			first_timestamp=$(kubectl_bin exec "$cluster-0" -c backup-agent -- pbm status -o json | jq '.backups.pitrChunks.pitrChunks | last | .range.end')
 		fi
 		let retry+=1
 		if [[ $retry -gt 30 ]]; then

--- a/e2e-tests/pitr/run
+++ b/e2e-tests/pitr/run
@@ -93,30 +93,6 @@ check_recovery() {
 	compare_mongo_cmd "find" "myApp:myPass@$cluster-2.$cluster.$namespace" "$cmp_postfix"
 }
 
-get_latest_restorable_time() {
-	local cluster=$1
-	local timestamp
-
-	timestamp=$(kubectl exec "$cluster-0" -c backup-agent -- pbm status -o json | jq '.backups.pitrChunks.pitrChunks | last | .range.end')
-
-	$date -u -d @"$timestamp" "+%Y-%m-%dT%H:%M:%SZ"
-}
-
-compare_latest_restorable_time() {
-	local cluster=$1
-	local backup_name=$2
-	local latest_restorable_time
-	latest_restorable_time=$(get_latest_restorable_time "$cluster")
-	local backup_time
-	backup_time=$(kubectl get psmdb-backup "$backup_name" -o jsonpath='{.status.latestRestorableTime}')
-
-	if [[ $latest_restorable_time != "$backup_time" ]]; then
-		echo "Error: latestRestorableTime is not equal to the latest timestamp of the backup $backup_name: $latest_restorable_time != $backup_time"
-		exit 1
-	fi
-
-}
-
 main() {
 	create_infra $namespace
 	deploy_minio

--- a/pkg/psmdb/backup/pbm.go
+++ b/pkg/psmdb/backup/pbm.go
@@ -389,8 +389,15 @@ func NotJobLock(j Job) LockHeaderPredicate {
 func (b *pbmC) HasLocks(ctx context.Context, predicates ...LockHeaderPredicate) (bool, error) {
 	locks, err := lock.GetLocks(ctx, b.Client, &lock.LockHeader{})
 	if err != nil {
-		return false, errors.Wrap(err, "getting lock data")
+		return false, errors.Wrap(err, "get lock data")
 	}
+
+	opLocks, err := lock.GetOpLocks(ctx, b.Client, &lock.LockHeader{})
+	if err != nil {
+		return false, errors.Wrap(err, "get op lock data")
+	}
+
+	locks = append(locks, opLocks...)
 
 	allowedByAllPredicates := func(l lock.LockHeader) bool {
 		for _, allow := range predicates {


### PR DESCRIPTION
[![K8SPSMDB-1065](https://badgen.net/badge/JIRA/K8SPSMDB-1065/green)](https://jira.percona.com/browse/K8SPSMDB-1065) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
To check if PITR is stopped operator uses `GetLocks()` function and it returns nothing because pitr slicing now is under `GetOpLocks()`

**Solution:**
Use `GetOpLocks()`

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?
- [x] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported MongoDB version?
- [x] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-1065]: https://perconadev.atlassian.net/browse/K8SPSMDB-1065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ