### PR TITLE
K8SPSMDB-998 - Fix default-cr test

### DIFF
--- a/e2e-tests/default-cr/compare/statefulset_minimal-cluster-cfg-oc.yml
+++ b/e2e-tests/default-cr/compare/statefulset_minimal-cluster-cfg-oc.yml
@@ -61,8 +61,8 @@ spec:
             - --storageEngine=wiredTiger
             - --relaxPermChecks
             - --sslAllowInvalidCertificates
-            - --clusterAuthMode=keyFile
-            - --keyFile=/etc/mongodb-secrets/mongodb-key
+            - --clusterAuthMode=x509
+            - --tlsMode=preferTLS
             - --configsvr
             - --enableEncryption
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
@@ -88,6 +88,12 @@ spec:
                 - /opt/percona/mongodb-healthcheck
                 - k8s
                 - liveness
+                - --ssl
+                - --sslInsecure
+                - --sslCAFile
+                - /etc/mongodb-ssl/ca.crt
+                - --sslPEMKeyFile
+                - /tmp/tls.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -174,7 +180,7 @@ spec:
         - name: ssl
           secret:
             defaultMode: 288
-            optional: true
+            optional: false
             secretName: minimal-cluster-ssl
         - name: ssl-internal
           secret:

--- a/e2e-tests/default-cr/compare/statefulset_minimal-cluster-cfg.yml
+++ b/e2e-tests/default-cr/compare/statefulset_minimal-cluster-cfg.yml
@@ -61,8 +61,8 @@ spec:
             - --storageEngine=wiredTiger
             - --relaxPermChecks
             - --sslAllowInvalidCertificates
-            - --clusterAuthMode=keyFile
-            - --keyFile=/etc/mongodb-secrets/mongodb-key
+            - --clusterAuthMode=x509
+            - --tlsMode=preferTLS
             - --configsvr
             - --enableEncryption
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
@@ -88,6 +88,12 @@ spec:
                 - /opt/percona/mongodb-healthcheck
                 - k8s
                 - liveness
+                - --ssl
+                - --sslInsecure
+                - --sslCAFile
+                - /etc/mongodb-ssl/ca.crt
+                - --sslPEMKeyFile
+                - /tmp/tls.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -176,7 +182,7 @@ spec:
         - name: ssl
           secret:
             defaultMode: 288
-            optional: true
+            optional: false
             secretName: minimal-cluster-ssl
         - name: ssl-internal
           secret:

--- a/e2e-tests/default-cr/compare/statefulset_minimal-cluster-rs0-oc.yml
+++ b/e2e-tests/default-cr/compare/statefulset_minimal-cluster-rs0-oc.yml
@@ -61,8 +61,8 @@ spec:
             - --storageEngine=wiredTiger
             - --relaxPermChecks
             - --sslAllowInvalidCertificates
-            - --clusterAuthMode=keyFile
-            - --keyFile=/etc/mongodb-secrets/mongodb-key
+            - --clusterAuthMode=x509
+            - --tlsMode=preferTLS
             - --shardsvr
             - --enableEncryption
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
@@ -88,6 +88,12 @@ spec:
                 - /opt/percona/mongodb-healthcheck
                 - k8s
                 - liveness
+                - --ssl
+                - --sslInsecure
+                - --sslCAFile
+                - /etc/mongodb-ssl/ca.crt
+                - --sslPEMKeyFile
+                - /tmp/tls.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -174,7 +180,7 @@ spec:
         - name: ssl
           secret:
             defaultMode: 288
-            optional: true
+            optional: false
             secretName: minimal-cluster-ssl
         - name: ssl-internal
           secret:

--- a/e2e-tests/default-cr/compare/statefulset_minimal-cluster-rs0.yml
+++ b/e2e-tests/default-cr/compare/statefulset_minimal-cluster-rs0.yml
@@ -61,8 +61,8 @@ spec:
             - --storageEngine=wiredTiger
             - --relaxPermChecks
             - --sslAllowInvalidCertificates
-            - --clusterAuthMode=keyFile
-            - --keyFile=/etc/mongodb-secrets/mongodb-key
+            - --clusterAuthMode=x509
+            - --tlsMode=preferTLS
             - --shardsvr
             - --enableEncryption
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
@@ -88,6 +88,12 @@ spec:
                 - /opt/percona/mongodb-healthcheck
                 - k8s
                 - liveness
+                - --ssl
+                - --sslInsecure
+                - --sslCAFile
+                - /etc/mongodb-ssl/ca.crt
+                - --sslPEMKeyFile
+                - /tmp/tls.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -176,7 +182,7 @@ spec:
         - name: ssl
           secret:
             defaultMode: 288
-            optional: true
+            optional: false
             secretName: minimal-cluster-ssl
         - name: ssl-internal
           secret:

--- a/e2e-tests/default-cr/run
+++ b/e2e-tests/default-cr/run
@@ -109,7 +109,7 @@ function main() {
 	wait_cluster_consistency $cluster
 
 	desc 'enabling arbiter'
-	kubectl_bin patch psmdb ${cluster} --type json -p='[{"op":"replace","path":"/spec/replsets/0/arbiter/enabled","value":true}]'
+	kubectl_bin patch psmdb ${cluster} --type json -p='[{"op":"replace","path":"/spec/replsets/0/arbiter/enabled","value":true},{"op":"replace","path":"/spec/replsets/0/size","value":4}]'
 	wait_cluster_consistency $cluster
 	wait_pod $cluster-rs0-arbiter-0
 


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
*There's a diff and we can no longer run size: 3 and arbiter enabled so we need to increase size.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
