### PR TITLE
K8SPSMDB-1146: Fix roles comparison

### DIFF
--- a/pkg/controller/perconaservermongodb/custom_users.go
+++ b/pkg/controller/perconaservermongodb/custom_users.go
@@ -76,6 +76,11 @@ func (r *ReconcilePerconaServerMongoDB) reconcileCustomUsers(ctx context.Context
 			continue
 		}
 
+		if len(user.Roles) == 0 {
+			log.Error(nil, "user must have at least one role", "user", user.Name)
+			continue
+		}
+
 		if user.DB == "" {
 			user.DB = "admin"
 		}

--- a/pkg/controller/perconaservermongodb/custom_users.go
+++ b/pkg/controller/perconaservermongodb/custom_users.go
@@ -13,7 +13,6 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
@@ -165,7 +164,7 @@ func handleRoles(ctx context.Context, cr *api.PerconaServerMongoDB, cli mongo.Cl
 
 func rolesChanged(r1, r2 *mongo.Role) bool {
 
-	log := log.FromContext(context.TODO())
+	log := logf.FromContext(context.TODO())
 
 	log.Info("AAAAAAAAAAAAAAAAA CR ROLEEE", "role", r1)
 	log.Info("AAAAAAAAAAAAAAAAA DB ROLEEE", "role", r2)
@@ -184,6 +183,8 @@ func rolesChanged(r1, r2 *mongo.Role) bool {
 		log.Info("AAAAAAAAAAAAAAABBBBBBBBBBB")
 		log.Info("AAAAAAAAAAAAAAABBBBBBBBBBB CR PRIV", "role", r1.Privileges)
 		log.Info("AAAAAAAAAAAAAAABBBBBBBBBBB DB PRIV", "role", r2.Privileges)
+
+		log.Info("AAAAAAAAAAAAAAABBBBBBBBBBB", "diff", cmp.Diff(r1.Privileges, r2.Privileges))
 		return true
 	}
 

--- a/pkg/controller/perconaservermongodb/custom_users.go
+++ b/pkg/controller/perconaservermongodb/custom_users.go
@@ -13,6 +13,7 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
@@ -163,6 +164,12 @@ func handleRoles(ctx context.Context, cr *api.PerconaServerMongoDB, cli mongo.Cl
 }
 
 func rolesChanged(r1, r2 *mongo.Role) bool {
+
+	log := log.FromContext(context.TODO())
+
+	log.Info("AAAAAAAAAAAAAAAAA CR ROLEEE", "role", r1)
+	log.Info("AAAAAAAAAAAAAAAAA DB ROLEEE", "role", r2)
+
 	if privilegesChanged(r1.Privileges, r2.Privileges) {
 		return true
 	}

--- a/pkg/controller/perconaservermongodb/custom_users.go
+++ b/pkg/controller/perconaservermongodb/custom_users.go
@@ -245,7 +245,7 @@ func toMongoRoleModel(role api.Role) (*mongo.Role, error) {
 		}
 
 		if p.Resource.Cluster != nil {
-			rp.Resource["cluster"] = p.Resource.Cluster
+			rp.Resource["cluster"] = &p.Resource.Cluster
 		} else {
 			rp.Resource["db"] = p.Resource.DB
 			rp.Resource["collection"] = p.Resource.Collection

--- a/pkg/controller/perconaservermongodb/custom_users.go
+++ b/pkg/controller/perconaservermongodb/custom_users.go
@@ -170,17 +170,37 @@ func rolesChanged(r1, r2 *mongo.Role) bool {
 	log.Info("AAAAAAAAAAAAAAAAA CR ROLEEE", "role", r1)
 	log.Info("AAAAAAAAAAAAAAAAA DB ROLEEE", "role", r2)
 
-	if privilegesChanged(r1.Privileges, r2.Privileges) {
+
+	opts := cmp.Options{
+		cmpopts.SortSlices(func(x, y string) bool { return x < y }),
+		cmpopts.EquateEmpty(),
+	}
+
+	if !cmp.Equal(r1.Privileges, r2.Privileges, opts) {
 		log.Info("AAAAAAAAAAAAAAA")
 		return true
 	}
+
+	if !cmp.Equal(r1.Privileges, r2.Privileges, opts) {
+		log.Info("AAAAAAAAAAAAAAABBBBBBBBBBB")
+		return true
+	}
+
+
+	// if privilegesChanged(r1.Privileges, r2.Privileges) {
+	// 	log.Info("AAAAAAAAAAAAAAA")
+	// 	return true
+	// }
 
 	if len(r1.AuthenticationRestrictions) != len(r2.AuthenticationRestrictions) {
 		log.Info("BBBBBBBBBBBBBBBBBBBB")
 		return true
 	}
 
-	opts := cmpopts.SortSlices(func(x, y string) bool { return x < y })
+	// opts := cmp.Options{
+	// 	cmpopts.SortSlices(func(x, y string) bool { return x < y }),
+	// 	cmpopts.EquateEmpty(),
+	// }
 
 	if !cmp.Equal(r1.AuthenticationRestrictions, r2.AuthenticationRestrictions, opts) {
 		log.Info("CCCCCCCCCCCCCCCCCCCCCC")
@@ -191,7 +211,8 @@ func rolesChanged(r1, r2 *mongo.Role) bool {
 		log.Info("DDDDDDDDDDDDDDDDDDD")
 		return true
 	}
-	if !cmp.Equal(r1.Roles, r2.Roles) {
+
+	if !cmp.Equal(r1.Roles, r2.Roles, opts) {
 		log.Info("EEEEEEEEEEEEEEEEEEEE")
 		return true
 	}

--- a/pkg/controller/perconaservermongodb/custom_users.go
+++ b/pkg/controller/perconaservermongodb/custom_users.go
@@ -6,6 +6,8 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -169,14 +171,16 @@ func rolesChanged(r1, r2 *mongo.Role) bool {
 		return true
 	}
 
-	if !reflect.DeepEqual(r1.AuthenticationRestrictions, r2.AuthenticationRestrictions) {
+	opts := cmpopts.SortSlices(func(x, y string) bool { return x < y })
+
+	if !cmp.Equal(r1.AuthenticationRestrictions, r2.AuthenticationRestrictions, opts) {
 		return true
 	}
 
 	if len(r1.Roles) != len(r2.Roles) {
 		return true
 	}
-	if !reflect.DeepEqual(r1.Roles, r2.Roles) {
+	if !cmp.Equal(r1.Roles, r2.Roles) {
 		return true
 	}
 

--- a/pkg/controller/perconaservermongodb/custom_users.go
+++ b/pkg/controller/perconaservermongodb/custom_users.go
@@ -170,7 +170,6 @@ func rolesChanged(r1, r2 *mongo.Role) bool {
 	log.Info("AAAAAAAAAAAAAAAAA CR ROLEEE", "role", r1)
 	log.Info("AAAAAAAAAAAAAAAAA DB ROLEEE", "role", r2)
 
-
 	opts := cmp.Options{
 		cmpopts.SortSlices(func(x, y string) bool { return x < y }),
 		cmpopts.EquateEmpty(),
@@ -183,9 +182,10 @@ func rolesChanged(r1, r2 *mongo.Role) bool {
 
 	if !cmp.Equal(r1.Privileges, r2.Privileges, opts) {
 		log.Info("AAAAAAAAAAAAAAABBBBBBBBBBB")
+		log.Info("AAAAAAAAAAAAAAABBBBBBBBBBB CR PRIV", "role", r1.Privileges)
+		log.Info("AAAAAAAAAAAAAAABBBBBBBBBBB DB PRIV", "role", r2.Privileges)
 		return true
 	}
-
 
 	// if privilegesChanged(r1.Privileges, r2.Privileges) {
 	// 	log.Info("AAAAAAAAAAAAAAA")

--- a/pkg/controller/perconaservermongodb/custom_users.go
+++ b/pkg/controller/perconaservermongodb/custom_users.go
@@ -163,58 +163,28 @@ func handleRoles(ctx context.Context, cr *api.PerconaServerMongoDB, cli mongo.Cl
 }
 
 func rolesChanged(r1, r2 *mongo.Role) bool {
-
-	log := logf.FromContext(context.TODO())
-
-	log.Info("AAAAAAAAAAAAAAAAA CR ROLEEE", "role", r1)
-	log.Info("AAAAAAAAAAAAAAAAA DB ROLEEE", "role", r2)
+	if len(r1.Privileges) != len(r2.Privileges) {
+		return true
+	}
+	if len(r1.AuthenticationRestrictions) != len(r2.AuthenticationRestrictions) {
+		return true
+	}
+	if len(r1.Roles) != len(r2.Roles) {
+		return true
+	}
 
 	opts := cmp.Options{
 		cmpopts.SortSlices(func(x, y string) bool { return x < y }),
 		cmpopts.EquateEmpty(),
 	}
 
-	if len(r1.Privileges) != len(r2.Privileges) {
-		log.Info("AAAAAAAAAAAAAAA")
-		return true
-	}
-
 	if !cmp.Equal(r1.Privileges, r2.Privileges, opts) {
-		log.Info("AAAAAAAAAAAAAAABBBBBBBBBBB")
-		log.Info("AAAAAAAAAAAAAAABBBBBBBBBBB CR PRIV", "role", r1.Privileges)
-		log.Info("AAAAAAAAAAAAAAABBBBBBBBBBB DB PRIV", "role", r2.Privileges)
-
-		log.Info("AAAAAAAAAAAAAAABBBBBBBBBBB", "diff", cmp.Diff(r1.Privileges, r2.Privileges))
 		return true
 	}
-
-	// if privilegesChanged(r1.Privileges, r2.Privileges) {
-	// 	log.Info("AAAAAAAAAAAAAAA")
-	// 	return true
-	// }
-
-	if len(r1.AuthenticationRestrictions) != len(r2.AuthenticationRestrictions) {
-		log.Info("BBBBBBBBBBBBBBBBBBBB")
-		return true
-	}
-
-	// opts := cmp.Options{
-	// 	cmpopts.SortSlices(func(x, y string) bool { return x < y }),
-	// 	cmpopts.EquateEmpty(),
-	// }
-
 	if !cmp.Equal(r1.AuthenticationRestrictions, r2.AuthenticationRestrictions, opts) {
-		log.Info("CCCCCCCCCCCCCCCCCCCCCC")
 		return true
 	}
-
-	if len(r1.Roles) != len(r2.Roles) {
-		log.Info("DDDDDDDDDDDDDDDDDDD")
-		return true
-	}
-
 	if !cmp.Equal(r1.Roles, r2.Roles, opts) {
-		log.Info("EEEEEEEEEEEEEEEEEEEE")
 		return true
 	}
 

--- a/pkg/controller/perconaservermongodb/custom_users.go
+++ b/pkg/controller/perconaservermongodb/custom_users.go
@@ -171,23 +171,28 @@ func rolesChanged(r1, r2 *mongo.Role) bool {
 	log.Info("AAAAAAAAAAAAAAAAA DB ROLEEE", "role", r2)
 
 	if privilegesChanged(r1.Privileges, r2.Privileges) {
+		log.Info("AAAAAAAAAAAAAAA")
 		return true
 	}
 
 	if len(r1.AuthenticationRestrictions) != len(r2.AuthenticationRestrictions) {
+		log.Info("BBBBBBBBBBBBBBBBBBBB")
 		return true
 	}
 
 	opts := cmpopts.SortSlices(func(x, y string) bool { return x < y })
 
 	if !cmp.Equal(r1.AuthenticationRestrictions, r2.AuthenticationRestrictions, opts) {
+		log.Info("CCCCCCCCCCCCCCCCCCCCCC")
 		return true
 	}
 
 	if len(r1.Roles) != len(r2.Roles) {
+		log.Info("DDDDDDDDDDDDDDDDDDD")
 		return true
 	}
 	if !cmp.Equal(r1.Roles, r2.Roles) {
+		log.Info("EEEEEEEEEEEEEEEEEEEE")
 		return true
 	}
 

--- a/pkg/controller/perconaservermongodb/custom_users.go
+++ b/pkg/controller/perconaservermongodb/custom_users.go
@@ -176,7 +176,7 @@ func rolesChanged(r1, r2 *mongo.Role) bool {
 		cmpopts.EquateEmpty(),
 	}
 
-	if !cmp.Equal(r1.Privileges, r2.Privileges, opts) {
+	if len(r1.Privileges) != len(r2.Privileges) {
 		log.Info("AAAAAAAAAAAAAAA")
 		return true
 	}

--- a/pkg/controller/perconaservermongodb/custom_users.go
+++ b/pkg/controller/perconaservermongodb/custom_users.go
@@ -245,7 +245,7 @@ func toMongoRoleModel(role api.Role) (*mongo.Role, error) {
 		}
 
 		if p.Resource.Cluster != nil {
-			rp.Resource["cluster"] = &p.Resource.Cluster
+			rp.Resource["cluster"] = *p.Resource.Cluster
 		} else {
 			rp.Resource["db"] = p.Resource.DB
 			rp.Resource["collection"] = p.Resource.Collection

--- a/pkg/controller/perconaservermongodb/custom_users_test.go
+++ b/pkg/controller/perconaservermongodb/custom_users_test.go
@@ -6,6 +6,88 @@ import (
 	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb/mongo"
 )
 
+func TestRolesChangedUUUU(t *testing.T) {
+	r2 := &mongo.Role{
+		Privileges: []mongo.RolePrivilege{
+			{
+				Resource: map[string]interface{}{
+					"db":         "test",
+					"collection": "test",
+				},
+				Actions: []string{"find"},
+			},
+			{
+				Resource: map[string]interface{}{
+					"db":         "test-two",
+					"collection": "test-two",
+				},
+				Actions: []string{"find", "insert", "remove", "update"},
+			},
+		},
+		AuthenticationRestrictions: nil,
+		Roles: []mongo.InheritenceRole{
+			{
+				Role: "read",
+				DB:   "test",
+			},
+			{
+				Role: "insert",
+				DB:   "test",
+			},
+		},
+	}
+
+	tests := []struct {
+		name string
+		r1   *mongo.Role
+		r2   *mongo.Role
+		want bool
+	}{
+		{
+			name: "Roles the same AAAAAAAAAAAAAAA",
+			want: false,
+			r1: &mongo.Role{
+				Privileges: []mongo.RolePrivilege{
+					{
+						Resource: map[string]interface{}{
+							"collection": "test",
+							"db":         "test",
+						},
+						Actions: []string{"find"},
+					},
+					{
+						Resource: map[string]interface{}{
+							"db":         "test-two",
+							"collection": "test-two",
+						},
+						Actions: []string{"find", "update", "insert", "remove"},
+					},
+				},
+				AuthenticationRestrictions: nil,
+				Roles: []mongo.InheritenceRole{
+					{
+						Role: "read",
+						DB:   "test",
+					},
+					{
+						Role: "insert",
+						DB:   "test",
+					},
+				},
+			},
+			r2: r2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := rolesChanged(tt.r1, tt.r2); got != tt.want {
+				t.Errorf("rolesChanged() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRolesChanged(t *testing.T) {
 	r2 := &mongo.Role{
 		Privileges: []mongo.RolePrivilege{
@@ -198,7 +280,7 @@ func TestRolesChanged(t *testing.T) {
 							"collection": "test-two",
 							"db":         "test-two",
 						},
-						Actions: []string{"insert","find",},
+						Actions: []string{"insert", "find"},
 					},
 				},
 				AuthenticationRestrictions: []mongo.RoleAuthenticationRestriction{

--- a/pkg/controller/perconaservermongodb/custom_users_test.go
+++ b/pkg/controller/perconaservermongodb/custom_users_test.go
@@ -7,25 +7,6 @@ import (
 )
 
 func TestRolesChangedUUUU(t *testing.T) {
-	r2 := &mongo.Role{
-		Privileges: []mongo.RolePrivilege{
-			{
-				Resource: map[string]interface{}{
-					"cluster": true,
-				},
-				Actions: []string{"addShard"},
-			},
-			{
-				Resource: map[string]interface{}{
-					"db":         "config",
-					"collection": "",
-				},
-				Actions: []string{"find", "update", "insert", "remove"},
-			},
-		},
-		AuthenticationRestrictions: nil,
-		Roles:                      []mongo.InheritenceRole{},
-	}
 
 	tests := []struct {
 		name string
@@ -34,7 +15,7 @@ func TestRolesChangedUUUU(t *testing.T) {
 		want bool
 	}{
 		{
-			name: "Roles the same AAAAAAAAAAAAAAA",
+			name: "Roles the same",
 			want: false,
 			r1: &mongo.Role{
 				Privileges: []mongo.RolePrivilege{
@@ -55,7 +36,25 @@ func TestRolesChangedUUUU(t *testing.T) {
 				AuthenticationRestrictions: nil,
 				Roles:                      nil,
 			},
-			r2: r2,
+			r2: &mongo.Role{
+				Privileges: []mongo.RolePrivilege{
+					{
+						Resource: map[string]interface{}{
+							"cluster": true,
+						},
+						Actions: []string{"addShard"},
+					},
+					{
+						Resource: map[string]interface{}{
+							"collection": "",
+							"db":         "config",
+						},
+						Actions: []string{"find", "update", "insert", "remove"},
+					},
+				},
+				AuthenticationRestrictions: nil,
+				Roles:                      []mongo.InheritenceRole{},
+			},
 		},
 	}
 

--- a/pkg/controller/perconaservermongodb/custom_users_test.go
+++ b/pkg/controller/perconaservermongodb/custom_users_test.go
@@ -11,16 +11,16 @@ func TestRolesChangedUUUU(t *testing.T) {
 		Privileges: []mongo.RolePrivilege{
 			{
 				Resource: map[string]interface{}{
-					"cluster": "true",
+					"cluster": true,
 				},
-				Actions: []string{"find"},
+				Actions: []string{"addShard"},
 			},
 			{
 				Resource: map[string]interface{}{
-					"db":         "test-two",
+					"db":         "config",
 					"collection": "",
 				},
-				Actions: []string{"find", "insert", "remove", "update"},
+				Actions: []string{"find", "update", "insert", "remove"},
 			},
 		},
 		AuthenticationRestrictions: nil,
@@ -40,16 +40,16 @@ func TestRolesChangedUUUU(t *testing.T) {
 				Privileges: []mongo.RolePrivilege{
 					{
 						Resource: map[string]interface{}{
-							"cluster": "true",
+							"cluster": true,
 						},
-						Actions: []string{"find"},
+						Actions: []string{"addShard"},
 					},
 					{
 						Resource: map[string]interface{}{
-							"db":         "test-two",
+							"db":         "config",
 							"collection": "",
 						},
-						Actions: []string{"find", "update", "insert", "remove"},
+						Actions: []string{"find", "insert", "remove", "update"},
 					},
 				},
 				AuthenticationRestrictions: nil,

--- a/pkg/controller/perconaservermongodb/custom_users_test.go
+++ b/pkg/controller/perconaservermongodb/custom_users_test.go
@@ -6,67 +6,6 @@ import (
 	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb/mongo"
 )
 
-func TestRolesChangedUUUU(t *testing.T) {
-
-	tests := []struct {
-		name string
-		r1   *mongo.Role
-		r2   *mongo.Role
-		want bool
-	}{
-		{
-			name: "Roles the same",
-			want: false,
-			r1: &mongo.Role{
-				Privileges: []mongo.RolePrivilege{
-					{
-						Resource: map[string]interface{}{
-							"cluster": true,
-						},
-						Actions: []string{"addShard"},
-					},
-					{
-						Resource: map[string]interface{}{
-							"db":         "config",
-							"collection": "",
-						},
-						Actions: []string{"find", "insert", "remove", "update"},
-					},
-				},
-				AuthenticationRestrictions: nil,
-				Roles:                      nil,
-			},
-			r2: &mongo.Role{
-				Privileges: []mongo.RolePrivilege{
-					{
-						Resource: map[string]interface{}{
-							"cluster": true,
-						},
-						Actions: []string{"addShard"},
-					},
-					{
-						Resource: map[string]interface{}{
-							"collection": "",
-							"db":         "config",
-						},
-						Actions: []string{"find", "update", "insert", "remove"},
-					},
-				},
-				AuthenticationRestrictions: nil,
-				Roles:                      []mongo.InheritenceRole{},
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := rolesChanged(tt.r1, tt.r2); got != tt.want {
-				t.Errorf("rolesChanged() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestRolesChanged(t *testing.T) {
 	r2 := &mongo.Role{
 		Privileges: []mongo.RolePrivilege{

--- a/pkg/controller/perconaservermongodb/custom_users_test.go
+++ b/pkg/controller/perconaservermongodb/custom_users_test.go
@@ -1,0 +1,234 @@
+package perconaservermongodb
+
+import (
+	"testing"
+
+	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb/mongo"
+)
+
+func TestRolesChanged(t *testing.T) {
+	r2 := &mongo.Role{
+		Privileges: []mongo.RolePrivilege{
+			{
+				Resource: map[string]interface{}{
+					"db":         "test",
+					"collection": "test",
+				},
+				Actions: []string{"find"},
+			},
+			{
+				Resource: map[string]interface{}{
+					"db":         "test-two",
+					"collection": "test-two",
+				},
+				Actions: []string{"find", "insert"},
+			},
+		},
+		AuthenticationRestrictions: []mongo.RoleAuthenticationRestriction{
+			{
+				ClientSource: []string{"localhost", "111.111.111.111"},
+			},
+			{
+				ServerAddress: []string{"localhost", "10.10.10.10"},
+				ClientSource:  []string{"localhost", "111.111.111.111"},
+			},
+		},
+		Roles: []mongo.InheritenceRole{
+			{
+				Role: "read",
+				DB:   "test",
+			},
+			{
+				Role: "insert",
+				DB:   "test",
+			},
+		},
+	}
+
+	tests := []struct {
+		name string
+		r1   *mongo.Role
+		r2   *mongo.Role
+		want bool
+	}{
+		{
+			name: "Roles the same",
+			want: false,
+			r1: &mongo.Role{
+				Privileges: []mongo.RolePrivilege{
+					{
+						Resource: map[string]interface{}{
+							"collection": "test",
+							"db":         "test",
+						},
+						Actions: []string{"find"},
+					},
+					{
+						Resource: map[string]interface{}{
+							"db":         "test-two",
+							"collection": "test-two",
+						},
+						Actions: []string{"insert", "find"},
+					},
+				},
+				AuthenticationRestrictions: []mongo.RoleAuthenticationRestriction{
+					{
+						ClientSource: []string{"111.111.111.111", "localhost"},
+					},
+					{
+						ServerAddress: []string{"10.10.10.10", "localhost"},
+						ClientSource:  []string{"localhost", "111.111.111.111"},
+					},
+				},
+				Roles: []mongo.InheritenceRole{
+					{
+						Role: "read",
+						DB:   "test",
+					},
+					{
+						Role: "insert",
+						DB:   "test",
+					},
+				},
+			},
+			r2: r2,
+		},
+		{
+			name: "Roles different",
+			want: true,
+			r1: &mongo.Role{
+				Privileges: []mongo.RolePrivilege{
+					{
+						Resource: map[string]interface{}{
+							"collection": "test",
+							"db":         "test",
+						},
+						Actions: []string{"find", "update"},
+					},
+					{
+						Resource: map[string]interface{}{
+							"db":         "test-two",
+							"collection": "test-two-different",
+						},
+						Actions: []string{"insert"},
+					},
+				},
+				AuthenticationRestrictions: []mongo.RoleAuthenticationRestriction{
+					{
+						ClientSource: []string{"111.111.111.111", "localhost"},
+					},
+					{
+						ServerAddress: []string{"10.10.10.10", "localhost"},
+						ClientSource:  []string{"localhost", "111.111.111.111"},
+					},
+				},
+				Roles: []mongo.InheritenceRole{
+					{
+						Role: "read",
+						DB:   "test",
+					},
+					{
+						Role: "update",
+						DB:   "test-two",
+					},
+					{
+						Role: "insert",
+						DB:   "test",
+					},
+				},
+			},
+			r2: r2,
+		},
+		{
+			name: "Privileges different",
+			want: true,
+			r1: &mongo.Role{
+				Privileges: []mongo.RolePrivilege{
+					{
+						Resource: map[string]interface{}{
+							"collection": "test",
+							"db":         "test",
+						},
+						Actions: []string{"find", "update"},
+					},
+					{
+						Resource: map[string]interface{}{
+							"db":         "test-two",
+							"collection": "test-two-different",
+						},
+						Actions: []string{"insert"},
+					},
+				},
+				AuthenticationRestrictions: []mongo.RoleAuthenticationRestriction{
+					{
+						ClientSource: []string{"111.111.111.111", "localhost"},
+					},
+					{
+						ServerAddress: []string{"10.10.10.10", "localhost"},
+						ClientSource:  []string{"localhost", "111.111.111.111"},
+					},
+				},
+				Roles: []mongo.InheritenceRole{
+					{
+						Role: "read",
+						DB:   "test",
+					},
+					{
+						Role: "insert",
+						DB:   "test",
+					},
+				},
+			},
+			r2: r2,
+		},
+		{
+			name: "AuthenticationRestrictions different",
+			want: true,
+			r1: &mongo.Role{
+				Privileges: []mongo.RolePrivilege{
+					{
+						Resource: map[string]interface{}{
+							"db":         "test",
+							"collection": "test",
+						},
+						Actions: []string{"find"},
+					},
+					{
+						Resource: map[string]interface{}{
+							"collection": "test-two",
+							"db":         "test-two",
+						},
+						Actions: []string{"insert","find",},
+					},
+				},
+				AuthenticationRestrictions: []mongo.RoleAuthenticationRestriction{
+					{
+						ServerAddress: []string{"1.1.1.1", "localhost"},
+					},
+					{
+						ClientSource: []string{"localhost"},
+					},
+				},
+				Roles: []mongo.InheritenceRole{
+					{
+						Role: "read",
+						DB:   "test",
+					},
+					{
+						Role: "insert",
+						DB:   "test",
+					},
+				},
+			},
+			r2: r2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := rolesChanged(tt.r1, tt.r2); got != tt.want {
+				t.Errorf("rolesChanged() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/controller/perconaservermongodb/custom_users_test.go
+++ b/pkg/controller/perconaservermongodb/custom_users_test.go
@@ -11,30 +11,20 @@ func TestRolesChangedUUUU(t *testing.T) {
 		Privileges: []mongo.RolePrivilege{
 			{
 				Resource: map[string]interface{}{
-					"db":         "test",
-					"collection": "test",
+					"cluster": "true",
 				},
 				Actions: []string{"find"},
 			},
 			{
 				Resource: map[string]interface{}{
 					"db":         "test-two",
-					"collection": "test-two",
+					"collection": "",
 				},
 				Actions: []string{"find", "insert", "remove", "update"},
 			},
 		},
 		AuthenticationRestrictions: nil,
-		Roles: []mongo.InheritenceRole{
-			{
-				Role: "read",
-				DB:   "test",
-			},
-			{
-				Role: "insert",
-				DB:   "test",
-			},
-		},
+		Roles:                      []mongo.InheritenceRole{},
 	}
 
 	tests := []struct {
@@ -50,30 +40,20 @@ func TestRolesChangedUUUU(t *testing.T) {
 				Privileges: []mongo.RolePrivilege{
 					{
 						Resource: map[string]interface{}{
-							"collection": "test",
-							"db":         "test",
+							"cluster": "true",
 						},
 						Actions: []string{"find"},
 					},
 					{
 						Resource: map[string]interface{}{
 							"db":         "test-two",
-							"collection": "test-two",
+							"collection": "",
 						},
 						Actions: []string{"find", "update", "insert", "remove"},
 					},
 				},
 				AuthenticationRestrictions: nil,
-				Roles: []mongo.InheritenceRole{
-					{
-						Role: "read",
-						DB:   "test",
-					},
-					{
-						Role: "insert",
-						DB:   "test",
-					},
-				},
+				Roles:                      nil,
 			},
 			r2: r2,
 		},

--- a/pkg/controller/perconaservermongodb/mgo.go
+++ b/pkg/controller/perconaservermongodb/mgo.go
@@ -809,17 +809,17 @@ func compareSlices(x, y []string) bool {
 	return true
 }
 
-// comparePrivileges compares 2 RolePrivilege arrays and returns true if they are equal
-func comparePrivileges(x []mongo.RolePrivilege, y []mongo.RolePrivilege) bool {
+// privilegesChanged compares 2 RolePrivilege arrays and returns true if they are equal
+func privilegesChanged(x []mongo.RolePrivilege, y []mongo.RolePrivilege) bool {
 	if len(x) != len(y) {
-		return false
+		return true
 	}
 	for i := range x {
 		if !(compareResources(x[i].Resource, y[i].Resource) && compareSlices(x[i].Actions, y[i].Actions)) {
-			return false
+			return true
 		}
 	}
-	return true
+	return false
 }
 
 func compareTags(tags mongo.ReplsetTags, selector api.PrimaryPreferTagSelectorSpec) bool {
@@ -851,7 +851,7 @@ func (r *ReconcilePerconaServerMongoDB) createOrUpdateSystemRoles(ctx context.Co
 		err = cli.CreateRole(ctx, "admin", mo)
 		return errors.Wrapf(err, "create role %s", role)
 	}
-	if !comparePrivileges(privileges, roleInfo.Privileges) {
+	if privilegesChanged(privileges, roleInfo.Privileges) {
 		err = cli.UpdateRole(ctx, "admin", mo)
 		return errors.Wrapf(err, "update role")
 	}

--- a/pkg/controller/perconaservermongodb/mgo.go
+++ b/pkg/controller/perconaservermongodb/mgo.go
@@ -815,7 +815,7 @@ func privilegesChanged(x []mongo.RolePrivilege, y []mongo.RolePrivilege) bool {
 		return true
 	}
 	for i := range x {
-		if !(compareResources(x[i].Resource, y[i].Resource) && compareSlices(x[i].Actions, y[i].Actions)) {
+		if !compareResources(x[i].Resource, y[i].Resource) || !compareSlices(x[i].Actions, y[i].Actions) {
 			return true
 		}
 	}


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
Comparing two roles, one in the CR and one in the DB was flawed and it made the operator to update the roles on every reconciliation loop regardless if the roles were changed or not.

**Solution:**
Fix roles comparison.

Note: this PR adds proper validation for empty roles for the user.

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?
- [x] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported MongoDB version?
- [x] Does the change support oldest and newest supported Kubernetes version?
