### PR TITLE
K8SPSMDB-739: fix switching `servicePerPod`

### DIFF
--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -224,7 +224,6 @@ spec:
 #      labels:
 #        rack: rack-22
 #      internalTrafficPolicy: Local
-#      externalTrafficPolicy: Local
     resources:
       limits:
         cpu: "300m"
@@ -437,7 +436,6 @@ spec:
 #        labels:
 #          rack: rack-22
 #        internalTrafficPolicy: Local
-#        externalTrafficPolicy: Local
       resources:
         limits:
           cpu: "300m"
@@ -549,7 +547,6 @@ spec:
 #          rack: rack-22
 #        nodePort: 32017
 #        internalTrafficPolicy: Local
-#        externalTrafficPolicy: Local
 #      hostAliases:
 #      - ip: "10.10.0.2"
 #        hostnames:

--- a/pkg/controller/perconaservermongodb/service.go
+++ b/pkg/controller/perconaservermongodb/service.go
@@ -16,32 +16,94 @@ import (
 	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb"
 )
 
-func (r *ReconcilePerconaServerMongoDB) ensureExternalServices(ctx context.Context, cr *api.PerconaServerMongoDB, replset *api.ReplsetSpec, podList *corev1.PodList) ([]corev1.Service, error) {
-	services := make([]corev1.Service, 0)
+func (r *ReconcilePerconaServerMongoDB) reconcileServices(ctx context.Context, cr *api.PerconaServerMongoDB, repls []*api.ReplsetSpec) error {
+	if err := r.reconcileReplsetServices(ctx, cr, repls); err != nil {
+		return errors.Wrap(err, "reconcile mongos services")
+	}
 
+	if err := r.reconcileMongosSvc(ctx, cr); err != nil {
+		return errors.Wrap(err, "reconcile mongos services")
+	}
+	return nil
+}
+
+func (r *ReconcilePerconaServerMongoDB) reconcileReplsetServices(ctx context.Context, cr *api.PerconaServerMongoDB, repls []*api.ReplsetSpec) error {
+	for _, rs := range repls {
+		// Create headless service
+		service := psmdb.Service(cr, rs)
+		if err := setControllerReference(cr, service, r.scheme); err != nil {
+			return errors.Wrapf(err, "set owner ref for service %s", service.Name)
+		}
+		if err := r.createOrUpdateSvc(ctx, cr, service, true); err != nil {
+			return errors.Wrapf(err, "create or update service for replset %s", rs.Name)
+		}
+		if !rs.Expose.Enabled {
+			continue
+		}
+		// Create exposed services
+		pods, err := psmdb.GetRSPods(ctx, r.client, cr, rs.Name)
+		if err != nil {
+			return errors.Wrapf(err, "get pods list for replset %s", rs.Name)
+		}
+		if err := r.ensureExternalServices(ctx, cr, rs, &pods); err != nil {
+			return errors.Wrap(err, "ensure external services")
+		}
+
+		if err := r.removeOutdatedServices(ctx, cr, rs); err != nil {
+			return errors.Wrapf(err, "failed to remove old services of replset %s", rs.Name)
+		}
+	}
+	return nil
+}
+
+func (r *ReconcilePerconaServerMongoDB) reconcileMongosSvc(ctx context.Context, cr *api.PerconaServerMongoDB) error {
+	if !cr.Spec.Sharding.Enabled {
+		return nil
+	}
+
+	if cr.Spec.Sharding.Mongos.Expose.ServicePerPod {
+		for i := 0; i < int(cr.Spec.Sharding.Mongos.Size); i++ {
+			err := r.createOrUpdateMongosSvc(ctx, cr, cr.Name+"-mongos-"+strconv.Itoa(i))
+			if err != nil {
+				return errors.Wrap(err, "create or update mongos service")
+			}
+		}
+	} else {
+		err := r.createOrUpdateMongosSvc(ctx, cr, cr.Name+"-mongos")
+		if err != nil {
+			return errors.Wrap(err, "create or update mongos service")
+		}
+	}
+
+	err := r.removeOutdatedMongosSvc(ctx, cr)
+	if err != nil {
+		return errors.Wrap(err, "remove outdated mongos services")
+	}
+	return nil
+}
+
+func (r *ReconcilePerconaServerMongoDB) ensureExternalServices(ctx context.Context, cr *api.PerconaServerMongoDB, replset *api.ReplsetSpec, podList *corev1.PodList) error {
 	for _, pod := range podList.Items {
 		service := psmdb.ExternalService(cr, replset, pod.Name)
 		err := setControllerReference(cr, service, r.scheme)
 		if err != nil {
-			return nil, errors.Wrapf(err, "set owner ref for Service %s", service.Name)
+			return errors.Wrapf(err, "set owner ref for Service %s", service.Name)
 		}
 
 		err = r.createOrUpdateSvc(ctx, cr, service, replset.Expose.SaveOldMeta())
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to create external service for replset %s", replset.Name)
+			return errors.Wrapf(err, "failed to create external service for replset %s", replset.Name)
 		}
 
 		if cr.Spec.MultiCluster.Enabled {
 			err = r.exportService(ctx, cr, service)
 			if err != nil {
-				return nil, errors.Wrapf(err, "failed to export service %s", service.Name)
+				return errors.Wrapf(err, "failed to export service %s", service.Name)
 			}
 		}
-
-		services = append(services, *service)
 	}
 
-	return services, nil
+	return nil
 }
 
 func (r *ReconcilePerconaServerMongoDB) exportService(ctx context.Context, cr *api.PerconaServerMongoDB, svc *corev1.Service) error {
@@ -165,5 +227,51 @@ func (r *ReconcilePerconaServerMongoDB) removeOutdatedServices(ctx context.Conte
 		}
 	}
 
+	return nil
+}
+
+func (r *ReconcilePerconaServerMongoDB) removeOutdatedMongosSvc(ctx context.Context, cr *api.PerconaServerMongoDB) error {
+	if cr.Spec.Pause && cr.Spec.Sharding.Enabled {
+		return nil
+	}
+
+	svcNames := make(map[string]struct{}, cr.Spec.Sharding.Mongos.Size)
+	if cr.Spec.Sharding.Mongos.Expose.ServicePerPod {
+		for i := 0; i < int(cr.Spec.Sharding.Mongos.Size); i++ {
+			svcNames[cr.Name+"-mongos-"+strconv.Itoa(i)] = struct{}{}
+		}
+	} else {
+		svcNames[cr.Name+"-mongos"] = struct{}{}
+	}
+
+	svcList, err := psmdb.GetMongosServices(ctx, r.client, cr)
+	if err != nil {
+		return errors.Wrap(err, "failed to list mongos services")
+	}
+
+	for _, service := range svcList.Items {
+		if _, ok := svcNames[service.Name]; !ok {
+			err = r.client.Delete(ctx, &service)
+			if err != nil {
+				return errors.Wrapf(err, "failed to delete service %s", service.Name)
+			}
+		}
+	}
+	return nil
+}
+
+func (r *ReconcilePerconaServerMongoDB) createOrUpdateMongosSvc(ctx context.Context, cr *api.PerconaServerMongoDB, name string) error {
+	svc := psmdb.MongosService(cr, name)
+	err := setControllerReference(cr, &svc, r.scheme)
+	if err != nil {
+		return errors.Wrapf(err, "set owner ref for service %s", svc.Name)
+	}
+
+	svc.Spec = psmdb.MongosServiceSpec(cr, name)
+
+	err = r.createOrUpdateSvc(ctx, cr, &svc, cr.Spec.Sharding.Mongos.Expose.SaveOldMeta())
+	if err != nil {
+		return errors.Wrap(err, "create or update mongos service")
+	}
 	return nil
 }

--- a/pkg/controller/perconaservermongodbrestore/physical.go
+++ b/pkg/controller/perconaservermongodbrestore/physical.go
@@ -28,6 +28,14 @@ import (
 	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb/backup"
 )
 
+var anotherOpBackoff = wait.Backoff{
+	Steps:    13,
+	Duration: time.Second,
+	Factor:   2.0,
+	Jitter:   0.1,
+	Cap:      15 * time.Minute,
+}
+
 // reconcilePhysicalRestore performs a physical restore of a Percona Server for MongoDB from a backup.
 func (r *ReconcilePerconaServerMongoDBRestore) reconcilePhysicalRestore(ctx context.Context, cr *psmdbv1.PerconaServerMongoDBRestore, bcp *psmdbv1.PerconaServerMongoDBBackup, cluster *psmdbv1.PerconaServerMongoDB) (psmdbv1.PerconaServerMongoDBRestoreStatus, error) {
 	log := logf.FromContext(ctx)
@@ -47,8 +55,12 @@ func (r *ReconcilePerconaServerMongoDBRestore) reconcilePhysicalRestore(ctx cont
 			return status, errors.Wrapf(err, "get pod/%s", podName)
 		}
 
-		if err := r.disablePITR(ctx, &pod); err != nil {
-			return status, err
+		if err := retry.OnError(anotherOpBackoff, func(err error) bool {
+			return strings.Contains(err.Error(), "another operation")
+		}, func() error {
+			return r.disablePITR(ctx, &pod)
+		}); err != nil {
+			return status, errors.Wrap(err, "disable pitr")
 		}
 
 		if cr.Spec.PITR != nil {
@@ -192,14 +204,7 @@ func (r *ReconcilePerconaServerMongoDBRestore) reconcilePhysicalRestore(ctx cont
 			restoreCommand = []string{"/opt/percona/pbm", "restore", bcp.Status.PBMname, "--out", "json"}
 		}
 
-		backoff := wait.Backoff{
-			Steps:    5,
-			Duration: 500 * time.Millisecond,
-			Factor:   5.0,
-			Jitter:   0.1,
-		}
-
-		err = retry.OnError(backoff, func(err error) bool {
+		err = retry.OnError(anotherOpBackoff, func(err error) bool {
 			return strings.Contains(err.Error(), "another operation")
 		}, func() error {
 			log.Info("Starting restore", "command", restoreCommand, "pod", pod.Name)


### PR DESCRIPTION
[![K8SPSMDB-739](https://badgen.net/badge/JIRA/K8SPSMDB-739/green)](https://jira.percona.com/browse/K8SPSMDB-739) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://perconadev.atlassian.net/browse/K8SPSMDB-739

**CHANGE DESCRIPTION**
---
**Problem:**
*Cluster goes into error state when `servicePerPod` is enabled. New services are not created. The following error is displayed in the operator: `failed to get mongos connection: ping mongo: server selection error: server selection timeout, current topology: { Type: Unknown, Servers: [{ Addr: , Type: Unknown, Last error: dial tcp: missing address }, { Addr: , Type: Unknown }, { Addr: , Type: Unknown }, ] }`*

**Cause:**
_This problem appeared after merging https://github.com/percona/percona-server-mongodb-operator/pull/1651. To communicate with mongos in `reconcileCluster` method, operator uses a `GetMongosAddrs` function to get the hostnames to use for connections. If `servicePerPod` is enabled, it returns the hostnames of services that don't exist yet. Currently we try to create services after the `reconcileCluster` method call._

_Before the https://github.com/percona/percona-server-mongodb-operator/pull/1651, we just threw an error log message from `reconcileCluster` and went on to create mongos services._


**Solution:**
*Create required services before communicating with mongos.*

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported MongoDB version?
- [x] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-739]: https://perconadev.atlassian.net/browse/K8SPSMDB-739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ