### PR TITLE
K8SPSMDB-739: add test for mongos servicePerPod

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -448,6 +448,11 @@ EOF
                         clusterRunner('cluster9')
                     }
                 }
+                stage('cluster10') {
+                    steps {
+                        clusterRunner('cluster10')
+                    }
+                }
             }
         }
     }

--- a/e2e-tests/balancer/run
+++ b/e2e-tests/balancer/run
@@ -39,7 +39,7 @@ check_service() {
 		done
 	elif [ $state = "removed" ]; then
 		echo "check that $svc_name was removed"
-		if [[ -z $(kubectl get service/$svc_name -o 'jsonpath={.spec.type}' 2>&1 | grep NotFound) ]] ; then
+		if [[ -z $(kubectl get service/$svc_name -o 'jsonpath={.spec.type}' 2>&1 | grep NotFound) ]]; then
 			echo "$svc_name was not removed."
 			exit 1
         else

--- a/e2e-tests/balancer/run
+++ b/e2e-tests/balancer/run
@@ -21,6 +21,35 @@ check_balancer() {
 	fi
 }
 
+check_service() {
+	state=$1
+    svc_name=$2
+	if [ $state = "present" ]; then
+		echo "check that $svc_name was created"
+		local timeout=0
+		until kubectl_bin get service/$svc_name -o 'jsonpath={.spec.type}' 2>&1 | grep -vq NotFound; do
+			sleep 1
+			timeout=$((timeout + 1))
+			echo -n '.'
+			if [[ ${timeout} -gt 900 ]]; then
+				echo
+				echo "Waiting timeout has been reached. Service $svc_name is not present. Exiting..."
+				exit 1
+			fi
+		done
+	elif [ $state = "removed" ]; then
+		echo "check that $svc_name was removed"
+		if [[ -z $(kubectl get service/$svc_name -o 'jsonpath={.spec.type}' 2>&1 | grep NotFound) ]] ; then
+			echo "$svc_name was not removed."
+			exit 1
+        else
+            echo "service $svc_name was removed"
+		fi
+	else
+		echo "unknown state $state"
+	fi
+}
+
 main() {
 	create_infra "$namespace"
 
@@ -56,6 +85,15 @@ main() {
 	kubectl patch psmdb some-name --type=merge -p '{"spec":{"sharding":{"balancer":{"enabled":true}}}}'
 	sleep 20
 	check_balancer "full"
+
+# Add check that servicePerPod creates 3 services for the running cluster
+	desc 'enabling servicePerPod for mongos'
+	kubectl patch psmdb some-name --type=merge -p '{"spec":{"sharding":{"mongos":{"expose":{"servicePerPod":true}}}}}'
+	# wait_for_running $cluster-mongos 3
+	check_service present $cluster-mongos-0
+	check_service present $cluster-mongos-1
+	check_service present $cluster-mongos-2
+	check_service removed $cluster-mongos
 
 	destroy "$namespace"
 }

--- a/e2e-tests/balancer/run
+++ b/e2e-tests/balancer/run
@@ -23,7 +23,7 @@ check_balancer() {
 
 check_service() {
 	state=$1
-    svc_name=$2
+	svc_name=$2
 	if [ $state = "present" ]; then
 		echo "check that $svc_name was created"
 		local timeout=0

--- a/e2e-tests/balancer/run
+++ b/e2e-tests/balancer/run
@@ -25,25 +25,25 @@ check_service() {
 	state=$1
 	svc_name=$2
 	if [ $state = "present" ]; then
-		echo "check that $svc_name was created"
+		echo -n "check that $svc_name was created"
 		local timeout=0
 		until kubectl_bin get service/$svc_name -o 'jsonpath={.spec.type}' 2>&1 | grep -vq NotFound; do
 			sleep 1
 			timeout=$((timeout + 1))
 			echo -n '.'
 			if [[ ${timeout} -gt 900 ]]; then
-				echo
 				echo "Waiting timeout has been reached. Service $svc_name is not present. Exiting..."
 				exit 1
 			fi
 		done
+		echo ".OK"
 	elif [ $state = "removed" ]; then
-		echo "check that $svc_name was removed"
-		if [[ -z $(kubectl get service/$svc_name -o 'jsonpath={.spec.type}' 2>&1 | grep NotFound) ]]; then
+		echo -n "check that $svc_name was removed"
+		if [[ -z $(kubectl_bin get service/$svc_name -o 'jsonpath={.spec.type}' 2>&1 | grep NotFound) ]]; then
 			echo "$svc_name was not removed."
 			exit 1
 		else
-			echo "service $svc_name was removed"
+			echo ".OK"
 		fi
 	else
 		echo "unknown state $state"

--- a/e2e-tests/balancer/run
+++ b/e2e-tests/balancer/run
@@ -86,7 +86,7 @@ main() {
 	sleep 20
 	check_balancer "full"
 
-# Add check that servicePerPod creates 3 services for the running cluster
+	# Add check that servicePerPod creates 3 services for the running cluster
 	desc 'enabling servicePerPod for mongos'
 	kubectl patch psmdb some-name --type=merge -p '{"spec":{"sharding":{"mongos":{"expose":{"servicePerPod":true}}}}}'
 	wait_for_running $cluster-mongos 3

--- a/e2e-tests/balancer/run
+++ b/e2e-tests/balancer/run
@@ -42,8 +42,8 @@ check_service() {
 		if [[ -z $(kubectl get service/$svc_name -o 'jsonpath={.spec.type}' 2>&1 | grep NotFound) ]]; then
 			echo "$svc_name was not removed."
 			exit 1
-        else
-            echo "service $svc_name was removed"
+		else
+			echo "service $svc_name was removed"
 		fi
 	else
 		echo "unknown state $state"

--- a/e2e-tests/balancer/run
+++ b/e2e-tests/balancer/run
@@ -89,7 +89,7 @@ main() {
 # Add check that servicePerPod creates 3 services for the running cluster
 	desc 'enabling servicePerPod for mongos'
 	kubectl patch psmdb some-name --type=merge -p '{"spec":{"sharding":{"mongos":{"expose":{"servicePerPod":true}}}}}'
-	# wait_for_running $cluster-mongos 3
+	wait_for_running $cluster-mongos 3
 	check_service present $cluster-mongos-0
 	check_service present $cluster-mongos-1
 	check_service present $cluster-mongos-2


### PR DESCRIPTION
[![K8SPSMDB-739](https://badgen.net/badge/JIRA/K8SPSMDB-739/green)](https://jira.percona.com/browse/K8SPSMDB-739) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
We do not have any test that checks that servicePerPOD for mongos works

**Solution:**
Add test

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-739]: https://perconadev.atlassian.net/browse/K8SPSMDB-739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ