### PR TITLE
K8SPSMDB-1082 - First delete non-voting/arbiter STS

### DIFF
--- a/pkg/controller/perconaservermongodb/psmdb_controller.go
+++ b/pkg/controller/perconaservermongodb/psmdb_controller.go
@@ -5,6 +5,7 @@ import (
 	"crypto/md5"
 	"fmt"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -709,6 +710,11 @@ func (r *ReconcilePerconaServerMongoDB) getSTSforRemoval(ctx context.Context, cr
 
 		removed = append(removed, sts)
 	}
+
+	// Sorting in reverse order to ensure that we first delete non-voting/arbiter before the main RS sts.
+	sort.Slice(removed, func(i, j int) bool {
+		return removed[i].Name > removed[j].Name
+	})
 
 	return removed, nil
 }


### PR DESCRIPTION
[![K8SPSMDB-1082](https://badgen.net/badge/JIRA/K8SPSMDB-1082/green)](https://jira.percona.com/browse/K8SPSMDB-1082) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
When deleting RS and all associated stateful sets, in some instances due to timing (especially on EKS), the operator fails to delete non-voting/arbiter stateful sets and they stay hanging there.

**Cause:**
The operator first deletes like main RS sts then non-voting/arbiter. When we do that and then we want to remove non-voting RS, the operator fails with the error `Type: ReplicaSetNoPrimary` because there is no primary at this point.

**Solution:**
Sorting all the stateful sets marked for deletion in a reverse order fixes the issues, because we ensure that non-votinng/arbiter sts is deleted first.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?
- [x] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported MongoDB version?
- [x] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-1082]: https://perconadev.atlassian.net/browse/K8SPSMDB-1082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ