### PR TITLE
K8SPSMDB-1117: Fix pvc-resize test on EKS

### DIFF
--- a/e2e-tests/pvc-resize/run
+++ b/e2e-tests/pvc-resize/run
@@ -82,10 +82,14 @@ kubectl_bin apply \
 
 desc 'create PSMDB cluster'
 cluster="some-name"
-spinup_psmdb "${cluster}-rs0" "$test_dir/conf/$cluster.yml"
+if [ "$EKS" == 1 ]; then
+	spinup_psmdb "${cluster}-rs0" "$test_dir/conf/$cluster-eks.yml"
+else
+	spinup_psmdb "${cluster}-rs0" "$test_dir/conf/$cluster.yml"
+fi
 
 patch_pvc_request "${cluster}" "2Gi"
-wait_cluster_consistency "$cluster" 3 2
+wait_cluster_consistency "$cluster"
 echo
 
 for pvc in $(kubectl_bin get pvc -l app.kubernetes.io/component=mongod -o name); do
@@ -106,7 +110,10 @@ for pvc in $(kubectl_bin get pvc -l app.kubernetes.io/component=mongod -o name);
 	echo "pvc/${pvc} was resized"
 done
 
-if [[ $EKS == 1 || -n ${OPENSHIFT} ]]; then
+wait_cluster_consistency "$cluster"
+echo
+
+if [[ "$EKS" == 1 || -n ${OPENSHIFT} ]]; then
 	# AWS rate limits PVC expansion for the same EBS volume (1 expand operation in every 6 hours),
 	# so we need to delete and recreate the cluster
 	echo "Deleting and recreating PSMDB cluster ${cluster}"
@@ -127,7 +134,7 @@ desc 'create resourcequota'
 
 apply_resourcequota 7Gi
 patch_pvc_request "${cluster}" "3Gi"
-wait_cluster_consistency "$cluster" 3 2
+wait_cluster_consistency "$cluster"
 echo
 
 echo -n "Waiting for pvc/mongod-data-some-name-rs0-0 to be resized"
@@ -149,7 +156,7 @@ echo "pvc/mongod-data-some-name-rs0-0 was resized"
 
 apply_resourcequota 9Gi
 patch_pvc_request "${cluster}" "3Gi"
-wait_cluster_consistency "$cluster" 3 2
+wait_cluster_consistency "$cluster"
 echo
 for pvc in $(kubectl_bin get pvc -l app.kubernetes.io/component=mongod -o name); do
 	retry=0

--- a/pkg/controller/perconaservermongodb/status.go
+++ b/pkg/controller/perconaservermongodb/status.go
@@ -260,6 +260,16 @@ func (r *ReconcilePerconaServerMongoDB) writeStatus(ctx context.Context, cr *api
 }
 
 func (r *ReconcilePerconaServerMongoDB) rsStatus(ctx context.Context, cr *api.PerconaServerMongoDB, rsSpec *api.ReplsetSpec) (api.ReplsetStatus, error) {
+	sts := &appsv1.StatefulSet{}
+	err := r.client.Get(ctx, types.NamespacedName{Name: cr.Name + "-" + rsSpec.Name, Namespace: cr.Namespace}, sts)
+	if err != nil {
+		return api.ReplsetStatus{}, client.IgnoreNotFound(err)
+	}
+
+	if sts.Annotations[api.AnnotationPVCResizeInProgress] != "" {
+		return api.ReplsetStatus{Status: api.AppStateInit}, nil
+	}
+
 	list, err := psmdb.GetRSPods(ctx, r.client, cr, rsSpec.Name)
 	if err != nil {
 		return api.ReplsetStatus{}, fmt.Errorf("get list: %v", err)


### PR DESCRIPTION
[![K8SPSMDB-1117](https://badgen.net/badge/JIRA/K8SPSMDB-1117/green)](https://jira.percona.com/browse/K8SPSMDB-1117) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
Cluster status remains ready during PVC resize. This, sometimes, causes PerconaServerMongoDB object to be deleted before statefulset is recreated.

**Solution:**
Ensure cluster status is initializing during PVC resize.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?
- [x] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported MongoDB version?
- [x] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-1117]: https://perconadev.atlassian.net/browse/K8SPSMDB-1117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ