### PR TITLE
K8SPSMDB-1056: Respect serviceAccountName in delete-backup finalize

### DIFF
--- a/config/crd/bases/psmdb.percona.com_perconaservermongodbbackups.yaml
+++ b/config/crd/bases/psmdb.percona.com_perconaservermongodbbackups.yaml
@@ -147,6 +147,8 @@ spec:
                 required:
                 - bucket
                 type: object
+              serviceAccountName:
+                type: string
               start:
                 format: date-time
                 type: string

--- a/config/crd/bases/psmdb.percona.com_perconaservermongodbrestores.yaml
+++ b/config/crd/bases/psmdb.percona.com_perconaservermongodbrestores.yaml
@@ -117,6 +117,8 @@ spec:
                     required:
                     - bucket
                     type: object
+                  serviceAccountName:
+                    type: string
                   start:
                     format: date-time
                     type: string

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -146,6 +146,8 @@ spec:
                 required:
                 - bucket
                 type: object
+              serviceAccountName:
+                type: string
               start:
                 format: date-time
                 type: string
@@ -280,6 +282,8 @@ spec:
                     required:
                     - bucket
                     type: object
+                  serviceAccountName:
+                    type: string
                   start:
                     format: date-time
                     type: string

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -146,6 +146,8 @@ spec:
                 required:
                 - bucket
                 type: object
+              serviceAccountName:
+                type: string
               start:
                 format: date-time
                 type: string
@@ -280,6 +282,8 @@ spec:
                     required:
                     - bucket
                     type: object
+                  serviceAccountName:
+                    type: string
                   start:
                     format: date-time
                     type: string

--- a/deploy/cw-bundle.yaml
+++ b/deploy/cw-bundle.yaml
@@ -146,6 +146,8 @@ spec:
                 required:
                 - bucket
                 type: object
+              serviceAccountName:
+                type: string
               start:
                 format: date-time
                 type: string
@@ -280,6 +282,8 @@ spec:
                     required:
                     - bucket
                     type: object
+                  serviceAccountName:
+                    type: string
                   start:
                     format: date-time
                     type: string

--- a/e2e-tests/ignore-labels-annotations/compare/service_some-name-mongos-0-one-service-label-annotation.yml
+++ b/e2e-tests/ignore-labels-annotations/compare/service_some-name-mongos-0-one-service-label-annotation.yml
@@ -1,4 +1,4 @@
-apiVersion: v1
+alpiVersion: v1
 kind: Service
 metadata:
   annotations:

--- a/e2e-tests/version-service/conf/crd.yaml
+++ b/e2e-tests/version-service/conf/crd.yaml
@@ -146,6 +146,8 @@ spec:
                 required:
                 - bucket
                 type: object
+              serviceAccountName:
+                type: string
               start:
                 format: date-time
                 type: string
@@ -280,6 +282,8 @@ spec:
                     required:
                     - bucket
                     type: object
+                  serviceAccountName:
+                    type: string
                   start:
                     format: date-time
                     type: string

--- a/pkg/apis/psmdb/v1/perconaservermongodbbackup_types.go
+++ b/pkg/apis/psmdb/v1/perconaservermongodbbackup_types.go
@@ -35,17 +35,18 @@ const (
 
 // PerconaServerMongoDBBackupStatus defines the observed state of PerconaServerMongoDBBackup
 type PerconaServerMongoDBBackupStatus struct {
-	Type           defs.BackupType         `json:"type,omitempty"`
-	State          BackupState             `json:"state,omitempty"`
-	StartAt        *metav1.Time            `json:"start,omitempty"`
-	CompletedAt    *metav1.Time            `json:"completed,omitempty"`
-	LastTransition *metav1.Time            `json:"lastTransition,omitempty"`
-	Destination    string                  `json:"destination,omitempty"`
-	StorageName    string                  `json:"storageName,omitempty"`
-	S3             *BackupStorageS3Spec    `json:"s3,omitempty"`
-	Azure          *BackupStorageAzureSpec `json:"azure,omitempty"`
-	ReplsetNames   []string                `json:"replsetNames,omitempty"`
-	PBMname        string                  `json:"pbmName,omitempty"`
+	Type               defs.BackupType         `json:"type,omitempty"`
+	State              BackupState             `json:"state,omitempty"`
+	StartAt            *metav1.Time            `json:"start,omitempty"`
+	CompletedAt        *metav1.Time            `json:"completed,omitempty"`
+	LastTransition     *metav1.Time            `json:"lastTransition,omitempty"`
+	Destination        string                  `json:"destination,omitempty"`
+	StorageName        string                  `json:"storageName,omitempty"`
+	S3                 *BackupStorageS3Spec    `json:"s3,omitempty"`
+	Azure              *BackupStorageAzureSpec `json:"azure,omitempty"`
+	ReplsetNames       []string                `json:"replsetNames,omitempty"`
+	PBMname            string                  `json:"pbmName,omitempty"`
+	ServiceAccountName string                  `json:"serviceAccountName,omitempty"`
 
 	// Deprecated: Use PBMPods instead
 	PBMPod               string            `json:"pbmPod,omitempty"`

--- a/pkg/controller/perconaservermongodbbackup/backup.go
+++ b/pkg/controller/perconaservermongodbbackup/backup.go
@@ -83,8 +83,9 @@ func (b *Backup) Start(ctx context.Context, k8sclient client.Client, cluster *ap
 	}
 
 	status = api.PerconaServerMongoDBBackupStatus{
-		StorageName: cr.Spec.StorageName,
-		PBMname:     name,
+		StorageName:        cr.Spec.StorageName,
+		PBMname:            name,
+		ServiceAccountName: cluster.Spec.Backup.ServiceAccountName,
 		LastTransition: &metav1.Time{
 			Time: time.Unix(time.Now().Unix(), 0),
 		},

--- a/pkg/controller/perconaservermongodbbackup/perconaservermongodbbackup_controller.go
+++ b/pkg/controller/perconaservermongodbbackup/perconaservermongodbbackup_controller.go
@@ -258,9 +258,10 @@ func (r *ReconcilePerconaServerMongoDBBackup) getPBMStorage(ctx context.Context,
 		}
 		return azure.New(azureConf, nil)
 	case cr.Status.S3 != nil:
-		if cr.Status.S3.CredentialsSecret == "" {
-			return nil, errors.New("no s3 credentials specified for the secret name")
+		if cr.Status.ServiceAccountName == "" && cr.Status.S3.CredentialsSecret == "" {
+			return nil, errors.New("no serviceAccountName or s3 credentials specified for the secret name specified")
 		}
+
 		s3Conf := s3.Conf{
 			Region:                cr.Status.S3.Region,
 			EndpointURL:           cr.Status.S3.EndpointURL,
@@ -271,9 +272,17 @@ func (r *ReconcilePerconaServerMongoDBBackup) getPBMStorage(ctx context.Context,
 			StorageClass:          cr.Status.S3.StorageClass,
 			InsecureSkipTLSVerify: cr.Status.S3.InsecureSkipTLSVerify,
 		}
-		s3secret, err := secret(ctx, r.client, cr.Namespace, cr.Status.S3.CredentialsSecret)
-		if err != nil {
-			return nil, errors.Wrap(err, "getting s3 credentials secret name")
+
+		if cr.Status.S3.CredentialsSecret != "" {
+			s3secret, err := secret(ctx, r.client, cr.Namespace, cr.Status.S3.CredentialsSecret)
+			if err != nil {
+				return nil, errors.Wrap(err, "getting s3 credentials secret name")
+			}
+
+			s3Conf.Credentials = s3.Credentials{
+				AccessKeyID:     string(s3secret.Data[backup.AWSAccessKeySecretKey]),
+				SecretAccessKey: string(s3secret.Data[backup.AWSSecretAccessKeySecretKey]),
+			}
 		}
 
 		if len(cr.Status.S3.ServerSideEncryption.SSECustomerAlgorithm) != 0 {
@@ -319,10 +328,6 @@ func (r *ReconcilePerconaServerMongoDBBackup) getPBMStorage(ctx context.Context,
 			}
 		}
 
-		s3Conf.Credentials = s3.Credentials{
-			AccessKeyID:     string(s3secret.Data[backup.AWSAccessKeySecretKey]),
-			SecretAccessKey: string(s3secret.Data[backup.AWSSecretAccessKeySecretKey]),
-		}
 		return s3.New(s3Conf, nil)
 	default:
 		return nil, errors.New("no storage info in backup status")

--- a/pkg/psmdb/backup/pbm.go
+++ b/pkg/psmdb/backup/pbm.go
@@ -268,53 +268,54 @@ func GetPBMConfig(ctx context.Context, k8sclient client.Client, cluster *api.Per
 				return conf, errors.Wrap(err, "get s3 credentials secret")
 			}
 
-			if len(stg.S3.ServerSideEncryption.SSECustomerAlgorithm) != 0 {
-
-				switch {
-				case len(stg.S3.ServerSideEncryption.SSECustomerKey) != 0:
-					conf.Storage.S3.ServerSideEncryption = &s3.AWSsse{
-						SseCustomerAlgorithm: stg.S3.ServerSideEncryption.SSECustomerAlgorithm,
-						SseCustomerKey:       stg.S3.ServerSideEncryption.SSECustomerKey,
-					}
-				case len(cluster.Spec.Secrets.SSE) != 0:
-					sseSecret, err := getSecret(ctx, k8sclient, cluster.Namespace, cluster.Spec.Secrets.SSE)
-
-					if err != nil {
-						return conf, errors.Wrap(err, "get sse credentials secret")
-					}
-					conf.Storage.S3.ServerSideEncryption = &s3.AWSsse{
-						SseCustomerAlgorithm: stg.S3.ServerSideEncryption.SSECustomerAlgorithm,
-						SseCustomerKey:       string(sseSecret.Data[SSECustomerKey]),
-					}
-				default:
-					return conf, errors.New("no SseCustomerKey specified")
-				}
-			}
-
-			if len(stg.S3.ServerSideEncryption.SSEAlgorithm) != 0 {
-				switch {
-				case len(stg.S3.ServerSideEncryption.KMSKeyID) != 0:
-					conf.Storage.S3.ServerSideEncryption = &s3.AWSsse{
-						SseAlgorithm: stg.S3.ServerSideEncryption.SSEAlgorithm,
-						KmsKeyID:     stg.S3.ServerSideEncryption.KMSKeyID,
-					}
-
-				case len(cluster.Spec.Secrets.SSE) != 0:
-					sseSecret, err := getSecret(ctx, k8sclient, cluster.Namespace, cluster.Spec.Secrets.SSE)
-					if err != nil {
-						return conf, errors.Wrap(err, "get sse credentials secret")
-					}
-					conf.Storage.S3.ServerSideEncryption = &s3.AWSsse{
-						SseAlgorithm: stg.S3.ServerSideEncryption.SSEAlgorithm,
-						KmsKeyID:     string(sseSecret.Data[KMSKeyID]),
-					}
-				default:
-					return conf, errors.New("no KmsKeyID specified")
-				}
-			}
 			conf.Storage.S3.Credentials = s3.Credentials{
 				AccessKeyID:     string(s3secret.Data[AWSAccessKeySecretKey]),
 				SecretAccessKey: string(s3secret.Data[AWSSecretAccessKeySecretKey]),
+			}
+		}
+
+		if len(stg.S3.ServerSideEncryption.SSECustomerAlgorithm) != 0 {
+
+			switch {
+			case len(stg.S3.ServerSideEncryption.SSECustomerKey) != 0:
+				conf.Storage.S3.ServerSideEncryption = &s3.AWSsse{
+					SseCustomerAlgorithm: stg.S3.ServerSideEncryption.SSECustomerAlgorithm,
+					SseCustomerKey:       stg.S3.ServerSideEncryption.SSECustomerKey,
+				}
+			case len(cluster.Spec.Secrets.SSE) != 0:
+				sseSecret, err := getSecret(ctx, k8sclient, cluster.Namespace, cluster.Spec.Secrets.SSE)
+
+				if err != nil {
+					return conf, errors.Wrap(err, "get sse credentials secret")
+				}
+				conf.Storage.S3.ServerSideEncryption = &s3.AWSsse{
+					SseCustomerAlgorithm: stg.S3.ServerSideEncryption.SSECustomerAlgorithm,
+					SseCustomerKey:       string(sseSecret.Data[SSECustomerKey]),
+				}
+			default:
+				return conf, errors.New("no SseCustomerKey specified")
+			}
+		}
+
+		if len(stg.S3.ServerSideEncryption.SSEAlgorithm) != 0 {
+			switch {
+			case len(stg.S3.ServerSideEncryption.KMSKeyID) != 0:
+				conf.Storage.S3.ServerSideEncryption = &s3.AWSsse{
+					SseAlgorithm: stg.S3.ServerSideEncryption.SSEAlgorithm,
+					KmsKeyID:     stg.S3.ServerSideEncryption.KMSKeyID,
+				}
+
+			case len(cluster.Spec.Secrets.SSE) != 0:
+				sseSecret, err := getSecret(ctx, k8sclient, cluster.Namespace, cluster.Spec.Secrets.SSE)
+				if err != nil {
+					return conf, errors.Wrap(err, "get sse credentials secret")
+				}
+				conf.Storage.S3.ServerSideEncryption = &s3.AWSsse{
+					SseAlgorithm: stg.S3.ServerSideEncryption.SSEAlgorithm,
+					KmsKeyID:     string(sseSecret.Data[KMSKeyID]),
+				}
+			default:
+				return conf, errors.New("no KmsKeyID specified")
 			}
 		}
 	case api.BackupStorageAzure:

--- a/privs.sh
+++ b/privs.sh
@@ -1,0 +1,195 @@
+#!/bin/bash
+
+# Variables
+
+kubectl_auth_command="kubectl auth can-i"  # Kubectl auth command
+missing_privileges=false
+cluster_wide=false                         # Set if operator is installed in cluster-wide mode
+missing_resources=false                    # If resource is not installed in k8s cluster
+# PXC and PSMDB for future use
+pxc_operator_install=true
+psmdb_operator_install=true
+pg_operator_install=true
+
+# privileges to check in the k8s cluster
+privileges=(
+    "create customresourcedefinitions"
+    "get customresourcedefinitions"
+    "list customresourcedefinitions"
+    "watch customresourcedefinitions"
+    "create events"
+    "patch events"
+    "create serviceaccount"
+    "get serviceaccount"
+    "list serviceaccount"
+    "watch serviceaccount"            
+    "'*' role"
+    "'*' pods"
+    "'*' pods --subresource=exec"
+    "'*' pods --subresource=log"
+    "'*' configmaps"
+    "'*' services"
+    "'*' persistentvolumeclaims"
+    "'*' deployments.apps"
+    "'*' replicasets.apps"
+    "'*' statefulset.apps"
+    "'*' jobs.batch"
+    "'*' cronjobs.batch"
+    "'*' poddisruptionbudgets.policy"
+    "'*' leases"
+    "'*' issuers"
+    "'*' certificates")
+
+# Display usage information
+usage() {
+    echo "Usage: $0 [--as AS_USER] [--namespace NAMESPACE] [--cluster-wide]"
+    echo "  --as AS_USER      Specify the user/service account(system:serviceaccount:<namespace>:<service-account>) to impersonate for privileges check"
+    echo "  --namespace NS    Specify the namespace for privileges check"
+    echo "  --cluster-wide    Set to perform cluster-wide privileges check"
+    echo "  --kubeconfig PATH   Specify the path to the kubeconfig file"
+    exit 1
+}
+
+# Check privileges with kubectl auth can-i
+check_privileges() {
+    action="$1"
+    command="${kubectl_auth_command} $action"
+    result=$(eval "$command" 2>&1)
+    if [[ "$result" != *"yes"* ]]; then
+        echo "Permission denied for action: $action"
+        
+        # Check if missing privileges is for Postgres Operator
+        if [[ ${pg_operator_privileges[@]} =~ $action ]] ; then 
+	        pg_operator_install=false
+            return
+        fi
+        # Placeholder for PXC and PSMDB for future
+
+        # Common privileges are missing, no operator can be installed
+        missing_privileges=true
+
+    elif [[ "$result" == *"Warning: the server doesn't have a resource type"* ]]; then
+        IFS=' ' read -ra action_array <<< "$action"
+        RESOURCE=$(echo "$action" | cut -d ' ' -f 2-)
+	    missing_resources=true
+        echo "Warning: Unable to check the privileges for resource '$RESOURCE', check if the resource '$RESOURCE' is present in the cluster"	    
+    fi
+}
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    key="$1"
+    case $key in
+        --as)
+        AS_USER="$2"
+        kubectl_auth_command="${kubectl_auth_command} --as ${AS_USER}"
+        shift # past argument
+        shift # past value
+        ;;
+        -n|--namespace)
+        NAMESPACE="$2"
+        shift # past argument
+        shift # past value
+        kubectl_auth_command="${kubectl_auth_command} -n ${NAMESPACE}"
+        ;;
+        --kubeconfig)
+        KUBE_CONFIG="$2"
+        shift # past argument
+        shift # past value
+        kubectl_auth_command="${kubectl_auth_command} --kubeconfig ${KUBE_CONFIG}"
+        ;;        
+        --cluster-wide)
+        cluster_wide=true
+        shift # past argument
+        ;;
+        --help|-h)
+        usage
+        ;;
+        *)    # unknown option
+        echo "Unknown option: $1"
+        exit 1
+        ;;
+    esac
+done
+
+
+
+# privileges for namespace-wide or cluster-wide mode
+if [[ "$cluster_wide" == true ]]; then
+    privileges+=(
+        "create clusterrole"
+        "get clusterrole"
+        "list clusterrole"
+        "watch clusterrole
+        "create clusterrolebinding"
+        "get clusterrolebinding"
+        "list clusterrolebinding"
+        "watch clusterrolebinding"
+    )
+else
+    privileges+=(
+        "create role"
+        "get role"
+        "list role"
+        "watch role
+        "create clusterrolebinding"
+        "get clusterrolebinding"
+        "list clusterrolebinding"
+        "watch clusterrolebinding"
+    )
+fi
+
+# privileges for PXC Operator
+
+# privileges for PSMDB Operator
+
+# privileges for Postgress Operator
+pg_operator_privileges=(
+    "'*' endpoints"
+    "create endpoints --subresource=restricted"
+)
+
+
+# Run kubectl auth can-i commands for the privileges
+printf "Checking privileges to install Percona Operators in kubernetes cluster...\n"
+
+for perm in "${privileges[@]}"; do
+    check_privileges "$perm"
+done
+
+
+if ${missing_resources}; then
+    printf "\nWarning: Some resources are not found in the kubernetes cluster.Check the Warning messages before you proceed\n"
+fi
+printf '%.0s-' {1..90}
+if ${missing_privileges}; then
+    printf "\nMISSING PRIVILEGES TO INSTALL any Percona Operator\n"
+    exit 0
+fi 
+
+if ! ${pg_operator_install}; then 
+    printf "\nMISSING PRIVILEGES TO INSTALL: Percona Operator for PostgreSQL\n"
+    printf "https://docs.percona.com/percona-operator-for-postgresql/index.html\n"
+else
+     printf "\nGOOD TO INSTALL: Percona Operator for PostgreSQL\n"
+     printf "https://docs.percona.com/percona-operator-for-postgresql/index.html\n"
+fi
+printf '%.0s-' {1..90};
+
+if ! ${pxc_operator_install}; then
+    printf "\nMISSING PRIVILEGES TO INSTALL: Percona Operator for MySQL based on Percona XtraDB Cluster\n"
+    printf "https://docs.percona.com/percona-operator-for-postgresql/index.html\n"
+else
+     printf "\nGOOD TO INSTALL: Percona Operator for MySQL based on Percona XtraDB Cluster\n"
+     printf "https://docs.percona.com/percona-operator-for-postgresql/index.html\n"
+fi
+printf '%.0s-' {1..90}; 
+
+if ! ${psmdb_operator_install}; then 
+    printf "\nMISSING PRIVILEGES TO INSTALL: Percona Operator for MongoDB\n"
+    printf "https://docs.percona.com/percona-operator-for-mongodb/index.html\n"
+else
+     printf "\nGOOD TO INSTALL: Percona Operator for MongoDB\n"
+     printf "https://docs.percona.com/percona-operator-for-mongodb/index.html\n"
+fi
+printf '%.0s-' {1..90} ; echo ""


### PR DESCRIPTION
[![K8SPSMDB-1056](https://badgen.net/badge/JIRA/K8SPSMDB-1056/green)](https://jira.percona.com/browse/K8SPSMDB-1056) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
We don't respect `cr.backup.serviceAccountName` when running `delete-backup` finalizer.

**Solution:**
Check if `cr.backup.serviceAccountName` is present and use it.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?
- [x] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported MongoDB version?
- [x] Does the change support oldest and newest supported Kubernetes version?