### PR TITLE
K8SPSMDB-921 add test for IRSA

### DIFF
--- a/e2e-tests/demand-backup-eks-credentials-irsa/compare/find-2nd.json
+++ b/e2e-tests/demand-backup-eks-credentials-irsa/compare/find-2nd.json
@@ -1,0 +1,4 @@
+switched to db myApp
+{ "_id" : , "x" : 100500 }
+{ "_id" : , "x" : 100501 }
+bye

--- a/e2e-tests/demand-backup-eks-credentials-irsa/compare/find.json
+++ b/e2e-tests/demand-backup-eks-credentials-irsa/compare/find.json
@@ -1,0 +1,3 @@
+switched to db myApp
+{ "_id" : , "x" : 100500 }
+bye

--- a/e2e-tests/demand-backup-eks-credentials-irsa/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/demand-backup-eks-credentials-irsa/compare/statefulset_some-name-rs0.yml
@@ -1,0 +1,269 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations: {}
+  generation: 1
+  labels:
+    app.kubernetes.io/component: mongod
+    app.kubernetes.io/instance: some-name
+    app.kubernetes.io/managed-by: percona-server-mongodb-operator
+    app.kubernetes.io/name: percona-server-mongodb
+    app.kubernetes.io/part-of: percona-server-mongodb
+    app.kubernetes.io/replset: rs0
+  name: some-name-rs0
+  ownerReferences:
+    - controller: true
+      kind: PerconaServerMongoDB
+      name: some-name
+spec:
+  podManagementPolicy: OrderedReady
+  replicas: 3
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: mongod
+      app.kubernetes.io/instance: some-name
+      app.kubernetes.io/managed-by: percona-server-mongodb-operator
+      app.kubernetes.io/name: percona-server-mongodb
+      app.kubernetes.io/part-of: percona-server-mongodb
+      app.kubernetes.io/replset: rs0
+  serviceName: some-name-rs0
+  template:
+    metadata:
+      annotations: {}
+      labels:
+        app.kubernetes.io/component: mongod
+        app.kubernetes.io/instance: some-name
+        app.kubernetes.io/managed-by: percona-server-mongodb-operator
+        app.kubernetes.io/name: percona-server-mongodb
+        app.kubernetes.io/part-of: percona-server-mongodb
+        app.kubernetes.io/replset: rs0
+    spec:
+      containers:
+        - args:
+            - --bind_ip_all
+            - --auth
+            - --dbpath=/data/db
+            - --port=27017
+            - --replSet=rs0
+            - --storageEngine=wiredTiger
+            - --relaxPermChecks
+            - --sslAllowInvalidCertificates
+            - --clusterAuthMode=x509
+            - --tlsMode=preferTLS
+            - --enableEncryption
+            - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
+            - --wiredTigerCacheSizeGB=0.25
+            - --wiredTigerIndexPrefixCompression=true
+            - --config=/etc/mongodb-config/mongod.conf
+            - --quiet
+          command:
+            - /opt/percona/ps-entry.sh
+          env:
+            - name: SERVICE_NAME
+              value: some-name
+            - name: MONGODB_PORT
+              value: "27017"
+            - name: MONGODB_REPLSET
+              value: rs0
+          envFrom:
+            - secretRef:
+                name: internal-some-name-users
+                optional: false
+          imagePullPolicy: Always
+          livenessProbe:
+            exec:
+              command:
+                - /opt/percona/mongodb-healthcheck
+                - k8s
+                - liveness
+                - --ssl
+                - --sslInsecure
+                - --sslCAFile
+                - /etc/mongodb-ssl/ca.crt
+                - --sslPEMKeyFile
+                - /tmp/tls.pem
+                - --startupDelaySeconds
+                - "7200"
+            failureThreshold: 4
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 10
+          name: mongod
+          ports:
+            - containerPort: 27017
+              name: mongodb
+              protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+                - /opt/percona/mongodb-healthcheck
+                - k8s
+                - readiness
+                - --component
+                - mongod
+            failureThreshold: 8
+            initialDelaySeconds: 10
+            periodSeconds: 3
+            successThreshold: 1
+            timeoutSeconds: 2
+          resources:
+            limits:
+              cpu: 500m
+              memory: 1G
+            requests:
+              cpu: 100m
+              memory: 100M
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /data/db
+              name: mongod-data
+            - mountPath: /etc/mongodb-secrets
+              name: some-name-mongodb-keyfile
+              readOnly: true
+            - mountPath: /etc/mongodb-ssl
+              name: ssl
+              readOnly: true
+            - mountPath: /etc/mongodb-ssl-internal
+              name: ssl-internal
+              readOnly: true
+            - mountPath: /etc/mongodb-config
+              name: config
+            - mountPath: /opt/percona
+              name: bin
+            - mountPath: /etc/mongodb-encryption
+              name: some-name-mongodb-encryption-key
+              readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
+          workingDir: /data/db
+        - args:
+            - pbm-agent-entrypoint
+          command:
+            - /opt/percona/pbm-entry.sh
+          env:
+            - name: PBM_AGENT_MONGODB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  key: MONGODB_BACKUP_USER
+                  name: internal-some-name-users
+                  optional: false
+            - name: PBM_AGENT_MONGODB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: MONGODB_BACKUP_PASSWORD
+                  name: internal-some-name-users
+                  optional: false
+            - name: PBM_MONGODB_REPLSET
+              value: rs0
+            - name: PBM_MONGODB_PORT
+              value: "27017"
+            - name: PBM_AGENT_SIDECAR
+              value: "true"
+            - name: PBM_AGENT_SIDECAR_SLEEP
+              value: "5"
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: PBM_MONGODB_URI
+              value: mongodb://$(PBM_AGENT_MONGODB_USERNAME):$(PBM_AGENT_MONGODB_PASSWORD)@$(POD_NAME)
+            - name: PBM_AGENT_TLS_ENABLED
+              value: "true"
+          imagePullPolicy: Always
+          name: backup-agent
+          resources: {}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /etc/mongodb-ssl
+              name: ssl
+              readOnly: true
+            - mountPath: /opt/percona
+              name: bin
+              readOnly: true
+            - mountPath: /data/db
+              name: mongod-data
+      dnsPolicy: ClusterFirst
+      initContainers:
+        - command:
+            - /init-entrypoint.sh
+          imagePullPolicy: Always
+          name: mongo-init
+          resources:
+            limits:
+              cpu: 500m
+              memory: 1G
+            requests:
+              cpu: 100m
+              memory: 100M
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /data/db
+              name: mongod-data
+            - mountPath: /opt/percona
+              name: bin
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext:
+        fsGroup: 1001
+      serviceAccount: default
+      serviceAccountName: default
+      terminationGracePeriodSeconds: 60
+      volumes:
+        - name: some-name-mongodb-keyfile
+          secret:
+            defaultMode: 288
+            optional: false
+            secretName: some-name-mongodb-keyfile
+        - emptyDir: {}
+          name: bin
+        - configMap:
+            defaultMode: 420
+            name: some-name-rs0-mongod
+            optional: true
+          name: config
+        - name: some-name-mongodb-encryption-key
+          secret:
+            defaultMode: 288
+            optional: false
+            secretName: some-name-mongodb-encryption-key
+        - name: ssl
+          secret:
+            defaultMode: 288
+            optional: false
+            secretName: some-name-ssl
+        - name: ssl-internal
+          secret:
+            defaultMode: 288
+            optional: true
+            secretName: some-name-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-some-name-users
+  updateStrategy:
+    rollingUpdate:
+      partition: 0
+    type: RollingUpdate
+  volumeClaimTemplates:
+    - metadata:
+        name: mongod-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+      status:
+        phase: Pending

--- a/e2e-tests/demand-backup-eks-credentials-irsa/conf/backup-aws-s3.yml
+++ b/e2e-tests/demand-backup-eks-credentials-irsa/conf/backup-aws-s3.yml
@@ -1,0 +1,9 @@
+apiVersion: psmdb.percona.com/v1
+kind: PerconaServerMongoDBBackup
+metadata:
+  finalizers:
+    - percona.com/delete-backup
+  name: backup-aws-s3
+spec:
+  clusterName: some-name
+  storageName: aws-s3

--- a/e2e-tests/demand-backup-eks-credentials-irsa/conf/restore.yml
+++ b/e2e-tests/demand-backup-eks-credentials-irsa/conf/restore.yml
@@ -1,0 +1,7 @@
+apiVersion: psmdb.percona.com/v1
+kind: PerconaServerMongoDBRestore
+metadata:
+  name:
+spec:
+  clusterName: some-name
+  backupName:

--- a/e2e-tests/demand-backup-eks-credentials-irsa/conf/s3-bucket-policy.json
+++ b/e2e-tests/demand-backup-eks-credentials-irsa/conf/s3-bucket-policy.json
@@ -1,0 +1,15 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:*"
+      ],
+      "Resource": [
+        "arn:aws:s3:::operator-testing",
+        "arn:aws:s3:::operator-testing/*"
+      ]
+    }
+  ]
+}

--- a/e2e-tests/demand-backup-eks-credentials-irsa/conf/some-name-rs0.yml
+++ b/e2e-tests/demand-backup-eks-credentials-irsa/conf/some-name-rs0.yml
@@ -1,0 +1,64 @@
+apiVersion: psmdb.percona.com/v1
+kind: PerconaServerMongoDB
+metadata:
+  name: some-name
+spec:
+  #platform: openshift
+  image:
+  imagePullPolicy: Always
+  backup:
+    enabled: true
+    image: perconalab/percona-server-mongodb-operator:1.1.0-backup
+    storages:
+      aws-s3:
+        type: s3
+        s3:
+          region: us-east-1
+          bucket: operator-testing
+          prefix: psmdb-demand-backup-eks-irsa
+    tasks:
+    - name: weekly
+      enabled: true
+      schedule: "0 0 * * 0"
+      compressionType: gzip
+      storageName: aws-s3
+  replsets:
+  - name: rs0
+    affinity:
+      antiAffinityTopologyKey: none
+    resources:
+      limits:
+        cpu: 500m
+        memory: 1G
+      requests:
+        cpu: 100m
+        memory: 0.1G
+    volumeSpec:
+      persistentVolumeClaim:
+        resources:
+          requests:
+            storage: 1Gi
+    size: 3
+    configuration: |
+      operationProfiling:
+        mode: slowOp
+        slowOpThresholdMs: 100
+      security:
+        enableEncryption: true
+        redactClientLogData: false
+      setParameter:
+        ttlMonitorSleepSecs: 60
+        wiredTigerConcurrentReadTransactions: 128
+        wiredTigerConcurrentWriteTransactions: 128
+      storage:
+        engine: wiredTiger
+        wiredTiger:
+          collectionConfig:
+            blockCompressor: snappy
+          engineConfig:
+            directoryForIndexes: false
+            journalCompressor: snappy
+          indexConfig:
+            prefixCompression: true
+  secrets:
+    users: some-users

--- a/e2e-tests/demand-backup-eks-credentials-irsa/conf/template.json
+++ b/e2e-tests/demand-backup-eks-credentials-irsa/conf/template.json
@@ -1,0 +1,16 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::119175775298:oidc-provider/${eks_cluster_oidc}"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+        }
+      }
+    }
+  ]
+}

--- a/e2e-tests/demand-backup-eks-credentials-irsa/run
+++ b/e2e-tests/demand-backup-eks-credentials-irsa/run
@@ -1,0 +1,139 @@
+#!/bin/bash
+
+set -o errexit
+
+test_dir=$(realpath $(dirname $0))
+. ${test_dir}/../functions
+set_debug
+# EKS cluster should be run without the policy AmazonS3FullAccess
+# This policy makes the test false passed.
+
+if [ $EKS -ne 1 ]; then
+	echo "Skip the test. We run it for EKS only "
+	exit 0
+fi
+cluster="some-name-rs0"
+
+# get cluster oidc
+eks_cluster=$(kubectl config view --minify -o jsonpath='{.contexts[0].context.cluster}' | awk -F/ '{print $NF}')
+IFS='.' read -r eks_cluster_name eks_cluster_region _ <<< "$eks_cluster"
+
+eks_cluster_oidc=$(aws eks describe-cluster --name $eks_cluster_name --region=$eks_cluster_region  --query "cluster.identity.oidc.issuer" --output text | sed 's|https://||')
+policy_arn="arn:aws:iam::119175775298:policy/operator-testing-access-s3"
+role_name="$cluster-psmdb-access-s3-bucket"
+
+# Create policy. Already done, we don't need to do it every time. But all steps should be illustrated in the
+#aws iam create-policy --policy-name operator-testing-allow-access-s3 --policy-document file://conf/s3-bucket-policy.json
+
+
+desc "create role"
+jq --arg eks_cluster_oidc "$eks_cluster_oidc" \
+   '.Statement[0].Principal.Federated = "arn:aws:iam::119175775298:oidc-provider/\($eks_cluster_oidc)" |
+    .Statement[0].Condition.StringEquals["$eks_cluster_oidc:aud"] = "sts.amazonaws.com"' \
+   $test_dir/conf/template.json > $test_dir/conf/role-trust-policy.json
+
+role_arn=$(aws iam create-role \
+    --role-name "$role_name" \
+    --assume-role-policy-document file://$test_dir/conf/role-trust-policy.json \
+    --description "Allow access to s3 bucket" \
+    --query "Role.Arn" \
+    --output text || true)
+
+role_arn="arn:aws:iam::119175775298:role/some-name-rs0-psmdb-access-s3-bucket"
+
+desc "connect role and policy"
+aws iam attach-role-policy --role-name "$role_name" --policy-arn $policy_arn
+
+create_infra "$namespace"
+
+desc "create secrets and start client"
+kubectl_bin apply \
+	-f "$conf_dir/secrets.yml" \
+	-f "$conf_dir/client.yml"
+
+desc "create first PSMDB cluster $cluster"
+apply_cluster $test_dir/conf/$cluster.yml
+
+desc 'check if all 3 Pods started'
+wait_for_running $cluster 3
+
+desc 'check if service and statefulset created with expected config'
+compare_kubectl statefulset/$cluster
+
+desc "update service accounts for operator and default (our cluster uses this one)"
+
+kubectl_bin annotate serviceaccount default \
+    eks.amazonaws.com/role-arn="$role_arn" \
+    --overwrite
+
+kubectl_bin annotate serviceaccount percona-server-mongodb-operator \
+    eks.amazonaws.com/role-arn="$role_arn" \
+    --overwrite
+
+desc "restart operator and cluster"
+operator_pod=$(get_operator_pod)
+kubectl_bin delete pod $operator_pod
+
+kubectl_bin delete pod "$cluster-0"
+kubectl_bin delete pod "$cluster-1"
+kubectl_bin delete pod "$cluster-2"
+
+wait_for_running $cluster 3
+
+kubectl exec $cluster-0 -c backup-agent -- sh -c 'if [ -z "$AWS_ROLE_ARN" ]; then echo "Variable AWS_ROLE_ARN not set" && exit 1; else echo "Variable AWS_ROLE_ARN is set"; fi'
+
+desc 'create user'
+run_mongo \
+	'db.createUser({user:"myApp",pwd:"myPass",roles:[{db:"myApp",role:"readWrite"}]})' \
+	"userAdmin:userAdmin123456@$cluster.$namespace"
+sleep 2
+
+desc 'write data, read from all'
+run_mongo \
+	'use myApp\n db.test.insert({ x: 100500 })' \
+	"myApp:myPass@$cluster.$namespace"
+
+minikube_sleep
+
+desc "compare mongo cmd"
+compare_mongo_cmd "find" "myApp:myPass@$cluster-0.$cluster.$namespace"
+compare_mongo_cmd "find" "myApp:myPass@$cluster-1.$cluster.$namespace"
+compare_mongo_cmd "find" "myApp:myPass@$cluster-2.$cluster.$namespace"
+
+
+#desc "wait backup agent"
+wait_backup_agent $cluster-0
+wait_backup_agent $cluster-1
+wait_backup_agent $cluster-2
+
+backup_name_aws="backup-aws-s3"
+
+desc 'run backups'
+run_backup aws-s3
+wait_backup "$backup_name_aws"
+sleep 5
+
+desc 'check backup and restore -- aws-s3'
+backup_dest_aws=$(get_backup_dest "$backup_name_aws")
+curl -s "https://s3.amazonaws.com/${backup_dest_aws}/rs0/myApp.test.gz" | gunzip >/dev/null
+run_mongo 'use myApp\n db.test.insert({ x: 100501 })' "myApp:myPass@$cluster.$namespace"
+compare_mongo_cmd "find" "myApp:myPass@$cluster-0.$cluster.$namespace" "-2nd"
+compare_mongo_cmd "find" "myApp:myPass@$cluster-1.$cluster.$namespace" "-2nd"
+compare_mongo_cmd "find" "myApp:myPass@$cluster-2.$cluster.$namespace" "-2nd"
+run_restore "$backup_name_aws"
+wait_restore "$backup_name_aws" "${cluster/-rs0/}"
+compare_mongo_cmd "find" "myApp:myPass@$cluster-0.$cluster.$namespace"
+compare_mongo_cmd "find" "myApp:myPass@$cluster-1.$cluster.$namespace"
+compare_mongo_cmd "find" "myApp:myPass@$cluster-2.$cluster.$namespace"
+
+desc 'delete backup and check if it is removed from bucket -- aws-s3'
+kubectl_bin delete psmdb-backup --all
+check_backup_deletion "https://s3.amazonaws.com/${backup_dest_aws}" "aws-s3"
+
+destroy $namespace
+
+desc "delete role"
+aws iam detach-role-policy --role-name "$role_name" --policy-arn "$policy_arn"
+aws iam delete-role --role-name "$role_name"
+
+desc 'test passed'


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
The test with access without credential (only IAM role for service account) was added
https://docs.percona.com/percona-backup-mongodb/manage/automate-s3-access.html#get-expert-help

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
