### PR TITLE
K8SPSMDB-1070: Fix panic in delete-psmdb-pods-in-order finalizer

### DIFF
--- a/pkg/controller/perconaservermongodb/finalizers.go
+++ b/pkg/controller/perconaservermongodb/finalizers.go
@@ -135,6 +135,10 @@ func (r *ReconcilePerconaServerMongoDB) deleteRSPods(ctx context.Context, cr *ap
 		return errors.Wrap(err, "get rs statefulset")
 	}
 
+	if len(pods.Items) == 0 {
+		return nil
+	}
+
 	// `k8sclient.List` returns unsorted list of pods
 	// We should sort pods to be sure that the first pod is the primary
 	sort.Slice(pods.Items, func(i, j int) bool {


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
Panic in delete-psmdb-pods-in-order finalizer if cluster is deleted before pods are created.

**Solution:**
Perform a sanity check before getting the first pod in the PodList.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?
- [x] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported MongoDB version?
- [x] Does the change support oldest and newest supported Kubernetes version?
