### PR TITLE
K8SPSMDB-1094: Check FCV

### DIFF
--- a/pkg/controller/perconaservermongodb/psmdb_controller.go
+++ b/pkg/controller/perconaservermongodb/psmdb_controller.go
@@ -409,7 +409,7 @@ func (r *ReconcilePerconaServerMongoDB) Reconcile(ctx context.Context, request r
 		return reconcile.Result{}, errors.Wrap(err, "reconcile mongos")
 	}
 
-	if err := r.upgradeFCVIfNeeded(ctx, cr, *repls[0], cr.Status.MongoVersion); err != nil {
+	if err := r.upgradeFCVIfNeeded(ctx, cr, cr.Status.MongoVersion); err != nil {
 		return reconcile.Result{}, errors.Wrap(err, "failed to set FCV")
 	}
 
@@ -895,8 +895,11 @@ func (r *ReconcilePerconaServerMongoDB) stopMongosInCaseOfRestore(ctx context.Co
 	return nil
 }
 
-func (r *ReconcilePerconaServerMongoDB) upgradeFCVIfNeeded(ctx context.Context, cr *api.PerconaServerMongoDB, repl api.ReplsetSpec, newFCV string) error {
-	if !cr.Spec.UpgradeOptions.SetFCV {
+func (r *ReconcilePerconaServerMongoDB) upgradeFCVIfNeeded(ctx context.Context, cr *api.PerconaServerMongoDB, newFCV string) error {
+
+	fmt.Printf("AAAAAAAAAAAAAAAA newFCV: %s\n", newFCV)
+
+	if !cr.Spec.UpgradeOptions.SetFCV || newFCV == "" {
 		return nil
 	}
 

--- a/pkg/controller/perconaservermongodb/psmdb_controller.go
+++ b/pkg/controller/perconaservermongodb/psmdb_controller.go
@@ -896,9 +896,6 @@ func (r *ReconcilePerconaServerMongoDB) stopMongosInCaseOfRestore(ctx context.Co
 }
 
 func (r *ReconcilePerconaServerMongoDB) upgradeFCVIfNeeded(ctx context.Context, cr *api.PerconaServerMongoDB, newFCV string) error {
-
-	fmt.Printf("AAAAAAAAAAAAAAAA newFCV: %s\n", newFCV)
-
 	if !cr.Spec.UpgradeOptions.SetFCV || newFCV == "" {
 		return nil
 	}


### PR DESCRIPTION
[![K8SPSMDB-1094](https://badgen.net/badge/JIRA/K8SPSMDB-1094/green)](https://jira.percona.com/browse/K8SPSMDB-1094) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
If `cr.Spec.UpgradeOptions.SetFCV` is set to `true` and we create a fresh cluster, the operator errors out with:
```
"error": "failed to set FCV: invalid version: Malformed version: "
```

**Cause:**
We pass `cr.Status.MongoVersion` to `r.upgradeFCVIfNeeded` and since `cr.Status.MongoVersion` is empty when creating a new cluster, the operator errors with the mentioned error since we have a empty string for a version.

**Solution:**
Proceed in `r.upgradeFCVIfNeeded` if the version is not empty.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?
- [x] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported MongoDB version?
- [x] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-1094]: https://perconadev.atlassian.net/browse/K8SPSMDB-1094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ