### PR TITLE
K8SPSMDB-1083: Disable liveness probe during physical restore

### DIFF
--- a/build/physical-restore-ps-entry.sh
+++ b/build/physical-restore-ps-entry.sh
@@ -5,7 +5,9 @@ set -o xtrace
 
 log=/tmp/pbm-agent.log
 
-/opt/percona/pbm-agent 2> ${log} &
+touch /opt/percona/restore-in-progress
+
+/opt/percona/pbm-agent 2>${log} &
 /opt/percona/ps-entry.sh "$@"
 
 echo "Physical restore in progress"


### PR DESCRIPTION
[![K8SPSMDB-1083](https://badgen.net/badge/JIRA/K8SPSMDB-1083/green)](https://jira.percona.com/browse/K8SPSMDB-1083) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
Liveness probe should be disabled during physical restore, otherwise it can make restore fail in big databases.

**Solution:**
Have a special file to temporarily disable liveness checks.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?
- [x] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported MongoDB version?
- [x] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-1083]: https://perconadev.atlassian.net/browse/K8SPSMDB-1083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ