### PR TITLE
K8SPSMDB-1055: fix type conversion for `pitr.compressionLevel`

### DIFF
--- a/e2e-tests/pitr/conf/some-name-rs0.yml
+++ b/e2e-tests/pitr/conf/some-name-rs0.yml
@@ -21,6 +21,10 @@ spec:
     pitr:
       enabled: true
       oplogSpanMin: 2
+      oplogOnly: false
+      oplogSpanMin: 10
+      compressionType: gzip
+      compressionLevel: 6
   replsets:
   - name: rs0
     affinity:

--- a/pkg/controller/perconaservermongodb/backup.go
+++ b/pkg/controller/perconaservermongodb/backup.go
@@ -439,7 +439,7 @@ func (r *ReconcilePerconaServerMongoDB) updatePITR(ctx context.Context, cr *api.
 
 	enabled, ok := val.(bool)
 	if !ok {
-		return errors.Wrap(err, "unexpected value of pitr.enabled")
+		return errors.Errorf("unexpected value of pitr.enabled: %T", val)
 	}
 
 	if enabled != cr.Spec.Backup.PITR.Enabled {
@@ -469,7 +469,7 @@ func (r *ReconcilePerconaServerMongoDB) updatePITR(ctx context.Context, cr *api.
 
 	oplogOnly, ok := val.(bool)
 	if !ok {
-		return errors.Wrap(err, "unexpected value of pitr.oplogOnly")
+		return errors.Errorf("unexpected value of pitr.oplogOnly: %T", val)
 	}
 
 	if oplogOnly != cr.Spec.Backup.PITR.OplogOnly {
@@ -491,7 +491,7 @@ func (r *ReconcilePerconaServerMongoDB) updatePITR(ctx context.Context, cr *api.
 
 	oplogSpanMin, ok := val.(float64)
 	if !ok {
-		return errors.Wrap(err, "unexpected value of pitr.oplogSpanMin")
+		return errors.Errorf("unexpected value of pitr.oplogSpanMin: %T", val)
 	}
 
 	if oplogSpanMin != cr.Spec.Backup.PITR.OplogSpanMin.Float64() {
@@ -512,7 +512,7 @@ func (r *ReconcilePerconaServerMongoDB) updatePITR(ctx context.Context, cr *api.
 	} else {
 		compression, ok = val.(string)
 		if !ok {
-			return errors.Wrap(err, "unexpected value of pitr.compression")
+			return errors.Errorf("unexpected value of pitr.compression: %T", val)
 		}
 	}
 
@@ -543,11 +543,16 @@ func (r *ReconcilePerconaServerMongoDB) updatePITR(ctx context.Context, cr *api.
 			return errors.Wrap(err, "get pitr.compressionLevel")
 		}
 	} else {
-		tmpCompressionLevel, ok := val.(int)
-		if !ok {
-			return errors.Wrap(err, "unexpected value of pitr.compressionLevel")
+		var iVal int
+		switch v := val.(type) {
+		case int64:
+			iVal = int(v)
+		case int32:
+			iVal = int(v)
+		default:
+			return errors.Errorf("unexpected value of pitr.compressionLevel: %T", val)
 		}
-		compressionLevel = &tmpCompressionLevel
+		compressionLevel = &iVal
 	}
 
 	if !reflect.DeepEqual(compressionLevel, cr.Spec.Backup.PITR.CompressionLevel) {


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/K8SPSMDB-1055

**CHANGE DESCRIPTION**
---
**Problem:**
*Short explanation of the problem.*

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
