### PR TITLE
K8SPSMDB-755: Fix enabling/disabling TLS in a running cluster

### DIFF
--- a/config/crd/bases/psmdb.percona.com_perconaservermongodbs.yaml
+++ b/config/crd/bases/psmdb.percona.com_perconaservermongodbs.yaml
@@ -18283,6 +18283,8 @@ spec:
                 type: integer
               state:
                 type: string
+              tlsMode:
+                type: string
             required:
             - ready
             - size

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -18956,6 +18956,8 @@ spec:
                 type: integer
               state:
                 type: string
+              tlsMode:
+                type: string
             required:
             - ready
             - size

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -18956,6 +18956,8 @@ spec:
                 type: integer
               state:
                 type: string
+              tlsMode:
+                type: string
             required:
             - ready
             - size

--- a/deploy/cw-bundle.yaml
+++ b/deploy/cw-bundle.yaml
@@ -18956,6 +18956,8 @@ spec:
                 type: integer
               state:
                 type: string
+              tlsMode:
+                type: string
             required:
             - ready
             - size

--- a/e2e-tests/conf/cmctl.yml
+++ b/e2e-tests/conf/cmctl.yml
@@ -21,7 +21,7 @@ spec:
           - /bin/sh
           - -c
           - |
-            curl -fsSL -o /tmp/cmctl.tar.gz https://github.com/cert-manager/cert-manager/releases/latest/download/cmctl-linux-amd64.tar.gz \
-            && tar -C /tmp -xzf /tmp/cmctl.tar.gz \
+            curl -fsSL -o /tmp/cmctl https://github.com/cert-manager/cmctl/releases/download/v2.0.0/cmctl_linux_amd64 \
+            && chmod +x /tmp/cmctl \
             && sleep 100500
       restartPolicy: Always

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -1492,6 +1492,7 @@ get_latest_restorable_time_from_backup_object() {
 
 	echo "$latestRestorableTime"
 }
+
 compare_latest_restorable_time() {
 	local cluster=$1
 	local backup_name=$2
@@ -1505,4 +1506,31 @@ compare_latest_restorable_time() {
 		echo "Error: latestRestorableTime is not equal to the latest timestamp of the backup $backup_name: $latest_restorable_time != $backup_time"
 		exit 1
 	fi
+}
+
+disable_tls() {
+	local cluster=$1
+
+	echo "Disabling TLS for cluster $cluster"
+
+	kubectl_bin patch psmdb ${cluster} --type merge -p='{"spec": { "unsafeFlags": { "tls": true }, "tls": { "mode": "disabled" } } }'
+}
+
+wait_for_cluster_state() {
+	local cluster_name=$1
+	local target_state=$2
+
+	echo -n "Waiting for cluster to reach ${target_state} state"
+	local timeout=0
+	until [[ $(kubectl_bin get psmdb ${cluster_name} -o jsonpath={.status.state}) == ${target_state} ]]; do
+		sleep 1
+		timeout=$((timeout + 1))
+		echo -n '.'
+		if [[ ${timeout} -gt 1500 ]]; then
+			echo
+			echo "Waiting timeout has been reached. Exiting..."
+			exit 1
+		fi
+	done
+	echo
 }

--- a/e2e-tests/tls-issue-cert-manager/compare/statefulset_some-name-cfg-tls-disabled.yml
+++ b/e2e-tests/tls-issue-cert-manager/compare/statefulset_some-name-cfg-tls-disabled.yml
@@ -1,0 +1,203 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations: {}
+  generation: 4
+  labels:
+    app.kubernetes.io/component: cfg
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/managed-by: percona-server-mongodb-operator
+    app.kubernetes.io/name: percona-server-mongodb
+    app.kubernetes.io/part-of: percona-server-mongodb
+    app.kubernetes.io/replset: cfg
+  name: some-name-cfg
+  ownerReferences:
+    - controller: true
+      kind: PerconaServerMongoDB
+      name: some-name
+spec:
+  podManagementPolicy: OrderedReady
+  replicas: 3
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: cfg
+      app.kubernetes.io/instance: some-name
+      app.kubernetes.io/managed-by: percona-server-mongodb-operator
+      app.kubernetes.io/name: percona-server-mongodb
+      app.kubernetes.io/part-of: percona-server-mongodb
+      app.kubernetes.io/replset: cfg
+  serviceName: some-name-cfg
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: cfg
+        app.kubernetes.io/instance: some-name
+        app.kubernetes.io/managed-by: percona-server-mongodb-operator
+        app.kubernetes.io/name: percona-server-mongodb
+        app.kubernetes.io/part-of: percona-server-mongodb
+        app.kubernetes.io/replset: cfg
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: cfg
+                  app.kubernetes.io/instance: some-name
+                  app.kubernetes.io/managed-by: percona-server-mongodb-operator
+                  app.kubernetes.io/name: percona-server-mongodb
+                  app.kubernetes.io/part-of: percona-server-mongodb
+                  app.kubernetes.io/replset: cfg
+              topologyKey: kubernetes.io/hostname
+      containers:
+        - args:
+            - --bind_ip_all
+            - --auth
+            - --dbpath=/data/db
+            - --port=27017
+            - --replSet=cfg
+            - --storageEngine=wiredTiger
+            - --relaxPermChecks
+            - --clusterAuthMode=keyFile
+            - --keyFile=/etc/mongodb-secrets/mongodb-key
+            - --tlsMode=disabled
+            - --configsvr
+            - --enableEncryption
+            - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
+            - --wiredTigerIndexPrefixCompression=true
+            - --quiet
+          command:
+            - /opt/percona/ps-entry.sh
+          env:
+            - name: SERVICE_NAME
+              value: some-name
+            - name: MONGODB_PORT
+              value: "27017"
+            - name: MONGODB_REPLSET
+              value: cfg
+          envFrom:
+            - secretRef:
+                name: internal-some-name-users
+                optional: false
+          imagePullPolicy: Always
+          livenessProbe:
+            exec:
+              command:
+                - /opt/percona/mongodb-healthcheck
+                - k8s
+                - liveness
+                - --startupDelaySeconds
+                - "7200"
+            failureThreshold: 4
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 10
+          name: mongod
+          ports:
+            - containerPort: 27017
+              name: mongodb
+              protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+                - /opt/percona/mongodb-healthcheck
+                - k8s
+                - readiness
+                - --component
+                - mongod
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 3
+            successThreshold: 1
+            timeoutSeconds: 2
+          resources: {}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /data/db
+              name: mongod-data
+            - mountPath: /etc/mongodb-secrets
+              name: some-name-mongodb-keyfile
+              readOnly: true
+            - mountPath: /etc/mongodb-ssl
+              name: ssl
+              readOnly: true
+            - mountPath: /etc/mongodb-ssl-internal
+              name: ssl-internal
+              readOnly: true
+            - mountPath: /opt/percona
+              name: bin
+            - mountPath: /etc/mongodb-encryption
+              name: some-name-mongodb-encryption-key
+              readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
+          workingDir: /data/db
+      dnsPolicy: ClusterFirst
+      initContainers:
+        - command:
+            - /init-entrypoint.sh
+          imagePullPolicy: Always
+          name: mongo-init
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /data/db
+              name: mongod-data
+            - mountPath: /opt/percona
+              name: bin
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext:
+        fsGroup: 1001
+      serviceAccount: default
+      serviceAccountName: default
+      terminationGracePeriodSeconds: 60
+      volumes:
+        - name: some-name-mongodb-keyfile
+          secret:
+            defaultMode: 288
+            optional: false
+            secretName: some-name-mongodb-keyfile
+        - emptyDir: {}
+          name: bin
+        - name: some-name-mongodb-encryption-key
+          secret:
+            defaultMode: 288
+            optional: false
+            secretName: some-name-mongodb-encryption-key
+        - name: ssl
+          secret:
+            defaultMode: 288
+            optional: true
+            secretName: some-name-ssl
+        - name: ssl-internal
+          secret:
+            defaultMode: 288
+            optional: true
+            secretName: some-name-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-some-name-users
+  updateStrategy:
+    rollingUpdate:
+      partition: 0
+    type: RollingUpdate
+  volumeClaimTemplates:
+    - metadata:
+        name: mongod-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 3Gi
+      status:
+        phase: Pending

--- a/e2e-tests/tls-issue-cert-manager/compare/statefulset_some-name-cfg-tls-disabled.yml
+++ b/e2e-tests/tls-issue-cert-manager/compare/statefulset_some-name-cfg-tls-disabled.yml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations: {}
-  generation: 4
+  generation: 7
   labels:
     app.kubernetes.io/component: cfg
     app.kubernetes.io/instance: some-name
@@ -187,9 +187,7 @@ spec:
             defaultMode: 420
             secretName: internal-some-name-users
   updateStrategy:
-    rollingUpdate:
-      partition: 0
-    type: RollingUpdate
+    type: OnDelete
   volumeClaimTemplates:
     - metadata:
         name: mongod-data

--- a/e2e-tests/tls-issue-cert-manager/compare/statefulset_some-name-cfg.yml
+++ b/e2e-tests/tls-issue-cert-manager/compare/statefulset_some-name-cfg.yml
@@ -1,0 +1,210 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations: {}
+  generation: 1
+  labels:
+    app.kubernetes.io/component: cfg
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/managed-by: percona-server-mongodb-operator
+    app.kubernetes.io/name: percona-server-mongodb
+    app.kubernetes.io/part-of: percona-server-mongodb
+    app.kubernetes.io/replset: cfg
+  name: some-name-cfg
+  ownerReferences:
+    - controller: true
+      kind: PerconaServerMongoDB
+      name: some-name
+spec:
+  podManagementPolicy: OrderedReady
+  replicas: 3
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: cfg
+      app.kubernetes.io/instance: some-name
+      app.kubernetes.io/managed-by: percona-server-mongodb-operator
+      app.kubernetes.io/name: percona-server-mongodb
+      app.kubernetes.io/part-of: percona-server-mongodb
+      app.kubernetes.io/replset: cfg
+  serviceName: some-name-cfg
+  template:
+    metadata:
+      annotations: {}
+      labels:
+        app.kubernetes.io/component: cfg
+        app.kubernetes.io/instance: some-name
+        app.kubernetes.io/managed-by: percona-server-mongodb-operator
+        app.kubernetes.io/name: percona-server-mongodb
+        app.kubernetes.io/part-of: percona-server-mongodb
+        app.kubernetes.io/replset: cfg
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: cfg
+                  app.kubernetes.io/instance: some-name
+                  app.kubernetes.io/managed-by: percona-server-mongodb-operator
+                  app.kubernetes.io/name: percona-server-mongodb
+                  app.kubernetes.io/part-of: percona-server-mongodb
+                  app.kubernetes.io/replset: cfg
+              topologyKey: kubernetes.io/hostname
+      containers:
+        - args:
+            - --bind_ip_all
+            - --auth
+            - --dbpath=/data/db
+            - --port=27017
+            - --replSet=cfg
+            - --storageEngine=wiredTiger
+            - --relaxPermChecks
+            - --sslAllowInvalidCertificates
+            - --clusterAuthMode=x509
+            - --tlsMode=preferTLS
+            - --configsvr
+            - --enableEncryption
+            - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
+            - --wiredTigerIndexPrefixCompression=true
+            - --quiet
+          command:
+            - /opt/percona/ps-entry.sh
+          env:
+            - name: SERVICE_NAME
+              value: some-name
+            - name: MONGODB_PORT
+              value: "27017"
+            - name: MONGODB_REPLSET
+              value: cfg
+          envFrom:
+            - secretRef:
+                name: internal-some-name-users
+                optional: false
+          imagePullPolicy: Always
+          livenessProbe:
+            exec:
+              command:
+                - /opt/percona/mongodb-healthcheck
+                - k8s
+                - liveness
+                - --ssl
+                - --sslInsecure
+                - --sslCAFile
+                - /etc/mongodb-ssl/ca.crt
+                - --sslPEMKeyFile
+                - /tmp/tls.pem
+                - --startupDelaySeconds
+                - "7200"
+            failureThreshold: 4
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 10
+          name: mongod
+          ports:
+            - containerPort: 27017
+              name: mongodb
+              protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+                - /opt/percona/mongodb-healthcheck
+                - k8s
+                - readiness
+                - --component
+                - mongod
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 3
+            successThreshold: 1
+            timeoutSeconds: 2
+          resources: {}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /data/db
+              name: mongod-data
+            - mountPath: /etc/mongodb-secrets
+              name: some-name-mongodb-keyfile
+              readOnly: true
+            - mountPath: /etc/mongodb-ssl
+              name: ssl
+              readOnly: true
+            - mountPath: /etc/mongodb-ssl-internal
+              name: ssl-internal
+              readOnly: true
+            - mountPath: /opt/percona
+              name: bin
+            - mountPath: /etc/mongodb-encryption
+              name: some-name-mongodb-encryption-key
+              readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
+          workingDir: /data/db
+      dnsPolicy: ClusterFirst
+      initContainers:
+        - command:
+            - /init-entrypoint.sh
+          imagePullPolicy: Always
+          name: mongo-init
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /data/db
+              name: mongod-data
+            - mountPath: /opt/percona
+              name: bin
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext:
+        fsGroup: 1001
+      serviceAccount: default
+      serviceAccountName: default
+      terminationGracePeriodSeconds: 60
+      volumes:
+        - name: some-name-mongodb-keyfile
+          secret:
+            defaultMode: 288
+            optional: false
+            secretName: some-name-mongodb-keyfile
+        - emptyDir: {}
+          name: bin
+        - name: some-name-mongodb-encryption-key
+          secret:
+            defaultMode: 288
+            optional: false
+            secretName: some-name-mongodb-encryption-key
+        - name: ssl
+          secret:
+            defaultMode: 288
+            optional: false
+            secretName: some-name-ssl
+        - name: ssl-internal
+          secret:
+            defaultMode: 288
+            optional: true
+            secretName: some-name-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-some-name-users
+  updateStrategy:
+    rollingUpdate:
+      partition: 0
+    type: RollingUpdate
+  volumeClaimTemplates:
+    - metadata:
+        name: mongod-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 3Gi
+      status:
+        phase: Pending

--- a/e2e-tests/tls-issue-cert-manager/compare/statefulset_some-name-cfg.yml
+++ b/e2e-tests/tls-issue-cert-manager/compare/statefulset_some-name-cfg.yml
@@ -194,9 +194,7 @@ spec:
             defaultMode: 420
             secretName: internal-some-name-users
   updateStrategy:
-    rollingUpdate:
-      partition: 0
-    type: RollingUpdate
+    type: OnDelete
   volumeClaimTemplates:
     - metadata:
         name: mongod-data

--- a/e2e-tests/tls-issue-cert-manager/compare/statefulset_some-name-mongos-tls-disabled.yml
+++ b/e2e-tests/tls-issue-cert-manager/compare/statefulset_some-name-mongos-tls-disabled.yml
@@ -1,0 +1,179 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations: {}
+  generation: 1
+  labels:
+    app.kubernetes.io/component: mongos
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/managed-by: percona-server-mongodb-operator
+    app.kubernetes.io/name: percona-server-mongodb
+    app.kubernetes.io/part-of: percona-server-mongodb
+  name: some-name-mongos
+  ownerReferences:
+    - controller: true
+      kind: PerconaServerMongoDB
+      name: some-name
+spec:
+  podManagementPolicy: OrderedReady
+  replicas: 3
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: mongos
+      app.kubernetes.io/instance: some-name
+      app.kubernetes.io/managed-by: percona-server-mongodb-operator
+      app.kubernetes.io/name: percona-server-mongodb
+      app.kubernetes.io/part-of: percona-server-mongodb
+  serviceName: ""
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: mongos
+        app.kubernetes.io/instance: some-name
+        app.kubernetes.io/managed-by: percona-server-mongodb-operator
+        app.kubernetes.io/name: percona-server-mongodb
+        app.kubernetes.io/part-of: percona-server-mongodb
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: mongos
+                  app.kubernetes.io/instance: some-name
+                  app.kubernetes.io/managed-by: percona-server-mongodb-operator
+                  app.kubernetes.io/name: percona-server-mongodb
+                  app.kubernetes.io/part-of: percona-server-mongodb
+              topologyKey: kubernetes.io/hostname
+      containers:
+        - args:
+            - mongos
+            - --bind_ip_all
+            - --port=27017
+            - --sslAllowInvalidCertificates
+            - --configdb
+            - cfg/some-name-cfg-0.some-name-cfg.NAME_SPACE.svc.cluster.local:27017,some-name-cfg-1.some-name-cfg.NAME_SPACE.svc.cluster.local:27017,some-name-cfg-2.some-name-cfg.NAME_SPACE.svc.cluster.local:27017
+            - --relaxPermChecks
+            - --clusterAuthMode=keyFile
+            - --keyFile=/etc/mongodb-secrets/mongodb-key
+            - --tlsMode=disabled
+          command:
+            - /opt/percona/ps-entry.sh
+          env:
+            - name: MONGODB_PORT
+              value: "27017"
+          envFrom:
+            - secretRef:
+                name: some-users
+                optional: false
+            - secretRef:
+                name: internal-some-name-users
+                optional: false
+          imagePullPolicy: Always
+          livenessProbe:
+            exec:
+              command:
+                - /opt/percona/mongodb-healthcheck
+                - k8s
+                - liveness
+                - --component
+                - mongos
+                - --startupDelaySeconds
+                - "10"
+            failureThreshold: 4
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 10
+          name: mongos
+          ports:
+            - containerPort: 27017
+              name: mongos
+              protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+                - /opt/percona/mongodb-healthcheck
+                - k8s
+                - readiness
+                - --component
+                - mongos
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 1
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources: {}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /data/db
+              name: mongod-data
+            - mountPath: /etc/mongodb-secrets
+              name: some-name-mongodb-keyfile
+              readOnly: true
+            - mountPath: /etc/mongodb-ssl
+              name: ssl
+              readOnly: true
+            - mountPath: /etc/mongodb-ssl-internal
+              name: ssl-internal
+              readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
+              readOnly: true
+            - mountPath: /opt/percona
+              name: bin
+          workingDir: /data/db
+      dnsPolicy: ClusterFirst
+      initContainers:
+        - command:
+            - /init-entrypoint.sh
+          imagePullPolicy: Always
+          name: mongo-init
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /data/db
+              name: mongod-data
+            - mountPath: /opt/percona
+              name: bin
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext:
+        fsGroup: 1001
+      serviceAccount: default
+      serviceAccountName: default
+      terminationGracePeriodSeconds: 60
+      volumes:
+        - name: some-name-mongodb-keyfile
+          secret:
+            defaultMode: 288
+            optional: false
+            secretName: some-name-mongodb-keyfile
+        - name: ssl
+          secret:
+            defaultMode: 288
+            optional: true
+            secretName: some-name-ssl
+        - name: ssl-internal
+          secret:
+            defaultMode: 288
+            optional: true
+            secretName: some-name-ssl-internal
+        - emptyDir: {}
+          name: mongod-data
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-some-name-users
+        - emptyDir: {}
+          name: bin
+  updateStrategy:
+    rollingUpdate:
+      partition: 0
+    type: RollingUpdate

--- a/e2e-tests/tls-issue-cert-manager/compare/statefulset_some-name-mongos-tls-disabled.yml
+++ b/e2e-tests/tls-issue-cert-manager/compare/statefulset_some-name-mongos-tls-disabled.yml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations: {}
-  generation: 1
+  generation: 5
   labels:
     app.kubernetes.io/component: mongos
     app.kubernetes.io/instance: some-name
@@ -174,6 +174,4 @@ spec:
         - emptyDir: {}
           name: bin
   updateStrategy:
-    rollingUpdate:
-      partition: 0
-    type: RollingUpdate
+    type: OnDelete

--- a/e2e-tests/tls-issue-cert-manager/compare/statefulset_some-name-mongos.yml
+++ b/e2e-tests/tls-issue-cert-manager/compare/statefulset_some-name-mongos.yml
@@ -1,0 +1,191 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations: {}
+  generation: 1
+  labels:
+    app.kubernetes.io/component: mongos
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/managed-by: percona-server-mongodb-operator
+    app.kubernetes.io/name: percona-server-mongodb
+    app.kubernetes.io/part-of: percona-server-mongodb
+  name: some-name-mongos
+  ownerReferences:
+    - controller: true
+      kind: PerconaServerMongoDB
+      name: some-name
+spec:
+  podManagementPolicy: OrderedReady
+  replicas: 3
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: mongos
+      app.kubernetes.io/instance: some-name
+      app.kubernetes.io/managed-by: percona-server-mongodb-operator
+      app.kubernetes.io/name: percona-server-mongodb
+      app.kubernetes.io/part-of: percona-server-mongodb
+  serviceName: ""
+  template:
+    metadata:
+      annotations: {}
+      labels:
+        app.kubernetes.io/component: mongos
+        app.kubernetes.io/instance: some-name
+        app.kubernetes.io/managed-by: percona-server-mongodb-operator
+        app.kubernetes.io/name: percona-server-mongodb
+        app.kubernetes.io/part-of: percona-server-mongodb
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/component: mongos
+                  app.kubernetes.io/instance: some-name
+                  app.kubernetes.io/managed-by: percona-server-mongodb-operator
+                  app.kubernetes.io/name: percona-server-mongodb
+                  app.kubernetes.io/part-of: percona-server-mongodb
+              topologyKey: kubernetes.io/hostname
+      containers:
+        - args:
+            - mongos
+            - --bind_ip_all
+            - --port=27017
+            - --sslAllowInvalidCertificates
+            - --configdb
+            - cfg/some-name-cfg-0.some-name-cfg.NAME_SPACE.svc.cluster.local:27017,some-name-cfg-1.some-name-cfg.NAME_SPACE.svc.cluster.local:27017,some-name-cfg-2.some-name-cfg.NAME_SPACE.svc.cluster.local:27017
+            - --relaxPermChecks
+            - --clusterAuthMode=x509
+            - --tlsMode=preferTLS
+          command:
+            - /opt/percona/ps-entry.sh
+          env:
+            - name: MONGODB_PORT
+              value: "27017"
+          envFrom:
+            - secretRef:
+                name: some-users
+                optional: false
+            - secretRef:
+                name: internal-some-name-users
+                optional: false
+          imagePullPolicy: Always
+          livenessProbe:
+            exec:
+              command:
+                - /opt/percona/mongodb-healthcheck
+                - k8s
+                - liveness
+                - --component
+                - mongos
+                - --ssl
+                - --sslInsecure
+                - --sslCAFile
+                - /etc/mongodb-ssl/ca.crt
+                - --sslPEMKeyFile
+                - /tmp/tls.pem
+                - --startupDelaySeconds
+                - "10"
+            failureThreshold: 4
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 10
+          name: mongos
+          ports:
+            - containerPort: 27017
+              name: mongos
+              protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+                - /opt/percona/mongodb-healthcheck
+                - k8s
+                - readiness
+                - --component
+                - mongos
+                - --ssl
+                - --sslInsecure
+                - --sslCAFile
+                - /etc/mongodb-ssl/ca.crt
+                - --sslPEMKeyFile
+                - /tmp/tls.pem
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            periodSeconds: 1
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources: {}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /data/db
+              name: mongod-data
+            - mountPath: /etc/mongodb-secrets
+              name: some-name-mongodb-keyfile
+              readOnly: true
+            - mountPath: /etc/mongodb-ssl
+              name: ssl
+              readOnly: true
+            - mountPath: /etc/mongodb-ssl-internal
+              name: ssl-internal
+              readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
+              readOnly: true
+            - mountPath: /opt/percona
+              name: bin
+          workingDir: /data/db
+      dnsPolicy: ClusterFirst
+      initContainers:
+        - command:
+            - /init-entrypoint.sh
+          imagePullPolicy: Always
+          name: mongo-init
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /data/db
+              name: mongod-data
+            - mountPath: /opt/percona
+              name: bin
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext:
+        fsGroup: 1001
+      serviceAccount: default
+      serviceAccountName: default
+      terminationGracePeriodSeconds: 60
+      volumes:
+        - name: some-name-mongodb-keyfile
+          secret:
+            defaultMode: 288
+            optional: false
+            secretName: some-name-mongodb-keyfile
+        - name: ssl
+          secret:
+            defaultMode: 288
+            optional: false
+            secretName: some-name-ssl
+        - name: ssl-internal
+          secret:
+            defaultMode: 288
+            optional: true
+            secretName: some-name-ssl-internal
+        - emptyDir: {}
+          name: mongod-data
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-some-name-users
+        - emptyDir: {}
+          name: bin
+  updateStrategy:
+    rollingUpdate:
+      partition: 0
+    type: RollingUpdate

--- a/e2e-tests/tls-issue-cert-manager/compare/statefulset_some-name-mongos.yml
+++ b/e2e-tests/tls-issue-cert-manager/compare/statefulset_some-name-mongos.yml
@@ -186,6 +186,4 @@ spec:
         - emptyDir: {}
           name: bin
   updateStrategy:
-    rollingUpdate:
-      partition: 0
-    type: RollingUpdate
+    type: OnDelete

--- a/e2e-tests/tls-issue-cert-manager/compare/statefulset_some-name-rs0-tls-disabled.yml
+++ b/e2e-tests/tls-issue-cert-manager/compare/statefulset_some-name-rs0-tls-disabled.yml
@@ -1,0 +1,204 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations: {}
+  generation: 4
+  labels:
+    app.kubernetes.io/component: mongod
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/managed-by: percona-server-mongodb-operator
+    app.kubernetes.io/name: percona-server-mongodb
+    app.kubernetes.io/part-of: percona-server-mongodb
+    app.kubernetes.io/replset: rs0
+  name: some-name-rs0
+  ownerReferences:
+    - controller: true
+      kind: PerconaServerMongoDB
+      name: some-name
+spec:
+  podManagementPolicy: OrderedReady
+  replicas: 3
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: mongod
+      app.kubernetes.io/instance: some-name
+      app.kubernetes.io/managed-by: percona-server-mongodb-operator
+      app.kubernetes.io/name: percona-server-mongodb
+      app.kubernetes.io/part-of: percona-server-mongodb
+      app.kubernetes.io/replset: rs0
+  serviceName: some-name-rs0
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: mongod
+        app.kubernetes.io/instance: some-name
+        app.kubernetes.io/managed-by: percona-server-mongodb-operator
+        app.kubernetes.io/name: percona-server-mongodb
+        app.kubernetes.io/part-of: percona-server-mongodb
+        app.kubernetes.io/replset: rs0
+    spec:
+      containers:
+        - args:
+            - --bind_ip_all
+            - --auth
+            - --dbpath=/data/db
+            - --port=27017
+            - --replSet=rs0
+            - --storageEngine=wiredTiger
+            - --relaxPermChecks
+            - --clusterAuthMode=keyFile
+            - --keyFile=/etc/mongodb-secrets/mongodb-key
+            - --tlsMode=disabled
+            - --shardsvr
+            - --enableEncryption
+            - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
+            - --wiredTigerCacheSizeGB=0.25
+            - --wiredTigerIndexPrefixCompression=true
+            - --quiet
+          command:
+            - /opt/percona/ps-entry.sh
+          env:
+            - name: SERVICE_NAME
+              value: some-name
+            - name: MONGODB_PORT
+              value: "27017"
+            - name: MONGODB_REPLSET
+              value: rs0
+          envFrom:
+            - secretRef:
+                name: internal-some-name-users
+                optional: false
+          imagePullPolicy: Always
+          livenessProbe:
+            exec:
+              command:
+                - /opt/percona/mongodb-healthcheck
+                - k8s
+                - liveness
+                - --startupDelaySeconds
+                - "7200"
+            failureThreshold: 4
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 10
+          name: mongod
+          ports:
+            - containerPort: 27017
+              name: mongodb
+              protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+                - /opt/percona/mongodb-healthcheck
+                - k8s
+                - readiness
+                - --component
+                - mongod
+            failureThreshold: 8
+            initialDelaySeconds: 10
+            periodSeconds: 3
+            successThreshold: 1
+            timeoutSeconds: 2
+          resources:
+            limits:
+              cpu: 500m
+              memory: 1G
+            requests:
+              cpu: 100m
+              memory: 100M
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /data/db
+              name: mongod-data
+            - mountPath: /etc/mongodb-secrets
+              name: some-name-mongodb-keyfile
+              readOnly: true
+            - mountPath: /etc/mongodb-ssl
+              name: ssl
+              readOnly: true
+            - mountPath: /etc/mongodb-ssl-internal
+              name: ssl-internal
+              readOnly: true
+            - mountPath: /opt/percona
+              name: bin
+            - mountPath: /etc/mongodb-encryption
+              name: some-name-mongodb-encryption-key
+              readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
+          workingDir: /data/db
+      dnsPolicy: ClusterFirst
+      initContainers:
+        - command:
+            - /init-entrypoint.sh
+          imagePullPolicy: Always
+          name: mongo-init
+          resources:
+            limits:
+              cpu: 500m
+              memory: 1G
+            requests:
+              cpu: 100m
+              memory: 100M
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /data/db
+              name: mongod-data
+            - mountPath: /opt/percona
+              name: bin
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext:
+        fsGroup: 1001
+      serviceAccount: default
+      serviceAccountName: default
+      terminationGracePeriodSeconds: 60
+      volumes:
+        - name: some-name-mongodb-keyfile
+          secret:
+            defaultMode: 288
+            optional: false
+            secretName: some-name-mongodb-keyfile
+        - emptyDir: {}
+          name: bin
+        - name: some-name-mongodb-encryption-key
+          secret:
+            defaultMode: 288
+            optional: false
+            secretName: some-name-mongodb-encryption-key
+        - name: ssl
+          secret:
+            defaultMode: 288
+            optional: true
+            secretName: some-name-ssl
+        - name: ssl-internal
+          secret:
+            defaultMode: 288
+            optional: true
+            secretName: some-name-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-some-name-users
+  updateStrategy:
+    rollingUpdate:
+      partition: 0
+    type: RollingUpdate
+  volumeClaimTemplates:
+    - metadata:
+        name: mongod-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+      status:
+        phase: Pending

--- a/e2e-tests/tls-issue-cert-manager/compare/statefulset_some-name-rs0-tls-disabled.yml
+++ b/e2e-tests/tls-issue-cert-manager/compare/statefulset_some-name-rs0-tls-disabled.yml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations: {}
-  generation: 4
+  generation: 8
   labels:
     app.kubernetes.io/component: mongod
     app.kubernetes.io/instance: some-name
@@ -188,9 +188,7 @@ spec:
             defaultMode: 420
             secretName: internal-some-name-users
   updateStrategy:
-    rollingUpdate:
-      partition: 0
-    type: RollingUpdate
+    type: OnDelete
   volumeClaimTemplates:
     - metadata:
         name: mongod-data

--- a/e2e-tests/tls-issue-cert-manager/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/tls-issue-cert-manager/compare/statefulset_some-name-rs0.yml
@@ -195,9 +195,7 @@ spec:
             defaultMode: 420
             secretName: internal-some-name-users
   updateStrategy:
-    rollingUpdate:
-      partition: 0
-    type: RollingUpdate
+    type: OnDelete
   volumeClaimTemplates:
     - metadata:
         name: mongod-data

--- a/e2e-tests/tls-issue-cert-manager/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/tls-issue-cert-manager/compare/statefulset_some-name-rs0.yml
@@ -1,0 +1,211 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations: {}
+  generation: 1
+  labels:
+    app.kubernetes.io/component: mongod
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/managed-by: percona-server-mongodb-operator
+    app.kubernetes.io/name: percona-server-mongodb
+    app.kubernetes.io/part-of: percona-server-mongodb
+    app.kubernetes.io/replset: rs0
+  name: some-name-rs0
+  ownerReferences:
+    - controller: true
+      kind: PerconaServerMongoDB
+      name: some-name
+spec:
+  podManagementPolicy: OrderedReady
+  replicas: 3
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: mongod
+      app.kubernetes.io/instance: some-name
+      app.kubernetes.io/managed-by: percona-server-mongodb-operator
+      app.kubernetes.io/name: percona-server-mongodb
+      app.kubernetes.io/part-of: percona-server-mongodb
+      app.kubernetes.io/replset: rs0
+  serviceName: some-name-rs0
+  template:
+    metadata:
+      annotations: {}
+      labels:
+        app.kubernetes.io/component: mongod
+        app.kubernetes.io/instance: some-name
+        app.kubernetes.io/managed-by: percona-server-mongodb-operator
+        app.kubernetes.io/name: percona-server-mongodb
+        app.kubernetes.io/part-of: percona-server-mongodb
+        app.kubernetes.io/replset: rs0
+    spec:
+      containers:
+        - args:
+            - --bind_ip_all
+            - --auth
+            - --dbpath=/data/db
+            - --port=27017
+            - --replSet=rs0
+            - --storageEngine=wiredTiger
+            - --relaxPermChecks
+            - --sslAllowInvalidCertificates
+            - --clusterAuthMode=x509
+            - --tlsMode=preferTLS
+            - --shardsvr
+            - --enableEncryption
+            - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
+            - --wiredTigerCacheSizeGB=0.25
+            - --wiredTigerIndexPrefixCompression=true
+            - --quiet
+          command:
+            - /opt/percona/ps-entry.sh
+          env:
+            - name: SERVICE_NAME
+              value: some-name
+            - name: MONGODB_PORT
+              value: "27017"
+            - name: MONGODB_REPLSET
+              value: rs0
+          envFrom:
+            - secretRef:
+                name: internal-some-name-users
+                optional: false
+          imagePullPolicy: Always
+          livenessProbe:
+            exec:
+              command:
+                - /opt/percona/mongodb-healthcheck
+                - k8s
+                - liveness
+                - --ssl
+                - --sslInsecure
+                - --sslCAFile
+                - /etc/mongodb-ssl/ca.crt
+                - --sslPEMKeyFile
+                - /tmp/tls.pem
+                - --startupDelaySeconds
+                - "7200"
+            failureThreshold: 4
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 10
+          name: mongod
+          ports:
+            - containerPort: 27017
+              name: mongodb
+              protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+                - /opt/percona/mongodb-healthcheck
+                - k8s
+                - readiness
+                - --component
+                - mongod
+            failureThreshold: 8
+            initialDelaySeconds: 10
+            periodSeconds: 3
+            successThreshold: 1
+            timeoutSeconds: 2
+          resources:
+            limits:
+              cpu: 500m
+              memory: 1G
+            requests:
+              cpu: 100m
+              memory: 100M
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /data/db
+              name: mongod-data
+            - mountPath: /etc/mongodb-secrets
+              name: some-name-mongodb-keyfile
+              readOnly: true
+            - mountPath: /etc/mongodb-ssl
+              name: ssl
+              readOnly: true
+            - mountPath: /etc/mongodb-ssl-internal
+              name: ssl-internal
+              readOnly: true
+            - mountPath: /opt/percona
+              name: bin
+            - mountPath: /etc/mongodb-encryption
+              name: some-name-mongodb-encryption-key
+              readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
+          workingDir: /data/db
+      dnsPolicy: ClusterFirst
+      initContainers:
+        - command:
+            - /init-entrypoint.sh
+          imagePullPolicy: Always
+          name: mongo-init
+          resources:
+            limits:
+              cpu: 500m
+              memory: 1G
+            requests:
+              cpu: 100m
+              memory: 100M
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /data/db
+              name: mongod-data
+            - mountPath: /opt/percona
+              name: bin
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext:
+        fsGroup: 1001
+      serviceAccount: default
+      serviceAccountName: default
+      terminationGracePeriodSeconds: 60
+      volumes:
+        - name: some-name-mongodb-keyfile
+          secret:
+            defaultMode: 288
+            optional: false
+            secretName: some-name-mongodb-keyfile
+        - emptyDir: {}
+          name: bin
+        - name: some-name-mongodb-encryption-key
+          secret:
+            defaultMode: 288
+            optional: false
+            secretName: some-name-mongodb-encryption-key
+        - name: ssl
+          secret:
+            defaultMode: 288
+            optional: false
+            secretName: some-name-ssl
+        - name: ssl-internal
+          secret:
+            defaultMode: 288
+            optional: true
+            secretName: some-name-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-some-name-users
+  updateStrategy:
+    rollingUpdate:
+      partition: 0
+    type: RollingUpdate
+  volumeClaimTemplates:
+    - metadata:
+        name: mongod-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+      status:
+        phase: Pending

--- a/e2e-tests/tls-issue-cert-manager/conf/some-name.yml
+++ b/e2e-tests/tls-issue-cert-manager/conf/some-name.yml
@@ -6,6 +6,7 @@ spec:
   #platform: openshift
   image:
   imagePullPolicy: Always
+  updateStrategy: SmartUpdate
   backup:
     enabled: false
   replsets:

--- a/e2e-tests/tls-issue-cert-manager/run
+++ b/e2e-tests/tls-issue-cert-manager/run
@@ -42,6 +42,12 @@ main() {
 	wait_for_running $cluster-cfg 3 "false"
 	wait_for_running $cluster-mongos 3
 
+	exit 0
+
+	compare_kubectl statefulset/${cluster}-rs0
+	compare_kubectl statefulset/${cluster}-cfg
+	compare_kubectl statefulset/${cluster}-mongos
+
 	desc 'check if certificates issued with certmanager'
 	check_tls_secret "$cluster-ssl"
 
@@ -80,6 +86,17 @@ main() {
 
 	desc 'check if internal certificate issued'
 	compare_kubectl certificate/$cluster-ssl-internal
+
+	desc 'disable TLS'
+	disable_tls "$cluster"
+	wait_for_running $cluster-rs0 3
+	wait_for_running $cluster-cfg 3 "false"
+
+	kubectl_bin delete sts $cluster-mongos
+
+	compare_kubectl statefulset/${cluster}-rs0 "-tls-disabled"
+	compare_kubectl statefulset/${cluster}-cfg "-tls-disabled"
+	compare_kubectl statefulset/${cluster}-mongos "-tls-disabled"
 
 	destroy "$namespace"
 	desc 'test passed'

--- a/e2e-tests/tls-issue-cert-manager/run
+++ b/e2e-tests/tls-issue-cert-manager/run
@@ -42,8 +42,6 @@ main() {
 	wait_for_running $cluster-cfg 3 "false"
 	wait_for_running $cluster-mongos 3
 
-	exit 0
-
 	compare_kubectl statefulset/${cluster}-rs0
 	compare_kubectl statefulset/${cluster}-cfg
 	compare_kubectl statefulset/${cluster}-mongos
@@ -89,10 +87,8 @@ main() {
 
 	desc 'disable TLS'
 	disable_tls "$cluster"
-	wait_for_running $cluster-rs0 3
-	wait_for_running $cluster-cfg 3 "false"
-
-	kubectl_bin delete sts $cluster-mongos
+	wait_for_cluster_state "${cluster}" "paused"
+	wait_for_cluster_state "${cluster}" "ready"
 
 	compare_kubectl statefulset/${cluster}-rs0 "-tls-disabled"
 	compare_kubectl statefulset/${cluster}-cfg "-tls-disabled"

--- a/e2e-tests/tls-issue-cert-manager/run
+++ b/e2e-tests/tls-issue-cert-manager/run
@@ -87,7 +87,7 @@ main() {
 
 	desc 'disable TLS'
 	disable_tls "$cluster"
-	wait_for_cluster_state "${cluster}" "paused"
+	wait_for_cluster_state "${cluster}" "initializing"
 	wait_for_cluster_state "${cluster}" "ready"
 
 	compare_kubectl statefulset/${cluster}-rs0 "-tls-disabled"

--- a/e2e-tests/version-service/conf/crd.yaml
+++ b/e2e-tests/version-service/conf/crd.yaml
@@ -18956,6 +18956,8 @@ spec:
                 type: integer
               state:
                 type: string
+              tlsMode:
+                type: string
             required:
             - ready
             - size

--- a/pkg/apis/psmdb/v1/psmdb_defaults.go
+++ b/pkg/apis/psmdb/v1/psmdb_defaults.go
@@ -65,6 +65,9 @@ func (cr *PerconaServerMongoDB) CheckNSetDefaults(platform version.Platform, log
 	if cr.Spec.ImagePullPolicy == "" {
 		cr.Spec.ImagePullPolicy = defaultImagePullPolicy
 	}
+	if cr.Spec.UpdateStrategy == "" {
+		cr.Spec.UpdateStrategy = SmartUpdateStatefulSetStrategyType
+	}
 	if cr.Spec.Secrets == nil {
 		cr.Spec.Secrets = &SecretsSpec{}
 	}

--- a/pkg/apis/psmdb/v1/psmdb_defaults.go
+++ b/pkg/apis/psmdb/v1/psmdb_defaults.go
@@ -65,9 +65,6 @@ func (cr *PerconaServerMongoDB) CheckNSetDefaults(platform version.Platform, log
 	if cr.Spec.ImagePullPolicy == "" {
 		cr.Spec.ImagePullPolicy = defaultImagePullPolicy
 	}
-	if cr.Spec.UpdateStrategy == "" {
-		cr.Spec.UpdateStrategy = SmartUpdateStatefulSetStrategyType
-	}
 	if cr.Spec.Secrets == nil {
 		cr.Spec.Secrets = &SecretsSpec{}
 	}

--- a/pkg/apis/psmdb/v1/psmdb_types.go
+++ b/pkg/apis/psmdb/v1/psmdb_types.go
@@ -259,6 +259,7 @@ type PerconaServerMongoDBStatus struct {
 	Host               string                   `json:"host,omitempty"`
 	Size               int32                    `json:"size"`
 	Ready              int32                    `json:"ready"`
+	TLSMode            TLSMode                  `json:"tlsMode,omitempty"`
 }
 
 type ConditionStatus string
@@ -1217,6 +1218,7 @@ func (cr *PerconaServerMongoDB) UnsafeTLSDisabled() bool {
 }
 
 const (
+	AnnotationRestartCluster      = "percona.com/restart-cluster"
 	AnnotationResyncPBM           = "percona.com/resync-pbm"
 	AnnotationPVCResizeInProgress = "percona.com/pvc-resize-in-progress"
 )

--- a/pkg/controller/perconaservermongodb/connections.go
+++ b/pkg/controller/perconaservermongodb/connections.go
@@ -10,6 +10,7 @@ import (
 	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
 	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb"
 	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb/mongo"
+	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb/tls"
 )
 
 type MongoClientProvider interface {
@@ -69,5 +70,11 @@ func (r *ReconcilePerconaServerMongoDB) standaloneClientWithRole(ctx context.Con
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get mongo host")
 	}
-	return r.MongoClientProvider().Standalone(ctx, cr, role, host, cr.TLSEnabled())
+
+	tlsEnabled, err := tls.IsEnabledForPod(ctx, r.client, cr, &pod, "mongod")
+	if err != nil {
+		return nil, errors.Wrap(err, "check if tls enabled")
+	}
+
+	return r.MongoClientProvider().Standalone(ctx, cr, role, host, tlsEnabled)
 }

--- a/pkg/controller/perconaservermongodb/mgo.go
+++ b/pkg/controller/perconaservermongodb/mgo.go
@@ -48,6 +48,10 @@ func (r *ReconcilePerconaServerMongoDB) reconcileCluster(ctx context.Context, cr
 		return api.AppStateInit, nil
 	}
 
+	if _, ok := cr.Annotations[api.AnnotationRestartCluster]; ok {
+		return api.AppStateStopping, nil
+	}
+
 	if replsetSize == 0 {
 		return api.AppStateReady, nil
 	}

--- a/pkg/controller/perconaservermongodb/smart.go
+++ b/pkg/controller/perconaservermongodb/smart.go
@@ -378,17 +378,6 @@ func (r *ReconcilePerconaServerMongoDB) smartMongosUpdate(ctx context.Context, c
 		return nil
 	}
 
-	if sts.Status.ReadyReplicas == 0 {
-		log.Info("no mongos pods are ready, deleting all mongos pods")
-
-		err := r.client.DeleteAllOf(ctx, &corev1.Pod{}, k8sclient.InNamespace(cr.Namespace), k8sclient.MatchingLabels{"app.kubernetes.io/component": "mongos"})
-		if err != nil {
-			return errors.Wrap(err, "delete all mongos pods")
-		}
-
-		return nil
-	}
-
 	log.Info("StatefulSet is changed, starting smart update", "name", sts.Name)
 
 	if sts.Status.ReadyReplicas < sts.Status.Replicas {

--- a/pkg/controller/perconaservermongodb/smart.go
+++ b/pkg/controller/perconaservermongodb/smart.go
@@ -378,6 +378,17 @@ func (r *ReconcilePerconaServerMongoDB) smartMongosUpdate(ctx context.Context, c
 		return nil
 	}
 
+	if sts.Status.ReadyReplicas == 0 {
+		log.Info("no mongos pods are ready, deleting all mongos pods")
+
+		err := r.client.DeleteAllOf(ctx, &corev1.Pod{}, k8sclient.InNamespace(cr.Namespace), k8sclient.MatchingLabels{"app.kubernetes.io/component": "mongos"})
+		if err != nil {
+			return errors.Wrap(err, "delete all mongos pods")
+		}
+
+		return nil
+	}
+
 	log.Info("StatefulSet is changed, starting smart update", "name", sts.Name)
 
 	if sts.Status.ReadyReplicas < sts.Status.Replicas {

--- a/pkg/controller/perconaservermongodb/ssl.go
+++ b/pkg/controller/perconaservermongodb/ssl.go
@@ -25,8 +25,7 @@ func (r *ReconcilePerconaServerMongoDB) reconcileSSL(ctx context.Context, cr *ap
 	if cr.Status.TLSMode != cr.Spec.TLS.Mode {
 		if cr.Status.TLSMode == api.TLSModeDisabled || cr.Spec.TLS.Mode == api.TLSModeDisabled {
 			err := k8s.AnnotateObject(ctx, r.client, cr, map[string]string{
-				api.AnnotationRestartCluster:    metav1.Now().Format(time.RFC3339),
-				api.AnnotationUpdateMongosFirst: "true",
+				api.AnnotationRestartCluster: metav1.Now().Format(time.RFC3339),
 			})
 			if err != nil {
 				return errors.Wrap(err, "annotate cr")

--- a/pkg/controller/perconaservermongodb/status.go
+++ b/pkg/controller/perconaservermongodb/status.go
@@ -196,6 +196,7 @@ func (r *ReconcilePerconaServerMongoDB) updateStatus(ctx context.Context, cr *ap
 		log.Error(err, "get psmdb connection endpoint")
 	}
 	cr.Status.Host = host
+	cr.Status.TLSMode = cr.Spec.TLS.Mode
 
 	state := api.AppStateInit
 

--- a/pkg/controller/perconaservermongodb/status_test.go
+++ b/pkg/controller/perconaservermongodb/status_test.go
@@ -54,6 +54,9 @@ func TestUpdateStatus(t *testing.T) {
 			CRVersion: "1.12.0",
 			Replsets:  []*api.ReplsetSpec{{Name: "rs0", Size: 3}, {Name: "rs1", Size: 3}},
 			Sharding:  api.Sharding{Enabled: true, Mongos: &api.MongosSpec{Size: 3}},
+			TLS: &api.TLSSpec{
+				Mode: api.TLSModePrefer,
+			},
 		},
 	}
 

--- a/pkg/psmdb/client.go
+++ b/pkg/psmdb/client.go
@@ -50,7 +50,12 @@ func MongoClient(ctx context.Context, k8sclient client.Client, cr *api.PerconaSe
 		Password:    c.Password,
 	}
 
-	if cr.TLSEnabled() {
+	tlsEnabled, err := tls.IsEnabledForReplset(ctx, k8sclient, cr, &rs)
+	if err != nil {
+		return nil, errors.Wrap(err, "check if tls enabled")
+	}
+
+	if tlsEnabled {
 		tlsCfg, err := tls.Config(ctx, k8sclient, cr)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to get TLS config")
@@ -73,7 +78,12 @@ func MongosClient(ctx context.Context, k8sclient client.Client, cr *api.PerconaS
 		Password: c.Password,
 	}
 
-	if cr.TLSEnabled() {
+	tlsEnabled, err := tls.IsEnabledForMongos(ctx, k8sclient, cr)
+	if err != nil {
+		return nil, errors.Wrap(err, "check if tls enabled")
+	}
+
+	if tlsEnabled {
 		tlsCfg, err := tls.Config(ctx, k8sclient, cr)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to get TLS config")

--- a/pkg/psmdb/mongos.go
+++ b/pkg/psmdb/mongos.go
@@ -255,6 +255,11 @@ func mongosContainerArgs(cr *api.PerconaServerMongoDB, useConfigFile bool, cfgIn
 	}
 
 	if cr.TLSEnabled() {
+		if !*cr.Spec.TLS.AllowInvalidCertificates {
+			// remove --sslAllowInvalidCertificates
+			args = append(args[:3], args[3+1:]...)
+		}
+
 		args = append(args,
 			"--clusterAuthMode=x509",
 		)

--- a/pkg/psmdb/tls/mode.go
+++ b/pkg/psmdb/tls/mode.go
@@ -1,0 +1,75 @@
+package tls
+
+import (
+	"context"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	psmdbv1 "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
+	"github.com/pkg/errors"
+)
+
+func GetEffectiveTLSMode(ctx context.Context, cli client.Client, cr *psmdbv1.PerconaServerMongoDB, pod *corev1.Pod, containerName string) (psmdbv1.TLSMode, error) {
+	err := cli.Get(ctx, client.ObjectKeyFromObject(pod), pod)
+	if err != nil {
+		return "", errors.Wrapf(err, "get pod/%s", pod.Name)
+	}
+
+	for _, ct := range pod.Spec.Containers {
+		if ct.Name == containerName {
+			for _, arg := range ct.Args {
+				if strings.HasPrefix(arg, "--tlsMode") {
+					tlsMode := strings.Split(arg, "=")[1]
+					return psmdbv1.TLSMode(tlsMode), nil
+				}
+			}
+			break
+		}
+	}
+
+	return cr.Spec.TLS.Mode, nil
+}
+
+func IsEnabledForReplset(ctx context.Context, client client.Client, cr *psmdbv1.PerconaServerMongoDB, rs *psmdbv1.ReplsetSpec) (bool, error) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cr.Name + "-" + rs.Name + "-0",
+			Namespace: cr.Namespace,
+		},
+	}
+
+	mode, err := GetEffectiveTLSMode(ctx, client, cr, pod, "mongod")
+	if err != nil {
+		return false, err
+	}
+
+	return mode != psmdbv1.TLSModeDisabled, nil
+}
+
+func IsEnabledForMongos(ctx context.Context, client client.Client, cr *psmdbv1.PerconaServerMongoDB) (bool, error) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cr.Name + "-mongos-0",
+			Namespace: cr.Namespace,
+		},
+	}
+
+	mode, err := GetEffectiveTLSMode(ctx, client, cr, pod, "mongos")
+	if err != nil {
+		return false, err
+	}
+
+	return mode != psmdbv1.TLSModeDisabled, nil
+}
+
+func IsEnabledForPod(ctx context.Context, client client.Client, cr *psmdbv1.PerconaServerMongoDB, pod *corev1.Pod, containerName string) (bool, error) {
+	mode, err := GetEffectiveTLSMode(ctx, client, cr, pod, containerName)
+	if err != nil {
+		return false, err
+	}
+
+	return mode != psmdbv1.TLSModeDisabled, nil
+}


### PR DESCRIPTION
[![K8SPSMDB-755](https://badgen.net/badge/JIRA/K8SPSMDB-755/green)](https://jira.percona.com/browse/K8SPSMDB-755) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
This commit fixes two problems:
1. `--sslAllowInvalidCertificates` is not removed from `mongos` args if
   TLS is disabled.
2. Disabling or enabling TLS on a running cluster is not working.

Fix for 1 was straightforward, since it was an oversight. Fix for 2 is
another story...

First of all, disabling TLS means setting `spec.tls.mode` to `disabled`
when it was one of `allowTLS`, `preferTLS` and `requireTLS`. Enabling
TLS means setting `spec.tls.mode` to one of `*TLS` options when it was
`disabled`.

Enabling and disabling didn't work because it causes a discrepancy
between the TLS mode used by `mongod` processes running in cluster and
the one set in cr.yaml. User changes `spec.tls.mode` and operator
immediately thinks it's the actual one and decide whether to use TLS or
not based on that. This causes connection errors since operator can
think TLS is disabled by looking at the cr.yaml even though it's
actually enforced in running processes.

To fix this issue, now operator detects the effective TLS mode by
looking at running container args and decides whether to use TLS or not
based on `--tlsMode` flag of `mongod` process.

But this doesn't fix all the problems...

During smart update, operator opens a PBM connection to the database to
check if there's an operation running. In a sharded cluster, PBM first
opens a connection to replset to get `configsvrConnectionString` in
`system.version` collection and then opens a connection to config server
replset since PBM's collections stored there. When user sets
`spec.tls.mode` to `disabled`, operator first updates config server
statefulset and set `--tlsMode=disabled`. Then it updates `rs0`
statefulset and during the smart update it correctly detects effective
TLS mode is not `disabled` and use TLS certificates to open PBM
connection. But then PBM tries to open connection to config server by
using the same TLS certificates and boom! connection fails.

To fix this issue we decided to restart the whole cluster (pause and
unpause) when users enables or disables TLS. So all pods will be
terminated first and then recreated with new TLS mode.

To communicate the need of full cluster restart, we decided to introduce
a new annotation: `percona.com/restart-cluster`. When operator detects
TLS mode is changed from `disabled` or to `disabled`, it annotates the
CR to add `percona.com/restart-cluster` and
`percona.com/update-mongos-first` (it's required to terminate mongos
pods first). After cluster reaches the `paused` state, it removes this
annotations.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?
- [x] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported MongoDB version?
- [x] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-755]: https://perconadev.atlassian.net/browse/K8SPSMDB-755?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ