### PR TITLE
K8SPSMDB-1177: Bump PBM to 2.7.0

### DIFF
--- a/e2e-tests/conf/client_with_tls.yml
+++ b/e2e-tests/conf/client_with_tls.yml
@@ -12,6 +12,7 @@ spec:
       labels:
         name: psmdb-client
     spec:
+      terminationGracePeriodSeconds: 10
       containers:
         - name: psmdb-client
           image: percona/percona-server-mongodb:4.4

--- a/e2e-tests/demand-backup-physical/run
+++ b/e2e-tests/demand-backup-physical/run
@@ -36,16 +36,27 @@ run_recovery_check() {
 
 	# we don't wait for cluster readiness here because the annotation gets removed then
 	wait_restore "${backup_name}" "${cluster}" "ready" "0" "1800"
+
 	kubectl_bin get psmdb ${cluster} -o yaml
 	if [ $(kubectl_bin get psmdb ${cluster} -o yaml | yq '.metadata.annotations."percona.com/resync-pbm"') == null ]; then
 		echo "psmdb/${cluster} should be annotated with percona.com/resync-pbm after a physical restore"
 		exit 1
 	fi
 	echo
+
 	wait_cluster_consistency ${cluster}
+
+	until [[ "$(kubectl_bin exec ${cluster}-rs0-0 -c backup-agent -- pbm status -o json | jq .running)" == '{}' ]]; do
+		local running=$(kubectl_bin exec ${cluster}-rs0-0 -c backup-agent -- pbm status -o json | jq -c .running)
+		echo "waiting for PBM operation to finish: ${running}";
+		sleep 5
+	done
+	echo "PBM operation is finished"
+
 	compare_mongo_cmd "find" "myApp:myPass@${cluster}-rs0-0.${cluster}-rs0.${namespace}"
 	compare_mongo_cmd "find" "myApp:myPass@${cluster}-rs0-1.${cluster}-rs0.${namespace}"
 	compare_mongo_cmd "find" "myApp:myPass@${cluster}-rs0-2.${cluster}-rs0.${namespace}"
+
 	echo
 	set -o xtrace
 }

--- a/e2e-tests/demand-backup-physical/run
+++ b/e2e-tests/demand-backup-physical/run
@@ -46,13 +46,6 @@ run_recovery_check() {
 
 	wait_cluster_consistency ${cluster}
 
-	until [[ "$(kubectl_bin exec ${cluster}-rs0-0 -c backup-agent -- pbm status -o json | jq .running)" == '{}' ]]; do
-		local running=$(kubectl_bin exec ${cluster}-rs0-0 -c backup-agent -- pbm status -o json | jq -c .running)
-		echo "waiting for PBM operation to finish: ${running}";
-		sleep 5
-	done
-	echo "PBM operation is finished"
-
 	compare_mongo_cmd "find" "myApp:myPass@${cluster}-rs0-0.${cluster}-rs0.${namespace}"
 	compare_mongo_cmd "find" "myApp:myPass@${cluster}-rs0-1.${cluster}-rs0.${namespace}"
 	compare_mongo_cmd "find" "myApp:myPass@${cluster}-rs0-2.${cluster}-rs0.${namespace}"

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -11,7 +11,7 @@ perconalab/percona-server-mongodb-operator:main-mongod5.0
 
 perconalab/percona-server-mongodb-operator:main-mongod6.0
 perconalab/percona-server-mongodb-operator:main-mongod7.0'}
-IMAGE_BACKUP=${IMAGE_BACKUP:-"perconalab/percona-server-mongodb-operator:main-backup"}
+IMAGE_BACKUP=${IMAGE_BACKUP:-"perconalab/percona-backup-mongodb:2.7.0"}
 SKIP_BACKUPS_TO_AWS_GCP_AZURE=${SKIP_BACKUPS_TO_AWS_GCP_AZURE:-1}
 PMM_SERVER_VER=${PMM_SERVER_VER:-"9.9.9"}
 IMAGE_PMM_CLIENT=${IMAGE_PMM_CLIENT:-"perconalab/pmm-client:dev-latest"}

--- a/e2e-tests/pitr-physical/run
+++ b/e2e-tests/pitr-physical/run
@@ -152,11 +152,6 @@ main() {
 	sleep 360
 
 	backup_name_minio="backup-minio"
-	run_backup $backup_name_minio 1 physical
-
-	# 2nd backup is required for to workaround PBM-1391
-	# in case of the 1st, pbmPITR collection is created after the backup
-	# and it causes crashes after physical restore
 	run_backup $backup_name_minio 2 physical
 
 	write_document "-2nd"

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/go-openapi/validate v0.24.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.22.0
 	github.com/hashicorp/go-version v1.7.0
-	github.com/percona/percona-backup-mongodb v1.8.1-0.20240902083313-f2cf881c856b
+	github.com/percona/percona-backup-mongodb v1.8.1-0.20241002124601-957ac501f939
 	github.com/pkg/errors v0.9.1
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -385,6 +385,8 @@ github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/9
 github.com/pelletier/go-toml v1.7.0/go.mod h1:vwGMzjaWMwyfHwgIBhI2YUM4fB6nL6lVAvS1LBMMhTE=
 github.com/percona/percona-backup-mongodb v1.8.1-0.20240902083313-f2cf881c856b h1:NUFwRNs75xaz4mNaGnt5E6jb0eMWIgNOf9mriwrCAeQ=
 github.com/percona/percona-backup-mongodb v1.8.1-0.20240902083313-f2cf881c856b/go.mod h1:KhIlTT4wR2mIkMvDtEFerr9zaADJorL7UThSztzxBaY=
+github.com/percona/percona-backup-mongodb v1.8.1-0.20241002124601-957ac501f939 h1:OggdqSzqe9pO3A4GaRlrLwZXS3zEQ84O4+7Jm9cg74s=
+github.com/percona/percona-backup-mongodb v1.8.1-0.20241002124601-957ac501f939/go.mod h1:KhIlTT4wR2mIkMvDtEFerr9zaADJorL7UThSztzxBaY=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pierrec/lz4 v2.6.1+incompatible h1:9UY3+iC23yxF0UfGaYrGplQ+79Rg+h/q9FV9ix19jjM=
 github.com/pierrec/lz4 v2.6.1+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=

--- a/pkg/controller/perconaservermongodbbackup/perconaservermongodbbackup_controller.go
+++ b/pkg/controller/perconaservermongodbbackup/perconaservermongodbbackup_controller.go
@@ -418,7 +418,7 @@ func (r *ReconcilePerconaServerMongoDBBackup) deleteBackupFinalizer(ctx context.
 		if err != nil {
 			return errors.Wrap(err, "get storage")
 		}
-		if err := pbmBackup.DeleteBackupFiles(getPBMBackupMeta(cr), stg); err != nil {
+		if err := pbmBackup.DeleteBackupFiles(stg, getPBMBackupMeta(cr).Name); err != nil {
 			return errors.Wrap(err, "failed to delete backup files with dummy PBM")
 		}
 		return nil

--- a/pkg/controller/perconaservermongodbrestore/physical.go
+++ b/pkg/controller/perconaservermongodbrestore/physical.go
@@ -242,15 +242,6 @@ func (r *ReconcilePerconaServerMongoDBRestore) reconcilePhysicalRestore(ctx cont
 	case defs.StatusError:
 		status.State = psmdbv1.RestoreStateError
 		status.Error = meta.Err
-	case defs.StatusPartlyDone:
-		status.State = psmdbv1.RestoreStateError
-		var pbmErr string
-		for _, rs := range meta.Replsets {
-			if rs.Status == defs.StatusError {
-				pbmErr += fmt.Sprintf("%s %s;", rs.Name, rs.Error)
-			}
-		}
-		status.Error = pbmErr
 	case defs.StatusRunning:
 		status.State = psmdbv1.RestoreStateRunning
 	case defs.StatusDone:

--- a/pkg/controller/perconaservermongodbrestore/physical.go
+++ b/pkg/controller/perconaservermongodbrestore/physical.go
@@ -47,6 +47,10 @@ func (r *ReconcilePerconaServerMongoDBRestore) reconcilePhysicalRestore(ctx cont
 			return status, errors.Wrapf(err, "get pod/%s", podName)
 		}
 
+		if err := r.waitForPBMOperationsToFinish(ctx, &pod); err != nil {
+			return status, err
+		}
+
 		if err := r.disablePITR(ctx, &pod); err != nil {
 			return status, err
 		}
@@ -135,53 +139,7 @@ func (r *ReconcilePerconaServerMongoDBRestore) reconcilePhysicalRestore(ctx cont
 		}
 
 		time.Sleep(5 * time.Second) // wait until pbm will start resync
-
-		waitErr := errors.New("waiting for PBM operation to finish")
-		err = retry.OnError(wait.Backoff{
-			Duration: 5 * time.Second,
-			Factor:   2.0,
-			Cap:      time.Hour,
-			Steps:    12,
-		}, func(err error) bool { return err == waitErr }, func() error {
-			err := retry.OnError(retry.DefaultBackoff, func(err error) bool { return strings.Contains(err.Error(), "No agent available") }, func() error {
-				stdoutBuf.Reset()
-				stderrBuf.Reset()
-
-				command := []string{"/opt/percona/pbm", "status", "--out", "json"}
-				err := r.clientcmd.Exec(ctx, &pod, "mongod", command, nil, stdoutBuf, stderrBuf, false)
-				if err != nil {
-					log.Error(err, "failed to get PBM status")
-					return err
-				}
-
-				log.V(1).Info("PBM status", "status", stdoutBuf.String())
-
-				return nil
-			})
-			if err != nil {
-				return errors.Wrapf(err, "get PBM status stderr: %s stdout: %s", stderrBuf.String(), stdoutBuf.String())
-			}
-
-			var pbmStatus struct {
-				Running struct {
-					Type string `json:"type,omitempty"`
-					OpId string `json:"opID,omitempty"`
-				} `json:"running"`
-			}
-
-			if err := json.Unmarshal(stdoutBuf.Bytes(), &pbmStatus); err != nil {
-				return errors.Wrap(err, "unmarshal PBM status output")
-			}
-
-			if len(pbmStatus.Running.OpId) == 0 {
-				return nil
-			}
-
-			log.Info("Waiting for another PBM operation to finish", "type", pbmStatus.Running.Type, "opID", pbmStatus.Running.OpId)
-
-			return waitErr
-		})
-		if err != nil {
+		if err := r.waitForPBMOperationsToFinish(ctx, &pod); err != nil {
 			return status, err
 		}
 
@@ -932,4 +890,71 @@ func (r *ReconcilePerconaServerMongoDBRestore) pbmConfigName(cluster *psmdbv1.Pe
 		return "pbm-config"
 	}
 	return cluster.Name + "-pbm-config"
+}
+
+func (r *ReconcilePerconaServerMongoDBRestore) waitForPBMOperationsToFinish(ctx context.Context, pod *corev1.Pod) error {
+	log := logf.FromContext(ctx)
+
+	stdoutBuf := &bytes.Buffer{}
+	stderrBuf := &bytes.Buffer{}
+
+	container := "mongod"
+	pbmBinary := "/opt/percona/pbm"
+	for _, c := range pod.Spec.Containers {
+		if c.Name == "backup-agent" {
+			container = c.Name
+			pbmBinary = "pbm"
+		}
+	}
+
+	waitErr := errors.New("waiting for PBM operation to finish")
+	err := retry.OnError(wait.Backoff{
+		Duration: 5 * time.Second,
+		Factor:   2.0,
+		Cap:      time.Hour,
+		Steps:    12,
+	}, func(err error) bool { return err == waitErr }, func() error {
+		err := retry.OnError(retry.DefaultBackoff, func(err error) bool { return strings.Contains(err.Error(), "No agent available") }, func() error {
+			stdoutBuf.Reset()
+			stderrBuf.Reset()
+
+			command := []string{pbmBinary, "status", "--out", "json"}
+			err := r.clientcmd.Exec(ctx, pod, container, command, nil, stdoutBuf, stderrBuf, false)
+			if err != nil {
+				log.Error(err, "failed to get PBM status")
+				return err
+			}
+
+			log.V(1).Info("PBM status", "status", stdoutBuf.String())
+
+			return nil
+		})
+		if err != nil {
+			return errors.Wrapf(err, "get PBM status stderr: %s stdout: %s", stderrBuf.String(), stdoutBuf.String())
+		}
+
+		var pbmStatus struct {
+			Running struct {
+				Type string `json:"type,omitempty"`
+				OpId string `json:"opID,omitempty"`
+			} `json:"running"`
+		}
+
+		if err := json.Unmarshal(stdoutBuf.Bytes(), &pbmStatus); err != nil {
+			return errors.Wrap(err, "unmarshal PBM status output")
+		}
+
+		if len(pbmStatus.Running.OpId) == 0 {
+			return nil
+		}
+
+		log.Info("Waiting for another PBM operation to finish", "type", pbmStatus.Running.Type, "opID", pbmStatus.Running.OpId)
+
+		return waitErr
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/psmdb/backup/pbm.go
+++ b/pkg/psmdb/backup/pbm.go
@@ -121,7 +121,7 @@ func getMongoUri(ctx context.Context, k8sclient client.Client, cr *api.PerconaSe
 
 	tlsKey := sslSecret.Data["tls.key"]
 	tlsCert := sslSecret.Data["tls.crt"]
-	tlsPemFile := fmt.Sprintf("/tmp/%s-%s-tls.pem", cr.Namespace, cr.Name )
+	tlsPemFile := fmt.Sprintf("/tmp/%s-%s-tls.pem", cr.Namespace, cr.Name)
 	f, err := os.OpenFile(tlsPemFile, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0o600)
 	if err != nil {
 		return "", errors.Wrapf(err, "open %s", tlsPemFile)
@@ -132,7 +132,7 @@ func getMongoUri(ctx context.Context, k8sclient client.Client, cr *api.PerconaSe
 	}
 
 	caCert := sslSecret.Data["ca.crt"]
-	caCertFile := fmt.Sprintf("/tmp/%s-%s-ca.crt", cr.Namespace, cr.Name )
+	caCertFile := fmt.Sprintf("/tmp/%s-%s-ca.crt", cr.Namespace, cr.Name)
 	f, err = os.OpenFile(caCertFile, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0o600)
 	if err != nil {
 		return "", errors.Wrapf(err, "open %s", caCertFile)
@@ -391,23 +391,23 @@ func GetPBMConfig(ctx context.Context, k8sclient client.Client, cluster *api.Per
 func (b *pbmC) ValidateBackup(ctx context.Context, bcp *psmdbv1.PerconaServerMongoDBBackup, cfg config.Config) error {
 	e := b.Logger().NewEvent(string(ctrl.CmdRestore), "", "", primitive.Timestamp{})
 	backupName := bcp.Status.PBMname
-	s, err := util.StorageFromConfig(&cfg.Storage, e)
+	stg, err := util.StorageFromConfig(&cfg.Storage, e)
 	if err != nil {
 		return errors.Wrap(err, "storage from config")
 	}
-	m, err := restore.GetMetaFromStore(s, backupName)
+	m, err := restore.GetMetaFromStore(stg, backupName)
 	if err != nil {
 		return errors.Wrap(err, "get backup metadata from storage")
 	}
 	switch bcp.Status.Type {
 	case "", defs.LogicalBackup:
-		if err := backup.CheckBackupFiles(ctx, m, s); err != nil {
+		if err := backup.CheckBackupFiles(ctx, stg, m.Name); err != nil {
 			return errors.Wrap(err, "check backup files")
 		}
 	case defs.PhysicalBackup:
 		for _, rs := range m.Replsets {
 			f := path.Join(m.Name, rs.Name)
-			files, err := s.List(f, "")
+			files, err := stg.List(f, "")
 			if err != nil {
 				return errors.Wrapf(err, "failed to list backup files at %s", f)
 			}


### PR DESCRIPTION
[![K8SPSMDB-1177](https://badgen.net/badge/JIRA/K8SPSMDB-1177/green)](https://jira.percona.com/browse/K8SPSMDB-1177) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
Bump PBM to 2.7.0.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?
- [x] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported MongoDB version?
- [x] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-1177]: https://perconadev.atlassian.net/browse/K8SPSMDB-1177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ