### PR TITLE
K8SPSMDB-1089: fix deleting cluster with wrong options

### DIFF
--- a/pkg/controller/perconaservermongodb/psmdb_controller.go
+++ b/pkg/controller/perconaservermongodb/psmdb_controller.go
@@ -279,6 +279,15 @@ func (r *ReconcilePerconaServerMongoDB) Reconcile(ctx context.Context, request r
 
 	err = cr.CheckNSetDefaults(r.serverVersion.Platform, log)
 	if err != nil {
+		// If the user created a cluster with finalizers and wrong options, it would be impossible to delete a cluster.
+		// We need to run checkFinalizers to delete finalizers
+		if cr.DeletionTimestamp != nil {
+			_, err := r.checkFinalizers(ctx, cr)
+			if err != nil {
+				log.Error(err, "failed to check finalizers")
+			}
+		}
+
 		err = errors.Wrap(err, "wrong psmdb options")
 		return reconcile.Result{}, err
 	}


### PR DESCRIPTION
[![K8SPSMDB-1089](https://badgen.net/badge/JIRA/K8SPSMDB-1089/green)](https://jira.percona.com/browse/K8SPSMDB-1089) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://perconadev.atlassian.net/browse/K8SPSMDB-1089

**DESCRIPTION**
---
**Problem:**
*If the user created a cluster with finalizers and wrong options, it would be impossible to delete a cluster.*

**Cause:**
*Part of code which is responsible for deleting finalizers is executed after the `CheckNSetDefaults` method. If this method fails due to invalid cluster options, finalizers will not be deleted.*

**Solution:**
*We need to run `checkFinalizers` to delete finalizers if `CheckNSetDefaults` fails.*

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported MongoDB version?
- [x] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-1089]: https://perconadev.atlassian.net/browse/K8SPSMDB-1089?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ