### PR TITLE
Fix tests for openshift

### DIFF
--- a/e2e-tests/data-at-rest-encryption/run
+++ b/e2e-tests/data-at-rest-encryption/run
@@ -57,7 +57,7 @@ sleep 5
 
 desc "check backup and restore -- minio"
 backup_dest_minio=$(get_backup_dest "$backup_name_minio")
-kubectl_bin run -i --rm aws-cli --image=perconalab/awscli --restart=Never -- \
+retry 3 5 kubectl_bin run -i --rm aws-cli --image=perconalab/awscli --restart=Never -- \
 	/usr/bin/env AWS_ACCESS_KEY_ID=some-access-key AWS_SECRET_ACCESS_KEY=some-secret-key AWS_DEFAULT_REGION=us-east-1 \
 	/usr/bin/aws --endpoint-url http://minio-service:9000 s3 ls s3://${backup_dest_minio}/rs0/ \
 	| grep myApp.test.gz

--- a/e2e-tests/demand-backup-physical-sharded/run
+++ b/e2e-tests/demand-backup-physical-sharded/run
@@ -29,13 +29,13 @@ run_recovery_check() {
 	local backup_name=$1
 	local compare_suffix=${2:-"_restore"}
 
-	wait_restore "${backup_name}" "${cluster}" "requested" "0" "2400"
+	wait_restore "${backup_name}" "${cluster}" "requested" "0" "3000"
 	echo
 
 	compare_kubectl "statefulset/${cluster}-rs0" ${compare_suffix}
 
 	# we don't wait for cluster readiness here because the annotation gets removed then
-	wait_restore "${backup_name}" "${cluster}" "ready" "0" "2400"
+	wait_restore "${backup_name}" "${cluster}" "ready" "0" "3000"
 	kubectl_bin get psmdb ${cluster} -o yaml
 	if [ $(kubectl_bin get psmdb ${cluster} -o yaml | yq '.metadata.annotations."percona.com/resync-pbm"') == null ]; then
 		echo "psmdb/${cluster} should be annotated with percona.com/resync-pbm after a physical restore"

--- a/e2e-tests/demand-backup-physical-sharded/run
+++ b/e2e-tests/demand-backup-physical-sharded/run
@@ -42,10 +42,11 @@ run_recovery_check() {
 		exit 1
 	fi
 	echo
+
 	wait_cluster_consistency ${cluster} 42
+	wait_for_pbm_operations ${cluster}
+
 	compare_mongos_cmd "find" "myApp:myPass@${cluster}-mongos.${namespace}" "-sharded"
-	echo
-	set -o xtrace
 }
 
 check_exported_mongos_service_endpoint() {

--- a/e2e-tests/demand-backup-physical-sharded/run
+++ b/e2e-tests/demand-backup-physical-sharded/run
@@ -29,7 +29,7 @@ run_recovery_check() {
 	local backup_name=$1
 	local compare_suffix=${2:-"_restore"}
 
-	wait_restore "${backup_name}" "${cluster}" "requested" "0" "1200"
+	wait_restore "${backup_name}" "${cluster}" "requested" "0" "1800"
 	echo
 
 	compare_kubectl "statefulset/${cluster}-rs0" ${compare_suffix}

--- a/e2e-tests/demand-backup-physical-sharded/run
+++ b/e2e-tests/demand-backup-physical-sharded/run
@@ -29,13 +29,13 @@ run_recovery_check() {
 	local backup_name=$1
 	local compare_suffix=${2:-"_restore"}
 
-	wait_restore "${backup_name}" "${cluster}" "requested" "0" "1800"
+	wait_restore "${backup_name}" "${cluster}" "requested" "0" "2400"
 	echo
 
 	compare_kubectl "statefulset/${cluster}-rs0" ${compare_suffix}
 
 	# we don't wait for cluster readiness here because the annotation gets removed then
-	wait_restore "${backup_name}" "${cluster}" "ready" "0" "1800"
+	wait_restore "${backup_name}" "${cluster}" "ready" "0" "2400"
 	kubectl_bin get psmdb ${cluster} -o yaml
 	if [ $(kubectl_bin get psmdb ${cluster} -o yaml | yq '.metadata.annotations."percona.com/resync-pbm"') == null ]; then
 		echo "psmdb/${cluster} should be annotated with percona.com/resync-pbm after a physical restore"

--- a/e2e-tests/demand-backup-physical/run
+++ b/e2e-tests/demand-backup-physical/run
@@ -37,7 +37,6 @@ run_recovery_check() {
 	# we don't wait for cluster readiness here because the annotation gets removed then
 	wait_restore "${backup_name}" "${cluster}" "ready" "0" "1800"
 
-	kubectl_bin get psmdb ${cluster} -o yaml
 	if [ $(kubectl_bin get psmdb ${cluster} -o yaml | yq '.metadata.annotations."percona.com/resync-pbm"') == null ]; then
 		echo "psmdb/${cluster} should be annotated with percona.com/resync-pbm after a physical restore"
 		exit 1
@@ -45,13 +44,11 @@ run_recovery_check() {
 	echo
 
 	wait_cluster_consistency ${cluster}
+	wait_for_pbm_operations ${cluster}
 
 	compare_mongo_cmd "find" "myApp:myPass@${cluster}-rs0-0.${cluster}-rs0.${namespace}"
 	compare_mongo_cmd "find" "myApp:myPass@${cluster}-rs0-1.${cluster}-rs0.${namespace}"
 	compare_mongo_cmd "find" "myApp:myPass@${cluster}-rs0-2.${cluster}-rs0.${namespace}"
-
-	echo
-	set -o xtrace
 }
 
 create_infra "${namespace}"

--- a/e2e-tests/demand-backup-physical/run
+++ b/e2e-tests/demand-backup-physical/run
@@ -29,13 +29,13 @@ run_recovery_check() {
 	local backup_name=$1
 	local compare_suffix=${2:-"_restore"}
 
-	wait_restore "${backup_name}" "${cluster}" "requested" "0" "2400"
+	wait_restore "${backup_name}" "${cluster}" "requested" "0" "3000"
 	echo
 
 	compare_kubectl "statefulset/${cluster}-rs0" ${compare_suffix}
 
 	# we don't wait for cluster readiness here because the annotation gets removed then
-	wait_restore "${backup_name}" "${cluster}" "ready" "0" "2400"
+	wait_restore "${backup_name}" "${cluster}" "ready" "0" "3000"
 
 	if [ $(kubectl_bin get psmdb ${cluster} -o yaml | yq '.metadata.annotations."percona.com/resync-pbm"') == null ]; then
 		echo "psmdb/${cluster} should be annotated with percona.com/resync-pbm after a physical restore"

--- a/e2e-tests/demand-backup-physical/run
+++ b/e2e-tests/demand-backup-physical/run
@@ -29,7 +29,7 @@ run_recovery_check() {
 	local backup_name=$1
 	local compare_suffix=${2:-"_restore"}
 
-	wait_restore "${backup_name}" "${cluster}" "requested" "0" "1200"
+	wait_restore "${backup_name}" "${cluster}" "requested" "0" "1800"
 	echo
 
 	compare_kubectl "statefulset/${cluster}-rs0" ${compare_suffix}

--- a/e2e-tests/demand-backup-physical/run
+++ b/e2e-tests/demand-backup-physical/run
@@ -29,13 +29,13 @@ run_recovery_check() {
 	local backup_name=$1
 	local compare_suffix=${2:-"_restore"}
 
-	wait_restore "${backup_name}" "${cluster}" "requested" "0" "1800"
+	wait_restore "${backup_name}" "${cluster}" "requested" "0" "2400"
 	echo
 
 	compare_kubectl "statefulset/${cluster}-rs0" ${compare_suffix}
 
 	# we don't wait for cluster readiness here because the annotation gets removed then
-	wait_restore "${backup_name}" "${cluster}" "ready" "0" "1800"
+	wait_restore "${backup_name}" "${cluster}" "ready" "0" "2400"
 
 	if [ $(kubectl_bin get psmdb ${cluster} -o yaml | yq '.metadata.annotations."percona.com/resync-pbm"') == null ]; then
 		echo "psmdb/${cluster} should be annotated with percona.com/resync-pbm after a physical restore"

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -239,6 +239,25 @@ wait_backup() {
 	set_debug
 }
 
+wait_for_pbm_operations() {
+	local cluster=$1
+
+	set +o xtrace
+	echo -n "waiting for PBM operation to finish"
+	retry=0
+	until [[ $(kubectl_bin exec ${cluster}-rs0-0 -c backup-agent -- pbm status -o json -s running | jq -r .running.opID) == null ]]; do
+		if [ $retry -ge 540 ]; then
+			echo max retry count $retry reached. something went wrong with PBM operations
+			exit 1
+		fi
+		echo -n .
+		sleep 5
+	done
+	echo
+	set_debug
+}
+
+
 run_restore() {
 	local backup_name=$1
 

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -257,7 +257,6 @@ wait_for_pbm_operations() {
 	set_debug
 }
 
-
 run_restore() {
 	local backup_name=$1
 

--- a/e2e-tests/pvc-resize/run
+++ b/e2e-tests/pvc-resize/run
@@ -157,6 +157,11 @@ if [[ $EKS == 1 || -n ${OPENSHIFT} ]]; then
 	else
 		spinup_psmdb "${cluster}-rs0" "$test_dir/conf/$cluster.yml"
 	fi
+	echo "Enabling PVC resize after recreating PSMDB cluster ${cluster} "
+	kubectl_bin patch psmdb "${cluster}" --type=json -p='[{"op": "add", "path": "/spec/enableVolumeExpansion", "value":true }]'
+	sleep 10
+
+	wait_cluster_consistency "$cluster"
 fi
 
 desc 'create resourcequota'

--- a/e2e-tests/serviceless-external-nodes/compare/statefulset_mydb-rs0-oc.yml
+++ b/e2e-tests/serviceless-external-nodes/compare/statefulset_mydb-rs0-oc.yml
@@ -1,0 +1,217 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations: {}
+  generation: 1
+  labels:
+    app.kubernetes.io/component: mongod
+    app.kubernetes.io/instance: mydb
+    app.kubernetes.io/managed-by: percona-server-mongodb-operator
+    app.kubernetes.io/name: percona-server-mongodb
+    app.kubernetes.io/part-of: percona-server-mongodb
+    app.kubernetes.io/replset: rs0
+  name: mydb-rs0
+  ownerReferences:
+    - controller: true
+      kind: PerconaServerMongoDB
+      name: mydb
+spec:
+  podManagementPolicy: OrderedReady
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: mongod
+      app.kubernetes.io/instance: mydb
+      app.kubernetes.io/managed-by: percona-server-mongodb-operator
+      app.kubernetes.io/name: percona-server-mongodb
+      app.kubernetes.io/part-of: percona-server-mongodb
+      app.kubernetes.io/replset: rs0
+  serviceName: mydb-rs0
+  template:
+    metadata:
+      annotations: {}
+      labels:
+        app.kubernetes.io/component: mongod
+        app.kubernetes.io/instance: mydb
+        app.kubernetes.io/managed-by: percona-server-mongodb-operator
+        app.kubernetes.io/name: percona-server-mongodb
+        app.kubernetes.io/part-of: percona-server-mongodb
+        app.kubernetes.io/replset: rs0
+    spec:
+      containers:
+        - args:
+            - --bind_ip_all
+            - --auth
+            - --dbpath=/data/db
+            - --port=27017
+            - --replSet=rs0
+            - --storageEngine=wiredTiger
+            - --relaxPermChecks
+            - --sslAllowInvalidCertificates
+            - --clusterAuthMode=keyFile
+            - --keyFile=/etc/mongodb-secrets/mongodb-key
+            - --tlsMode=allowTLS
+            - --enableEncryption
+            - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
+            - --wiredTigerCacheSizeGB=0.25
+            - --wiredTigerIndexPrefixCompression=true
+            - --config=/etc/mongodb-config/mongod.conf
+            - --quiet
+          command:
+            - /opt/percona/ps-entry.sh
+          env:
+            - name: SERVICE_NAME
+              value: mydb
+            - name: MONGODB_PORT
+              value: "27017"
+            - name: MONGODB_REPLSET
+              value: rs0
+          envFrom:
+            - secretRef:
+                name: internal-mydb-users
+                optional: false
+          imagePullPolicy: Always
+          livenessProbe:
+            exec:
+              command:
+                - /opt/percona/mongodb-healthcheck
+                - k8s
+                - liveness
+                - --ssl
+                - --sslInsecure
+                - --sslCAFile
+                - /etc/mongodb-ssl/ca.crt
+                - --sslPEMKeyFile
+                - /tmp/tls.pem
+                - --startupDelaySeconds
+                - "7200"
+            failureThreshold: 4
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 10
+          name: mongod
+          ports:
+            - containerPort: 27017
+              name: mongodb
+              protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+                - /opt/percona/mongodb-healthcheck
+                - k8s
+                - readiness
+                - --component
+                - mongod
+            failureThreshold: 8
+            initialDelaySeconds: 10
+            periodSeconds: 3
+            successThreshold: 1
+            timeoutSeconds: 2
+          resources:
+            limits:
+              cpu: 300m
+              memory: 500M
+            requests:
+              cpu: 300m
+              memory: 500M
+          securityContext:
+            runAsNonRoot: true
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /data/db
+              name: mongod-data
+            - mountPath: /etc/mongodb-secrets
+              name: mydb-custom-mongodb-keyfile
+              readOnly: true
+            - mountPath: /etc/mongodb-ssl
+              name: ssl
+              readOnly: true
+            - mountPath: /etc/mongodb-ssl-internal
+              name: ssl-internal
+              readOnly: true
+            - mountPath: /etc/mongodb-config
+              name: config
+            - mountPath: /opt/percona
+              name: bin
+            - mountPath: /etc/mongodb-encryption
+              name: mydb-custom-encryption-key
+              readOnly: true
+            - mountPath: /etc/users-secret
+              name: users-secret-file
+          workingDir: /data/db
+      dnsPolicy: ClusterFirst
+      initContainers:
+        - command:
+            - /init-entrypoint.sh
+          imagePullPolicy: Always
+          name: mongo-init
+          resources:
+            limits:
+              cpu: 300m
+              memory: 500M
+            requests:
+              cpu: 300m
+              memory: 500M
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /data/db
+              name: mongod-data
+            - mountPath: /opt/percona
+              name: bin
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: default
+      serviceAccountName: default
+      terminationGracePeriodSeconds: 60
+      volumes:
+        - name: mydb-custom-mongodb-keyfile
+          secret:
+            defaultMode: 288
+            optional: false
+            secretName: mydb-custom-mongodb-keyfile
+        - emptyDir: {}
+          name: bin
+        - configMap:
+            defaultMode: 420
+            name: mydb-rs0-mongod
+            optional: true
+          name: config
+        - name: mydb-custom-encryption-key
+          secret:
+            defaultMode: 288
+            optional: false
+            secretName: mydb-custom-encryption-key
+        - name: ssl
+          secret:
+            defaultMode: 288
+            optional: false
+            secretName: mydb-custom-ssl
+        - name: ssl-internal
+          secret:
+            defaultMode: 288
+            optional: true
+            secretName: mydb-custom-ssl-internal
+        - name: users-secret-file
+          secret:
+            defaultMode: 420
+            secretName: internal-mydb-users
+  updateStrategy:
+    rollingUpdate:
+      partition: 0
+    type: RollingUpdate
+  volumeClaimTemplates:
+    - metadata:
+        name: mongod-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 3Gi
+      status:
+        phase: Pending

--- a/e2e-tests/serviceless-external-nodes/run
+++ b/e2e-tests/serviceless-external-nodes/run
@@ -22,7 +22,7 @@ apply_cluster "$test_dir/conf/main.yml"
 wait_for_running "$cluster-rs0" 1
 compare_kubectl statefulset/mydb-rs0
 
-secrets_count=$(kubectl_bin get secret -o yaml | yq '.items | length')
+secrets_count=$(kubectl_bin get secret -o json | jq --arg pattern "$cluster" '[.items[] | select(.metadata.name | test($pattern))] | length')
 if [[ $secrets_count != 6 ]]; then
 	echo "It's expected to have 6 secrets. Currently have $secrets_count"
 	exit 1
@@ -41,7 +41,7 @@ apply_cluster "$test_dir/conf/external.yml"
 wait_pod ${cluster}-rs0-0
 wait_pod ${cluster}-rs0-1
 
-secrets_count=$(kubectl_bin get secret -o yaml | yq '.items | length')
+secrets_count=$(kubectl_bin get secret -o json | jq --arg pattern "$cluster" '[.items[] | select(.metadata.name | test($pattern))] | length')
 if [[ $secrets_count != 6 ]]; then
 	echo "It's expected to have 6 secrets. Currently have $secrets_count"
 	exit 1


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
1) `demand-backup-physical-sharded` and `demand-backup-physical failing`. In e2e tests, we start 2nd restore just after 1st restore finishes and it fails because of running resync operation.
2) `pvc-resize` on `openshift` fails
3) `serviceless-external-nodes` on openshift fails

**Cause:**
1) `demand-backup-physical-sharded` and `demand-backup-physical` failing due to long PBM resync. After physical restore finishes, operator automatically starts resync. Especially on storages with lots of backups, resync takes a long time.
2) `pvc-resize` on openshift fails - starting with 1.18.0 `pvc-resize` is disabled by default. On EKS and openshift we recreate cluster in the middle of pvc-reside (due to limits for resize requests) but did not enable pvc-resize again
3) `serviceless-external-nodes` on openshift fails - check of `secrets` number was added to tests. `secrets` on openshift have dockercfg secrets:
```
k get secret
NAME                                              TYPE                      DATA   AGE
builder-dockercfg-xzpz2                           kubernetes.io/dockercfg   1      144m
default-dockercfg-dnthr                           kubernetes.io/dockercfg   1      144m
deployer-dockercfg-spbmz                          kubernetes.io/dockercfg   1      144m
internal-my-cluster-name-users                    Opaque                    10     7m55s
my-cluster-name-mongodb-encryption-key            Opaque                    1      7m54s
my-cluster-name-mongodb-keyfile                   Opaque                    1      7m54s
my-cluster-name-secrets                           Opaque                    10     7m55s
my-cluster-name-ssl                               kubernetes.io/tls         3      7m54s
my-cluster-name-ssl-internal                      kubernetes.io/tls         3      7m54s
percona-server-mongodb-operator-dockercfg-ndbth   kubernetes.io/dockercfg   1      7m58s
```
As a result count of secrets is bigger than expected. + test failed due to `securityContext` diff.

**Solution:**
1) Wait for resync to finish before starting another restore. Increase timeouts
2) Enable `pvc-reize` for the recreated cluster
3) Add diff file for openshift and count only` $cluster` secrets for check.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?