### PR TITLE
CLOUD-849 - Fix reviewdog for manifests on release branch

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -79,6 +79,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: |
+      - name: check on release branch
+        if: ${{ contains(github.head_ref, 'release-') || contains(github.base_ref, 'release-') }}
+        run: |
+          make generate manifests VERSION="$(grep "Version" version/version.go|grep -oE "[0-9]+\.[0-9]+\.[0-9]+")" IMAGE_TAG_BASE="percona/percona-server-mongodb-operator"
+          git diff --exit-code
+      - name: check on non release branches
+        if: ${{ ! (contains(github.head_ref, 'release-') || contains(github.base_ref, 'release-')) }}
+        run: |
           make generate manifests VERSION=main
           git diff --exit-code


### PR DESCRIPTION
[![CLOUD-849](https://badgen.net/badge/JIRA/CLOUD-849/green)](https://jira.percona.com/browse/CLOUD-849) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
*On release branches we don't use main images so the reviewdog for manifests is failing and we need to ignore it.*

**Solution:**
*If a branch is named `release-` then we will use the exact version and instead of `perconalab` use `percona` repository. The check will only be done for operator image and bundles, not for other images since we cannot know all the versions.*

Test run on fake release branch: https://github.com/percona/percona-server-mongodb-operator/pull/1565 

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[CLOUD-849]: https://perconadev.atlassian.net/browse/CLOUD-849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ