### PR TITLE
K8SPSMDB-1205: Allow backups in unmanaged clusters

### DIFF
--- a/e2e-tests/cross-site-sharded/run
+++ b/e2e-tests/cross-site-sharded/run
@@ -16,19 +16,21 @@ replica_cluster="cross-site-sharded-replica"
 wait_for_members() {
   local endpoint="$1"
   local rsName="$2"
-  local nodes_amount=0
-  until [[ ${nodes_amount} == 6 ]]; do
-    nodes_amount=$(run_mongos 'rs.conf().members.length' "clusterAdmin:clusterAdmin123456@$endpoint" "mongodb" ":27017" \
+  local target_count=$3
+
+  local nodes_count=0
+  until [[ ${nodes_count} == ${target_count} ]]; do
+    nodes_count=$(run_mongos 'rs.conf().members.length' "clusterAdmin:clusterAdmin123456@$endpoint" "mongodb" ":27017" \
      | egrep -v 'I NETWORK|W NETWORK|Error saving history file|Percona Server for MongoDB|connecting to:|Unable to reach primary for set|Implicit session:|versions do not match|Error saving history file:|bye' \
      | $sed -re 's/ObjectId\("[0-9a-f]+"\)//; s/-[0-9]+.svc/-xxx.svc/')
 
-    echo "waiting for all members to be configured in ${rsName}"
+    echo -n "waiting for all members to be configured in ${rsName}"
     let retry+=1
     if [ $retry -ge 15 ]; then
-      echo "Max retry count $retry reached. something went wrong with mongo cluster. Config for endpoint $endpoint has $nodes_amount but expected 6."
+      echo "Max retry count ${retry} reached. something went wrong with mongo cluster. Config for endpoint ${endpoint} has ${nodes_count} but expected ${target_count}."
       exit 1
     fi
-    echo -n .
+    echo .
     sleep 10
   done
 }
@@ -164,9 +166,9 @@ kubectl_bin patch psmdb ${main_cluster} --type=merge --patch '{
 			  }
 		}'
 
-wait_for_members $replica_cfg_0_endpoint cfg
-wait_for_members $replica_rs0_0_endpoint rs0
-wait_for_members $replica_rs1_0_endpoint rs1
+wait_for_members $replica_cfg_0_endpoint cfg 6
+wait_for_members $replica_rs0_0_endpoint rs0 6
+wait_for_members $replica_rs1_0_endpoint rs1 6
 
 kubectl_bin config set-context $(kubectl_bin config current-context) --namespace="$replica_namespace"
 

--- a/pkg/apis/psmdb/v1/psmdb_defaults.go
+++ b/pkg/apis/psmdb/v1/psmdb_defaults.go
@@ -589,10 +589,6 @@ func (cr *PerconaServerMongoDB) CheckNSetDefaults(platform version.Platform, log
 		cr.Spec.ClusterServiceDNSMode = DNSModeInternal
 	}
 
-	if cr.Spec.Unmanaged && cr.Spec.Backup.Enabled {
-		return errors.New("backup.enabled must be false on unmanaged clusters")
-	}
-
 	if cr.Spec.Unmanaged && cr.Spec.UpdateStrategy == SmartUpdateStatefulSetStrategyType {
 		return errors.New("SmartUpdate is not allowed on unmanaged clusters, set updateStrategy to RollingUpdate or OnDelete")
 	}

--- a/pkg/apis/psmdb/v1/psmdb_types.go
+++ b/pkg/apis/psmdb/v1/psmdb_types.go
@@ -1160,10 +1160,6 @@ func (cr *PerconaServerMongoDB) MongosNamespacedName() types.NamespacedName {
 func (cr *PerconaServerMongoDB) CanBackup(ctx context.Context) error {
 	logf.FromContext(ctx).V(1).Info("checking if backup is allowed", "backup", cr.Name)
 
-	if cr.Spec.Unmanaged {
-		return errors.Errorf("backups are not allowed on unmanaged clusters")
-	}
-
 	if cr.Status.State == AppStateReady {
 		return nil
 	}

--- a/pkg/apis/psmdb/v1/psmdb_types.go
+++ b/pkg/apis/psmdb/v1/psmdb_types.go
@@ -1158,7 +1158,8 @@ func (cr *PerconaServerMongoDB) MongosNamespacedName() types.NamespacedName {
 }
 
 func (cr *PerconaServerMongoDB) CanBackup(ctx context.Context) error {
-	logf.FromContext(ctx).V(1).Info("checking if backup is allowed", "backup", cr.Name)
+	log := logf.FromContext(ctx).V(1).WithValues("cluster", cr.Name, "namespace", cr.Namespace)
+	log.Info("checking if backup is allowed")
 
 	if cr.Status.State == AppStateReady {
 		return nil
@@ -1176,6 +1177,17 @@ func (cr *PerconaServerMongoDB) CanBackup(ctx context.Context) error {
 		if rs.Ready < int32(1) {
 			return errors.New(rsName + " has no ready nodes")
 		}
+	}
+
+	return nil
+}
+
+func (cr *PerconaServerMongoDB) CanRestore(ctx context.Context) error {
+	log := logf.FromContext(ctx).V(1).WithValues("cluster", cr.Name, "namespace", cr.Namespace)
+	log.Info("checking if restore is allowed")
+
+	if cr.Spec.Unmanaged {
+		return errors.New("can't run restore in an unmanaged cluster")
 	}
 
 	return nil

--- a/pkg/controller/perconaservermongodbbackup/backup.go
+++ b/pkg/controller/perconaservermongodbbackup/backup.go
@@ -199,11 +199,7 @@ func (b *Backup) Status(ctx context.Context, cr *api.PerconaServerMongoDBBackup)
 func backupPods(replsets []pbmBackup.BackupReplset) map[string]string {
 	pods := make(map[string]string)
 	for _, rs := range replsets {
-		spl := strings.Split(rs.Node, ".")
-		if len(spl) == 0 {
-			continue
-		}
-		pods[rs.Name] = spl[0]
+		pods[rs.Name] = rs.Node
 	}
 	return pods
 }

--- a/pkg/controller/perconaservermongodbrestore/perconaservermongodbrestore_controller.go
+++ b/pkg/controller/perconaservermongodbrestore/perconaservermongodbrestore_controller.go
@@ -153,15 +153,19 @@ func (r *ReconcilePerconaServerMongoDBRestore) Reconcile(ctx context.Context, re
 		return reconcile.Result{}, nil
 	}
 
-	bcp, err := r.getBackup(ctx, cr)
-	if err != nil {
-		return rr, errors.Wrap(err, "get backup")
-	}
-
 	cluster := new(psmdbv1.PerconaServerMongoDB)
 	err = r.client.Get(ctx, types.NamespacedName{Name: cr.Spec.ClusterName, Namespace: cr.Namespace}, cluster)
 	if err != nil {
 		return rr, errors.Wrapf(err, "get cluster %s/%s", cr.Namespace, cr.Spec.ClusterName)
+	}
+
+	if err = cluster.CanRestore(ctx); err != nil {
+		return reconcile.Result{}, errors.Wrap(err, "can cluster restore")
+	}
+
+	bcp, err := r.getBackup(ctx, cr)
+	if err != nil {
+		return rr, errors.Wrap(err, "get backup")
 	}
 
 	var svr *version.ServerVersion

--- a/pkg/psmdb/backup/pbm.go
+++ b/pkg/psmdb/backup/pbm.go
@@ -639,7 +639,7 @@ func (b *pbmC) Node(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	return strings.Split(lock.Node, ".")[0], nil
+	return lock.Node, nil
 }
 
 func (b *pbmC) GetStorage(ctx context.Context, e pbmLog.LogEvent) (storage.Storage, error) {


### PR DESCRIPTION
[![K8SPSMDB-1205](https://badgen.net/badge/JIRA/K8SPSMDB-1205/green)](https://jira.percona.com/browse/K8SPSMDB-1205) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
We don't allow users to run backups in unmanaged clusters.

**Cause:**
We deliberately added this limitation to prevent confusing users. If you run a backup in an unmanaged (and secondary) cluster, backup object will be created in unmanaged cluster but you won't be able to restore it in the same cluster.

**Solution:**
We're removing the limitation. Technically, we don't need to do much thanks to distributed architecture of PBM. Users can now run backups either in managed or unmanaged clusters. pbm-agent instances will select a node to take backup from among themselves.

> [!WARNING]
> There are some caveats which might be confusing:
> 1. Even if the backup is started in primary (managed) cluster, most likely **it'll actually be taken from a secondary even if it's in a separate cluster**. This is because PBM automatically assigns a lower priority to primary member so backup won't have any negative effect on write performance. Users have the chance the provide a custom PBM configuration to change this behavior.
> 2. Even though you can run backups in unmanaged clusters, **you can't run restores** on them.
> 3. PBM configuration is shared across all clusters, since it's stored in MongoDB. Operator will reconfigure PBM every time it runs a backup and **setting PBM configuration in one cluster will affect the others too**. For example if you set `oplogSpanMin` to `2` in a secondary cluster, this will be applied to primary cluster too. 

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [x] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported MongoDB version?
- [x] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-1205]: https://perconadev.atlassian.net/browse/K8SPSMDB-1205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ