### PR TITLE
K8SPSMDB - Fix default-cr and upgrade-consistency-sharded-tls tests

### DIFF
--- a/e2e-tests/default-cr/compare/statefulset_minimal-cluster-cfg-oc.yml
+++ b/e2e-tests/default-cr/compare/statefulset_minimal-cluster-cfg-oc.yml
@@ -67,6 +67,7 @@ spec:
             - --enableEncryption
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/default-cr/compare/statefulset_minimal-cluster-cfg.yml
+++ b/e2e-tests/default-cr/compare/statefulset_minimal-cluster-cfg.yml
@@ -67,6 +67,7 @@ spec:
             - --enableEncryption
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/default-cr/compare/statefulset_minimal-cluster-rs0-oc.yml
+++ b/e2e-tests/default-cr/compare/statefulset_minimal-cluster-rs0-oc.yml
@@ -67,6 +67,7 @@ spec:
             - --enableEncryption
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/default-cr/compare/statefulset_minimal-cluster-rs0.yml
+++ b/e2e-tests/default-cr/compare/statefulset_minimal-cluster-rs0.yml
@@ -67,6 +67,7 @@ spec:
             - --enableEncryption
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerIndexPrefixCompression=true
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/default-cr/compare/statefulset_my-cluster-name-cfg-oc.yml
+++ b/e2e-tests/default-cr/compare/statefulset_my-cluster-name-cfg-oc.yml
@@ -55,6 +55,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/default-cr/compare/statefulset_my-cluster-name-cfg.yml
+++ b/e2e-tests/default-cr/compare/statefulset_my-cluster-name-cfg.yml
@@ -55,6 +55,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/default-cr/compare/statefulset_my-cluster-name-rs0-oc.yml
+++ b/e2e-tests/default-cr/compare/statefulset_my-cluster-name-rs0-oc.yml
@@ -55,6 +55,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/default-cr/compare/statefulset_my-cluster-name-rs0.yml
+++ b/e2e-tests/default-cr/compare/statefulset_my-cluster-name-rs0.yml
@@ -55,6 +55,7 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
+            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1140-oc.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1140-oc.yml
@@ -67,7 +67,6 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
-            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1150-oc.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1150-oc.yml
@@ -67,7 +67,6 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
-            - --quiet
           command:
             - /opt/percona/ps-entry.sh
           env:


### PR DESCRIPTION
[![K8SPSMDB-998](https://badgen.net/badge/JIRA/K8SPSMDB-998/green)](https://jira.percona.com/browse/K8SPSMDB-998) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
These tests are not run in PR tests so the option was not added correctly.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-998]: https://perconadev.atlassian.net/browse/K8SPSMDB-998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ