### PR TITLE
K8SPSMDB-1101: fix usage of custom cert-manager certificates

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -654,6 +654,7 @@ compare_kubectl() {
 			del(.spec.template.spec.containers[].env[] | select(.name == "NAMESPACE")) |
 			del(.metadata.selfLink) |
 			del(.metadata.annotations."cloud.google.com/neg") |
+			del(.metadata.annotations."kubectl.kubernetes.io/last-applied-configuration") |
 			del(.. | select(has("image")).image) |
 			del(.. | select(has("clusterIP")).clusterIP) |
 			del(.. | select(has("clusterIPs")).clusterIPs) |

--- a/e2e-tests/tls-issue-cert-manager/compare/certificate_some-name-ca-cert-custom.yml
+++ b/e2e-tests/tls-issue-cert-manager/compare/certificate_some-name-ca-cert-custom.yml
@@ -1,0 +1,16 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  annotations:
+    some-random-annotation: "true"
+  generation: 1
+  name: some-name-ca-cert
+spec:
+  commonName: some-name-ca
+  duration: 8760h0m0s
+  isCA: true
+  issuerRef:
+    kind: Issuer
+    name: some-name-psmdb-ca-issuer
+  renewBefore: 730h0m0s
+  secretName: some-name-ca-cert

--- a/e2e-tests/tls-issue-cert-manager/compare/certificate_some-name-ssl-custom.yml
+++ b/e2e-tests/tls-issue-cert-manager/compare/certificate_some-name-ssl-custom.yml
@@ -10,30 +10,30 @@ spec:
   dnsNames:
     - localhost
     - some-name-rs0
-    - some-name-rs0.tls-issue-cert-manager-3840
-    - some-name-rs0.tls-issue-cert-manager-3840.svc.cluster.local
+    - some-name-rs0.NAME_SPACE
+    - some-name-rs0.NAME_SPACE.svc.cluster.local
     - '*.some-name-rs0'
-    - '*.some-name-rs0.tls-issue-cert-manager-3840'
-    - '*.some-name-rs0.tls-issue-cert-manager-3840.svc.cluster.local'
-    - some-name-rs0.tls-issue-cert-manager-3840.svc.clusterset.local
-    - '*.some-name-rs0.tls-issue-cert-manager-3840.svc.clusterset.local'
-    - '*.tls-issue-cert-manager-3840.svc.clusterset.local'
+    - '*.some-name-rs0.NAME_SPACE'
+    - '*.some-name-rs0.NAME_SPACE.svc.cluster.local'
+    - some-name-rs0.NAME_SPACE.svc.clusterset.local
+    - '*.some-name-rs0.NAME_SPACE.svc.clusterset.local'
+    - '*.NAME_SPACE.svc.clusterset.local'
     - some-name-mongos
-    - some-name-mongos.tls-issue-cert-manager-3840
-    - some-name-mongos.tls-issue-cert-manager-3840.svc.cluster.local
+    - some-name-mongos.NAME_SPACE
+    - some-name-mongos.NAME_SPACE.svc.cluster.local
     - '*.some-name-mongos'
-    - '*.some-name-mongos.tls-issue-cert-manager-3840'
-    - '*.some-name-mongos.tls-issue-cert-manager-3840.svc.cluster.local'
+    - '*.some-name-mongos.NAME_SPACE'
+    - '*.some-name-mongos.NAME_SPACE.svc.cluster.local'
     - some-name-cfg
-    - some-name-cfg.tls-issue-cert-manager-3840
-    - some-name-cfg.tls-issue-cert-manager-3840.svc.cluster.local
+    - some-name-cfg.NAME_SPACE
+    - some-name-cfg.NAME_SPACE.svc.cluster.local
     - '*.some-name-cfg'
-    - '*.some-name-cfg.tls-issue-cert-manager-3840'
-    - '*.some-name-cfg.tls-issue-cert-manager-3840.svc.cluster.local'
-    - some-name-mongos.tls-issue-cert-manager-3840.svc.clusterset.local
-    - '*.some-name-mongos.tls-issue-cert-manager-3840.svc.clusterset.local'
-    - some-name-cfg.tls-issue-cert-manager-3840.svc.clusterset.local
-    - '*.some-name-cfg.tls-issue-cert-manager-3840.svc.clusterset.local'
+    - '*.some-name-cfg.NAME_SPACE'
+    - '*.some-name-cfg.NAME_SPACE.svc.cluster.local'
+    - some-name-mongos.NAME_SPACE.svc.clusterset.local
+    - '*.some-name-mongos.NAME_SPACE.svc.clusterset.local'
+    - some-name-cfg.NAME_SPACE.svc.clusterset.local
+    - '*.some-name-cfg.NAME_SPACE.svc.clusterset.local'
   duration: 2160h0m0s
   issuerRef:
     kind: Issuer

--- a/e2e-tests/tls-issue-cert-manager/compare/certificate_some-name-ssl-custom.yml
+++ b/e2e-tests/tls-issue-cert-manager/compare/certificate_some-name-ssl-custom.yml
@@ -1,0 +1,44 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  annotations:
+    some-random-annotation: "true"
+  generation: 1
+  name: some-name-ssl
+spec:
+  commonName: some-name
+  dnsNames:
+    - localhost
+    - some-name-rs0
+    - some-name-rs0.tls-issue-cert-manager-3840
+    - some-name-rs0.tls-issue-cert-manager-3840.svc.cluster.local
+    - '*.some-name-rs0'
+    - '*.some-name-rs0.tls-issue-cert-manager-3840'
+    - '*.some-name-rs0.tls-issue-cert-manager-3840.svc.cluster.local'
+    - some-name-rs0.tls-issue-cert-manager-3840.svc.clusterset.local
+    - '*.some-name-rs0.tls-issue-cert-manager-3840.svc.clusterset.local'
+    - '*.tls-issue-cert-manager-3840.svc.clusterset.local'
+    - some-name-mongos
+    - some-name-mongos.tls-issue-cert-manager-3840
+    - some-name-mongos.tls-issue-cert-manager-3840.svc.cluster.local
+    - '*.some-name-mongos'
+    - '*.some-name-mongos.tls-issue-cert-manager-3840'
+    - '*.some-name-mongos.tls-issue-cert-manager-3840.svc.cluster.local'
+    - some-name-cfg
+    - some-name-cfg.tls-issue-cert-manager-3840
+    - some-name-cfg.tls-issue-cert-manager-3840.svc.cluster.local
+    - '*.some-name-cfg'
+    - '*.some-name-cfg.tls-issue-cert-manager-3840'
+    - '*.some-name-cfg.tls-issue-cert-manager-3840.svc.cluster.local'
+    - some-name-mongos.tls-issue-cert-manager-3840.svc.clusterset.local
+    - '*.some-name-mongos.tls-issue-cert-manager-3840.svc.clusterset.local'
+    - some-name-cfg.tls-issue-cert-manager-3840.svc.clusterset.local
+    - '*.some-name-cfg.tls-issue-cert-manager-3840.svc.clusterset.local'
+  duration: 2160h0m0s
+  issuerRef:
+    kind: Issuer
+    name: some-name-psmdb-issuer
+  secretName: some-name-ssl
+  subject:
+    organizations:
+      - CUSTOM

--- a/e2e-tests/tls-issue-cert-manager/compare/certificate_some-name-ssl-internal-custom.yml
+++ b/e2e-tests/tls-issue-cert-manager/compare/certificate_some-name-ssl-internal-custom.yml
@@ -10,30 +10,30 @@ spec:
   dnsNames:
     - localhost
     - some-name-rs0
-    - some-name-rs0.tls-issue-cert-manager-3840
-    - some-name-rs0.tls-issue-cert-manager-3840.svc.cluster.local
+    - some-name-rs0.NAME_SPACE
+    - some-name-rs0.NAME_SPACE.svc.cluster.local
     - '*.some-name-rs0'
-    - '*.some-name-rs0.tls-issue-cert-manager-3840'
-    - '*.some-name-rs0.tls-issue-cert-manager-3840.svc.cluster.local'
-    - some-name-rs0.tls-issue-cert-manager-3840.svc.clusterset.local
-    - '*.some-name-rs0.tls-issue-cert-manager-3840.svc.clusterset.local'
-    - '*.tls-issue-cert-manager-3840.svc.clusterset.local'
+    - '*.some-name-rs0.NAME_SPACE'
+    - '*.some-name-rs0.NAME_SPACE.svc.cluster.local'
+    - some-name-rs0.NAME_SPACE.svc.clusterset.local
+    - '*.some-name-rs0.NAME_SPACE.svc.clusterset.local'
+    - '*.NAME_SPACE.svc.clusterset.local'
     - some-name-mongos
-    - some-name-mongos.tls-issue-cert-manager-3840
-    - some-name-mongos.tls-issue-cert-manager-3840.svc.cluster.local
+    - some-name-mongos.NAME_SPACE
+    - some-name-mongos.NAME_SPACE.svc.cluster.local
     - '*.some-name-mongos'
-    - '*.some-name-mongos.tls-issue-cert-manager-3840'
-    - '*.some-name-mongos.tls-issue-cert-manager-3840.svc.cluster.local'
+    - '*.some-name-mongos.NAME_SPACE'
+    - '*.some-name-mongos.NAME_SPACE.svc.cluster.local'
     - some-name-cfg
-    - some-name-cfg.tls-issue-cert-manager-3840
-    - some-name-cfg.tls-issue-cert-manager-3840.svc.cluster.local
+    - some-name-cfg.NAME_SPACE
+    - some-name-cfg.NAME_SPACE.svc.cluster.local
     - '*.some-name-cfg'
-    - '*.some-name-cfg.tls-issue-cert-manager-3840'
-    - '*.some-name-cfg.tls-issue-cert-manager-3840.svc.cluster.local'
-    - some-name-mongos.tls-issue-cert-manager-3840.svc.clusterset.local
-    - '*.some-name-mongos.tls-issue-cert-manager-3840.svc.clusterset.local'
-    - some-name-cfg.tls-issue-cert-manager-3840.svc.clusterset.local
-    - '*.some-name-cfg.tls-issue-cert-manager-3840.svc.clusterset.local'
+    - '*.some-name-cfg.NAME_SPACE'
+    - '*.some-name-cfg.NAME_SPACE.svc.cluster.local'
+    - some-name-mongos.NAME_SPACE.svc.clusterset.local
+    - '*.some-name-mongos.NAME_SPACE.svc.clusterset.local'
+    - some-name-cfg.NAME_SPACE.svc.clusterset.local
+    - '*.some-name-cfg.NAME_SPACE.svc.clusterset.local'
   duration: 2160h0m0s
   issuerRef:
     kind: Issuer

--- a/e2e-tests/tls-issue-cert-manager/compare/certificate_some-name-ssl-internal-custom.yml
+++ b/e2e-tests/tls-issue-cert-manager/compare/certificate_some-name-ssl-internal-custom.yml
@@ -1,0 +1,44 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  annotations:
+    some-random-annotation: "true"
+  generation: 1
+  name: some-name-ssl-internal
+spec:
+  commonName: some-name
+  dnsNames:
+    - localhost
+    - some-name-rs0
+    - some-name-rs0.tls-issue-cert-manager-3840
+    - some-name-rs0.tls-issue-cert-manager-3840.svc.cluster.local
+    - '*.some-name-rs0'
+    - '*.some-name-rs0.tls-issue-cert-manager-3840'
+    - '*.some-name-rs0.tls-issue-cert-manager-3840.svc.cluster.local'
+    - some-name-rs0.tls-issue-cert-manager-3840.svc.clusterset.local
+    - '*.some-name-rs0.tls-issue-cert-manager-3840.svc.clusterset.local'
+    - '*.tls-issue-cert-manager-3840.svc.clusterset.local'
+    - some-name-mongos
+    - some-name-mongos.tls-issue-cert-manager-3840
+    - some-name-mongos.tls-issue-cert-manager-3840.svc.cluster.local
+    - '*.some-name-mongos'
+    - '*.some-name-mongos.tls-issue-cert-manager-3840'
+    - '*.some-name-mongos.tls-issue-cert-manager-3840.svc.cluster.local'
+    - some-name-cfg
+    - some-name-cfg.tls-issue-cert-manager-3840
+    - some-name-cfg.tls-issue-cert-manager-3840.svc.cluster.local
+    - '*.some-name-cfg'
+    - '*.some-name-cfg.tls-issue-cert-manager-3840'
+    - '*.some-name-cfg.tls-issue-cert-manager-3840.svc.cluster.local'
+    - some-name-mongos.tls-issue-cert-manager-3840.svc.clusterset.local
+    - '*.some-name-mongos.tls-issue-cert-manager-3840.svc.clusterset.local'
+    - some-name-cfg.tls-issue-cert-manager-3840.svc.clusterset.local
+    - '*.some-name-cfg.tls-issue-cert-manager-3840.svc.clusterset.local'
+  duration: 2160h0m0s
+  issuerRef:
+    kind: Issuer
+    name: some-name-psmdb-issuer
+  secretName: some-name-ssl-internal
+  subject:
+    organizations:
+      - CUSTOM

--- a/e2e-tests/tls-issue-cert-manager/compare/issuer_some-name-psmdb-ca-issuer-custom.yml
+++ b/e2e-tests/tls-issue-cert-manager/compare/issuer_some-name-psmdb-ca-issuer-custom.yml
@@ -1,0 +1,9 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  annotations:
+    some-random-annotation: "true"
+  generation: 1
+  name: some-name-psmdb-ca-issuer
+spec:
+  selfSigned: {}

--- a/e2e-tests/tls-issue-cert-manager/compare/issuer_some-name-psmdb-issuer-custom.yml
+++ b/e2e-tests/tls-issue-cert-manager/compare/issuer_some-name-psmdb-issuer-custom.yml
@@ -1,0 +1,10 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  annotations:
+    some-random-annotation: "true"
+  generation: 1
+  name: some-name-psmdb-issuer
+spec:
+  ca:
+    secretName: some-name-ca-cert

--- a/e2e-tests/tls-issue-cert-manager/conf/some-name-ca-cert.yml
+++ b/e2e-tests/tls-issue-cert-manager/conf/some-name-ca-cert.yml
@@ -1,0 +1,15 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  annotations:
+    some-random-annotation: "true"
+  name: some-name-ca-cert
+spec:
+  commonName: some-name-ca
+  duration: 8760h0m0s
+  isCA: true
+  issuerRef:
+    kind: Issuer
+    name: some-name-psmdb-ca-issuer
+  renewBefore: 730h0m0s
+  secretName: some-name-ca-cert

--- a/e2e-tests/tls-issue-cert-manager/conf/some-name-psmdb-ca-issuer.yml
+++ b/e2e-tests/tls-issue-cert-manager/conf/some-name-psmdb-ca-issuer.yml
@@ -1,0 +1,8 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  annotations:
+    some-random-annotation: "true"
+  name: some-name-psmdb-ca-issuer
+spec:
+  selfSigned: {}

--- a/e2e-tests/tls-issue-cert-manager/conf/some-name-psmdb-issuer.yml
+++ b/e2e-tests/tls-issue-cert-manager/conf/some-name-psmdb-issuer.yml
@@ -1,0 +1,9 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  annotations:
+    some-random-annotation: "true"
+  name: some-name-psmdb-issuer
+spec:
+  ca:
+    secretName: some-name-ca-cert

--- a/e2e-tests/tls-issue-cert-manager/conf/some-name-ssl-internal.yml
+++ b/e2e-tests/tls-issue-cert-manager/conf/some-name-ssl-internal.yml
@@ -9,30 +9,30 @@ spec:
   dnsNames:
   - localhost
   - some-name-rs0
-  - some-name-rs0.tls-issue-cert-manager-3840
-  - some-name-rs0.tls-issue-cert-manager-3840.svc.cluster.local
+  - some-name-rs0.NAME_SPACE
+  - some-name-rs0.NAME_SPACE.svc.cluster.local
   - '*.some-name-rs0'
-  - '*.some-name-rs0.tls-issue-cert-manager-3840'
-  - '*.some-name-rs0.tls-issue-cert-manager-3840.svc.cluster.local'
-  - some-name-rs0.tls-issue-cert-manager-3840.svc.clusterset.local
-  - '*.some-name-rs0.tls-issue-cert-manager-3840.svc.clusterset.local'
-  - '*.tls-issue-cert-manager-3840.svc.clusterset.local'
+  - '*.some-name-rs0.NAME_SPACE'
+  - '*.some-name-rs0.NAME_SPACE.svc.cluster.local'
+  - some-name-rs0.NAME_SPACE.svc.clusterset.local
+  - '*.some-name-rs0.NAME_SPACE.svc.clusterset.local'
+  - '*.NAME_SPACE.svc.clusterset.local'
   - some-name-mongos
-  - some-name-mongos.tls-issue-cert-manager-3840
-  - some-name-mongos.tls-issue-cert-manager-3840.svc.cluster.local
+  - some-name-mongos.NAME_SPACE
+  - some-name-mongos.NAME_SPACE.svc.cluster.local
   - '*.some-name-mongos'
-  - '*.some-name-mongos.tls-issue-cert-manager-3840'
-  - '*.some-name-mongos.tls-issue-cert-manager-3840.svc.cluster.local'
+  - '*.some-name-mongos.NAME_SPACE'
+  - '*.some-name-mongos.NAME_SPACE.svc.cluster.local'
   - some-name-cfg
-  - some-name-cfg.tls-issue-cert-manager-3840
-  - some-name-cfg.tls-issue-cert-manager-3840.svc.cluster.local
+  - some-name-cfg.NAME_SPACE
+  - some-name-cfg.NAME_SPACE.svc.cluster.local
   - '*.some-name-cfg'
-  - '*.some-name-cfg.tls-issue-cert-manager-3840'
-  - '*.some-name-cfg.tls-issue-cert-manager-3840.svc.cluster.local'
-  - some-name-mongos.tls-issue-cert-manager-3840.svc.clusterset.local
-  - '*.some-name-mongos.tls-issue-cert-manager-3840.svc.clusterset.local'
-  - some-name-cfg.tls-issue-cert-manager-3840.svc.clusterset.local
-  - '*.some-name-cfg.tls-issue-cert-manager-3840.svc.clusterset.local'
+  - '*.some-name-cfg.NAME_SPACE'
+  - '*.some-name-cfg.NAME_SPACE.svc.cluster.local'
+  - some-name-mongos.NAME_SPACE.svc.clusterset.local
+  - '*.some-name-mongos.NAME_SPACE.svc.clusterset.local'
+  - some-name-cfg.NAME_SPACE.svc.clusterset.local
+  - '*.some-name-cfg.NAME_SPACE.svc.clusterset.local'
   duration: 2160h0m0s
   issuerRef:
     kind: Issuer

--- a/e2e-tests/tls-issue-cert-manager/conf/some-name-ssl-internal.yml
+++ b/e2e-tests/tls-issue-cert-manager/conf/some-name-ssl-internal.yml
@@ -1,0 +1,43 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  annotations:
+    some-random-annotation: "true"
+  name: some-name-ssl-internal
+spec:
+  commonName: some-name
+  dnsNames:
+  - localhost
+  - some-name-rs0
+  - some-name-rs0.tls-issue-cert-manager-3840
+  - some-name-rs0.tls-issue-cert-manager-3840.svc.cluster.local
+  - '*.some-name-rs0'
+  - '*.some-name-rs0.tls-issue-cert-manager-3840'
+  - '*.some-name-rs0.tls-issue-cert-manager-3840.svc.cluster.local'
+  - some-name-rs0.tls-issue-cert-manager-3840.svc.clusterset.local
+  - '*.some-name-rs0.tls-issue-cert-manager-3840.svc.clusterset.local'
+  - '*.tls-issue-cert-manager-3840.svc.clusterset.local'
+  - some-name-mongos
+  - some-name-mongos.tls-issue-cert-manager-3840
+  - some-name-mongos.tls-issue-cert-manager-3840.svc.cluster.local
+  - '*.some-name-mongos'
+  - '*.some-name-mongos.tls-issue-cert-manager-3840'
+  - '*.some-name-mongos.tls-issue-cert-manager-3840.svc.cluster.local'
+  - some-name-cfg
+  - some-name-cfg.tls-issue-cert-manager-3840
+  - some-name-cfg.tls-issue-cert-manager-3840.svc.cluster.local
+  - '*.some-name-cfg'
+  - '*.some-name-cfg.tls-issue-cert-manager-3840'
+  - '*.some-name-cfg.tls-issue-cert-manager-3840.svc.cluster.local'
+  - some-name-mongos.tls-issue-cert-manager-3840.svc.clusterset.local
+  - '*.some-name-mongos.tls-issue-cert-manager-3840.svc.clusterset.local'
+  - some-name-cfg.tls-issue-cert-manager-3840.svc.clusterset.local
+  - '*.some-name-cfg.tls-issue-cert-manager-3840.svc.clusterset.local'
+  duration: 2160h0m0s
+  issuerRef:
+    kind: Issuer
+    name: some-name-psmdb-issuer
+  secretName: some-name-ssl-internal
+  subject:
+    organizations:
+    - CUSTOM

--- a/e2e-tests/tls-issue-cert-manager/conf/some-name-ssl.yml
+++ b/e2e-tests/tls-issue-cert-manager/conf/some-name-ssl.yml
@@ -9,30 +9,30 @@ spec:
   dnsNames:
   - localhost
   - some-name-rs0
-  - some-name-rs0.tls-issue-cert-manager-3840
-  - some-name-rs0.tls-issue-cert-manager-3840.svc.cluster.local
+  - some-name-rs0.NAME_SPACE
+  - some-name-rs0.NAME_SPACE.svc.cluster.local
   - '*.some-name-rs0'
-  - '*.some-name-rs0.tls-issue-cert-manager-3840'
-  - '*.some-name-rs0.tls-issue-cert-manager-3840.svc.cluster.local'
-  - some-name-rs0.tls-issue-cert-manager-3840.svc.clusterset.local
-  - '*.some-name-rs0.tls-issue-cert-manager-3840.svc.clusterset.local'
-  - '*.tls-issue-cert-manager-3840.svc.clusterset.local'
+  - '*.some-name-rs0.NAME_SPACE'
+  - '*.some-name-rs0.NAME_SPACE.svc.cluster.local'
+  - some-name-rs0.NAME_SPACE.svc.clusterset.local
+  - '*.some-name-rs0.NAME_SPACE.svc.clusterset.local'
+  - '*.NAME_SPACE.svc.clusterset.local'
   - some-name-mongos
-  - some-name-mongos.tls-issue-cert-manager-3840
-  - some-name-mongos.tls-issue-cert-manager-3840.svc.cluster.local
+  - some-name-mongos.NAME_SPACE
+  - some-name-mongos.NAME_SPACE.svc.cluster.local
   - '*.some-name-mongos'
-  - '*.some-name-mongos.tls-issue-cert-manager-3840'
-  - '*.some-name-mongos.tls-issue-cert-manager-3840.svc.cluster.local'
+  - '*.some-name-mongos.NAME_SPACE'
+  - '*.some-name-mongos.NAME_SPACE.svc.cluster.local'
   - some-name-cfg
-  - some-name-cfg.tls-issue-cert-manager-3840
-  - some-name-cfg.tls-issue-cert-manager-3840.svc.cluster.local
+  - some-name-cfg.NAME_SPACE
+  - some-name-cfg.NAME_SPACE.svc.cluster.local
   - '*.some-name-cfg'
-  - '*.some-name-cfg.tls-issue-cert-manager-3840'
-  - '*.some-name-cfg.tls-issue-cert-manager-3840.svc.cluster.local'
-  - some-name-mongos.tls-issue-cert-manager-3840.svc.clusterset.local
-  - '*.some-name-mongos.tls-issue-cert-manager-3840.svc.clusterset.local'
-  - some-name-cfg.tls-issue-cert-manager-3840.svc.clusterset.local
-  - '*.some-name-cfg.tls-issue-cert-manager-3840.svc.clusterset.local'
+  - '*.some-name-cfg.NAME_SPACE'
+  - '*.some-name-cfg.NAME_SPACE.svc.cluster.local'
+  - some-name-mongos.NAME_SPACE.svc.clusterset.local
+  - '*.some-name-mongos.NAME_SPACE.svc.clusterset.local'
+  - some-name-cfg.NAME_SPACE.svc.clusterset.local
+  - '*.some-name-cfg.NAME_SPACE.svc.clusterset.local'
   duration: 2160h0m0s
   issuerRef:
     kind: Issuer

--- a/e2e-tests/tls-issue-cert-manager/conf/some-name-ssl.yml
+++ b/e2e-tests/tls-issue-cert-manager/conf/some-name-ssl.yml
@@ -1,0 +1,43 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  annotations:
+    some-random-annotation: "true"
+  name: some-name-ssl
+spec:
+  commonName: some-name
+  dnsNames:
+  - localhost
+  - some-name-rs0
+  - some-name-rs0.tls-issue-cert-manager-3840
+  - some-name-rs0.tls-issue-cert-manager-3840.svc.cluster.local
+  - '*.some-name-rs0'
+  - '*.some-name-rs0.tls-issue-cert-manager-3840'
+  - '*.some-name-rs0.tls-issue-cert-manager-3840.svc.cluster.local'
+  - some-name-rs0.tls-issue-cert-manager-3840.svc.clusterset.local
+  - '*.some-name-rs0.tls-issue-cert-manager-3840.svc.clusterset.local'
+  - '*.tls-issue-cert-manager-3840.svc.clusterset.local'
+  - some-name-mongos
+  - some-name-mongos.tls-issue-cert-manager-3840
+  - some-name-mongos.tls-issue-cert-manager-3840.svc.cluster.local
+  - '*.some-name-mongos'
+  - '*.some-name-mongos.tls-issue-cert-manager-3840'
+  - '*.some-name-mongos.tls-issue-cert-manager-3840.svc.cluster.local'
+  - some-name-cfg
+  - some-name-cfg.tls-issue-cert-manager-3840
+  - some-name-cfg.tls-issue-cert-manager-3840.svc.cluster.local
+  - '*.some-name-cfg'
+  - '*.some-name-cfg.tls-issue-cert-manager-3840'
+  - '*.some-name-cfg.tls-issue-cert-manager-3840.svc.cluster.local'
+  - some-name-mongos.tls-issue-cert-manager-3840.svc.clusterset.local
+  - '*.some-name-mongos.tls-issue-cert-manager-3840.svc.clusterset.local'
+  - some-name-cfg.tls-issue-cert-manager-3840.svc.clusterset.local
+  - '*.some-name-cfg.tls-issue-cert-manager-3840.svc.clusterset.local'
+  duration: 2160h0m0s
+  issuerRef:
+    kind: Issuer
+    name: some-name-psmdb-issuer
+  secretName: some-name-ssl
+  subject:
+    organizations:
+    - CUSTOM

--- a/e2e-tests/tls-issue-cert-manager/run
+++ b/e2e-tests/tls-issue-cert-manager/run
@@ -31,10 +31,52 @@ main() {
 	desc 'create secrets and start client'
 	kubectl_bin apply -f "$conf_dir/secrets.yml"
 	kubectl_bin apply -f "$conf_dir/client_with_tls.yml"
+
+	desc 'create custom cert-manager issuers and certificates'
+	kubectl_bin apply -f "$test_dir/conf/some-name-psmdb-ca-issuer.yml"
+	kubectl_bin apply -f "$test_dir/conf/some-name-psmdb-issuer.yml"
+	kubectl_bin apply -f "$test_dir/conf/some-name-ca-cert.yml"
+	kubectl_bin apply -f "$test_dir/conf/some-name-ssl-internal.yml"
+	kubectl_bin apply -f "$test_dir/conf/some-name-ssl.yml"
 	deploy_cmctl
+	sleep 60
 
 	cluster="some-name"
 	desc "create first PSMDB cluster $cluster"
+	apply_cluster "$test_dir/conf/$cluster.yml"
+
+	desc 'check if all Pods started'
+	wait_for_running $cluster-rs0 3
+	wait_for_running $cluster-cfg 3 "false"
+	wait_for_running $cluster-mongos 3
+
+	desc 'compare custom certificates and issuers'
+	compare_kubectl "certificate/${cluster}-ssl" "-custom"
+	compare_kubectl "certificate/${cluster}-ssl-internal" "-custom"
+	compare_kubectl "certificate/${cluster}-ca-cert" "-custom"
+	compare_kubectl "issuer/$cluster-psmdb-ca-issuer" "-custom"
+	compare_kubectl "issuer/$cluster-psmdb-issuer" "-custom"
+
+	desc 'delete cluster'
+	kubectl delete psmdb --all
+	kubectl delete pvc --all
+
+	desc 'delete custom cert-manager issuers and certificates'
+	kubectl_bin delete -f "$test_dir/conf/some-name-psmdb-ca-issuer.yml"
+	kubectl_bin delete -f "$test_dir/conf/some-name-psmdb-issuer.yml"
+	kubectl_bin delete -f "$test_dir/conf/some-name-ca-cert.yml"
+	kubectl_bin delete -f "$test_dir/conf/some-name-ssl-internal.yml"
+	kubectl_bin delete -f "$test_dir/conf/some-name-ssl.yml"
+
+	sleep 30
+
+	desc 'delete ssl secrets, operator should recreate them'
+	kubectl_bin delete secret "$cluster-ssl-internal"
+	kubectl_bin delete secret "$cluster-ssl"
+
+	sleep 30
+
+	desc "recreate PSMDB cluster $cluster"
 	apply_cluster "$test_dir/conf/$cluster.yml"
 
 	desc 'check if all Pods started'

--- a/pkg/controller/perconaservermongodb/psmdb_controller.go
+++ b/pkg/controller/perconaservermongodb/psmdb_controller.go
@@ -1392,7 +1392,11 @@ func (r *ReconcilePerconaServerMongoDB) sslAnnotation(ctx context.Context, cr *a
 	sslInternalSecret, err := getSecret(api.SSLInternalSecretName(cr))
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			if cr.UnsafeTLSDisabled() || tls.IsSecretCreatedByUser(cr, sslSecret) {
+			isCustomSecret, serr := tls.IsSecretCreatedByUser(ctx, r.client, cr, sslSecret)
+			if serr != nil {
+				return nil, errors.Wrap(serr, "failed to check if secret is created by user")
+			}
+			if cr.UnsafeTLSDisabled() || isCustomSecret {
 				return annotation, nil
 			}
 			return nil, errTLSNotReady

--- a/pkg/controller/perconaservermongodb/ssl.go
+++ b/pkg/controller/perconaservermongodb/ssl.go
@@ -36,6 +36,10 @@ func (r *ReconcilePerconaServerMongoDB) reconcileSSL(ctx context.Context, cr *ap
 	if client.IgnoreNotFound(errSecret) != nil {
 		return errors.Wrap(errSecret, "get SSL secret")
 	}
+	isCustomSecret, serr := tls.IsSecretCreatedByUser(ctx, r.client, cr, &secretObj)
+	if serr != nil {
+		return errors.Wrap(serr, "failed to check if secret is created by user")
+	}
 	errInternalSecret := r.client.Get(ctx,
 		types.NamespacedName{
 			Namespace: cr.Namespace,
@@ -46,14 +50,18 @@ func (r *ReconcilePerconaServerMongoDB) reconcileSSL(ctx context.Context, cr *ap
 	if client.IgnoreNotFound(errInternalSecret) != nil {
 		return errors.Wrap(errInternalSecret, "get internal SSL secret")
 	}
+	isCustomSecretInternal, serr := tls.IsSecretCreatedByUser(ctx, r.client, cr, &secretInternalObj)
+	if serr != nil {
+		return errors.Wrap(serr, "failed to check if internal secret is created by user")
+	}
 
-	if errSecret == nil && tls.IsSecretCreatedByUser(cr, &secretObj) {
+	if errSecret == nil && isCustomSecret {
 		// We shouldn't do anything if the user has created a custom ssl secret.
 		// We should also allow the use of operator without internal ssl secret, so we only check for non-internal secret here.
 		return nil
 	}
 
-	if k8serr.IsNotFound(errSecret) && errInternalSecret == nil && tls.IsSecretCreatedByUser(cr, &secretInternalObj) {
+	if k8serr.IsNotFound(errSecret) && errInternalSecret == nil && isCustomSecretInternal {
 		// If the user has only created an internal secret, we should create a copy of it as a non-internal secret.
 		newSecret := secretInternalObj.DeepCopy()
 		newSecret.ObjectMeta = metav1.ObjectMeta{

--- a/pkg/psmdb/tls/certmanager.go
+++ b/pkg/psmdb/tls/certmanager.go
@@ -277,13 +277,14 @@ func (c *certManagerController) WaitForCerts(ctx context.Context, cr *api.Percon
 					return err
 				} else if err == nil {
 					successCount++
-					if v, ok := secret.Annotations[cm.CertificateNameKey]; ok && v == secret.Name {
-						if err = controllerutil.SetControllerReference(cr, secret, c.scheme); err != nil {
-							return errors.Wrap(err, "set controller reference")
-						}
-						if err = c.cl.Update(ctx, secret); err != nil {
-							return errors.Wrap(err, "failed to update secret")
-						}
+					if v, ok := secret.Annotations[cm.CertificateNameKey]; !ok || v != secret.Name {
+						continue
+					}
+					if err = controllerutil.SetControllerReference(cr, secret, c.scheme); err != nil {
+						return errors.Wrap(err, "set controller reference")
+					}
+					if err = c.cl.Update(ctx, secret); err != nil {
+						return errors.Wrap(err, "failed to update secret")
 					}
 				}
 			}


### PR DESCRIPTION
[![K8SPSMDB-1101](https://badgen.net/badge/JIRA/K8SPSMDB-1101/green)](https://jira.percona.com/browse/K8SPSMDB-1101) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://perconadev.atlassian.net/browse/K8SPSMDB-1101

**DESCRIPTION**
---
**Problem:**
*Custom certificates created using `cert-manager` are overwritten by operator.*

**Cause:**
*If tls secrets were created using `cert-manager`, the operator doesn't check whether they were created by the user.*

**Solution:**
*Check that the tls secrets created using `cert-manager` have been created by the user.*

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported MongoDB version?
- [x] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-1101]: https://perconadev.atlassian.net/browse/K8SPSMDB-1101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ