### PR TITLE
K8SPSMDB-1175: fix `clusterAuthMode`

### DIFF
--- a/pkg/psmdb/container.go
+++ b/pkg/psmdb/container.go
@@ -192,7 +192,7 @@ func containerArgs(ctx context.Context, cr *api.PerconaServerMongoDB, replset *a
 		args = append(args, "--sslAllowInvalidCertificates")
 	}
 
-	if (cr.TLSEnabled() && cr.Spec.TLS.Mode == api.TLSModeAllow) || cr.UnsafeTLSDisabled() || cr.Spec.Secrets.InternalKey != "" {
+	if cr.Spec.Secrets.InternalKey != "" || (cr.TLSEnabled() && cr.Spec.TLS.Mode == api.TLSModeAllow) || (!cr.TLSEnabled() && cr.UnsafeTLSDisabled()) {
 		args = append(args,
 			"--clusterAuthMode=keyFile",
 			"--keyFile="+mongodSecretsDir+"/mongodb-key",

--- a/pkg/psmdb/mongos.go
+++ b/pkg/psmdb/mongos.go
@@ -255,7 +255,7 @@ func mongosContainerArgs(cr *api.PerconaServerMongoDB, useConfigFile bool, cfgIn
 		"--relaxPermChecks",
 	}...)
 
-	if (cr.TLSEnabled() && cr.Spec.TLS.Mode == api.TLSModeAllow) || cr.UnsafeTLSDisabled() || cr.Spec.Secrets.InternalKey != "" {
+	if cr.Spec.Secrets.InternalKey != "" || (cr.TLSEnabled() && cr.Spec.TLS.Mode == api.TLSModeAllow) || (!cr.TLSEnabled() && cr.UnsafeTLSDisabled()) {
 		args = append(args,
 			"--clusterAuthMode=keyFile",
 			"--keyFile="+mongodSecretsDir+"/mongodb-key",


### PR DESCRIPTION
[![K8SPSMDB-1175](https://badgen.net/badge/JIRA/K8SPSMDB-1175/green)](https://jira.percona.com/browse/K8SPSMDB-1175) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://perconadev.atlassian.net/browse/K8SPSMDB-1175

**DESCRIPTION**
---
**Problem:**
*When `.spec.unsafeFlags.tls` is switched to `true` while TLS is enabled, all statefulsets are updated to use `--clusterAuthMode=keyFile` instead of `--clusterAuthMode=x509`. This leads to mongos being stuck in a smartUpdate.*

**Cause:**
*My PR https://github.com/percona/percona-server-mongodb-operator/pull/1639 introduced a regression, by using `--clusterAuthMode=keyFile` when `.spec.unsafeFlags.tls` is `true` even if TLS is enabled.*

**Solution:**
*If `.spec.unsafeFlags.tls` is true, use `--clusterAuthMode=keyFile` only when TLS is disabled.*

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported MongoDB version?
- [x] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-1175]: https://perconadev.atlassian.net/browse/K8SPSMDB-1175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ