### PR TITLE
K8SPSMDB-675: Fix constantly updated status conditions

### DIFF
--- a/e2e-tests/expose-sharded/compare/statefulset_some-name-cfg-4-oc.yml
+++ b/e2e-tests/expose-sharded/compare/statefulset_some-name-cfg-4-oc.yml
@@ -162,13 +162,13 @@ spec:
             - name: PBM_AGENT_MONGODB_USERNAME
               valueFrom:
                 secretKeyRef:
-                  key: MONGODB_BACKUP_USER
+                  key: MONGODB_BACKUP_USER_ESCAPED
                   name: internal-some-name-users
                   optional: false
             - name: PBM_AGENT_MONGODB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  key: MONGODB_BACKUP_PASSWORD
+                  key: MONGODB_BACKUP_PASSWORD_ESCAPED
                   name: internal-some-name-users
                   optional: false
             - name: PBM_MONGODB_REPLSET

--- a/e2e-tests/expose-sharded/compare/statefulset_some-name-cfg-oc.yml
+++ b/e2e-tests/expose-sharded/compare/statefulset_some-name-cfg-oc.yml
@@ -162,13 +162,13 @@ spec:
             - name: PBM_AGENT_MONGODB_USERNAME
               valueFrom:
                 secretKeyRef:
-                  key: MONGODB_BACKUP_USER
+                  key: MONGODB_BACKUP_USER_ESCAPED
                   name: internal-some-name-users
                   optional: false
             - name: PBM_AGENT_MONGODB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  key: MONGODB_BACKUP_PASSWORD
+                  key: MONGODB_BACKUP_PASSWORD_ESCAPED
                   name: internal-some-name-users
                   optional: false
             - name: PBM_MONGODB_REPLSET

--- a/e2e-tests/expose-sharded/compare/statefulset_some-name-cfg.yml
+++ b/e2e-tests/expose-sharded/compare/statefulset_some-name-cfg.yml
@@ -163,13 +163,13 @@ spec:
             - name: PBM_AGENT_MONGODB_USERNAME
               valueFrom:
                 secretKeyRef:
-                  key: MONGODB_BACKUP_USER
+                  key: MONGODB_BACKUP_USER_ESCAPED
                   name: internal-some-name-users
                   optional: false
             - name: PBM_AGENT_MONGODB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  key: MONGODB_BACKUP_PASSWORD
+                  key: MONGODB_BACKUP_PASSWORD_ESCAPED
                   name: internal-some-name-users
                   optional: false
             - name: PBM_MONGODB_REPLSET

--- a/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0-4-oc.yml
+++ b/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0-4-oc.yml
@@ -160,13 +160,13 @@ spec:
             - name: PBM_AGENT_MONGODB_USERNAME
               valueFrom:
                 secretKeyRef:
-                  key: MONGODB_BACKUP_USER
+                  key: MONGODB_BACKUP_USER_ESCAPED
                   name: internal-some-name-users
                   optional: false
             - name: PBM_AGENT_MONGODB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  key: MONGODB_BACKUP_PASSWORD
+                  key: MONGODB_BACKUP_PASSWORD_ESCAPED
                   name: internal-some-name-users
                   optional: false
             - name: PBM_MONGODB_REPLSET

--- a/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0-oc.yml
@@ -160,13 +160,13 @@ spec:
             - name: PBM_AGENT_MONGODB_USERNAME
               valueFrom:
                 secretKeyRef:
-                  key: MONGODB_BACKUP_USER
+                  key: MONGODB_BACKUP_USER_ESCAPED
                   name: internal-some-name-users
                   optional: false
             - name: PBM_AGENT_MONGODB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  key: MONGODB_BACKUP_PASSWORD
+                  key: MONGODB_BACKUP_PASSWORD_ESCAPED
                   name: internal-some-name-users
                   optional: false
             - name: PBM_MONGODB_REPLSET

--- a/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0-sharding-disabled-oc.yml
+++ b/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0-sharding-disabled-oc.yml
@@ -159,13 +159,13 @@ spec:
             - name: PBM_AGENT_MONGODB_USERNAME
               valueFrom:
                 secretKeyRef:
-                  key: MONGODB_BACKUP_USER
+                  key: MONGODB_BACKUP_USER_ESCAPED
                   name: internal-some-name-users
                   optional: false
             - name: PBM_AGENT_MONGODB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  key: MONGODB_BACKUP_PASSWORD
+                  key: MONGODB_BACKUP_PASSWORD_ESCAPED
                   name: internal-some-name-users
                   optional: false
             - name: PBM_MONGODB_REPLSET

--- a/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0-sharding-disabled.yml
+++ b/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0-sharding-disabled.yml
@@ -160,13 +160,13 @@ spec:
             - name: PBM_AGENT_MONGODB_USERNAME
               valueFrom:
                 secretKeyRef:
-                  key: MONGODB_BACKUP_USER
+                  key: MONGODB_BACKUP_USER_ESCAPED
                   name: internal-some-name-users
                   optional: false
             - name: PBM_AGENT_MONGODB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  key: MONGODB_BACKUP_PASSWORD
+                  key: MONGODB_BACKUP_PASSWORD_ESCAPED
                   name: internal-some-name-users
                   optional: false
             - name: PBM_MONGODB_REPLSET

--- a/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0-sharding-enabled-oc.yml
+++ b/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0-sharding-enabled-oc.yml
@@ -160,13 +160,13 @@ spec:
             - name: PBM_AGENT_MONGODB_USERNAME
               valueFrom:
                 secretKeyRef:
-                  key: MONGODB_BACKUP_USER
+                  key: MONGODB_BACKUP_USER_ESCAPED
                   name: internal-some-name-users
                   optional: false
             - name: PBM_AGENT_MONGODB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  key: MONGODB_BACKUP_PASSWORD
+                  key: MONGODB_BACKUP_PASSWORD_ESCAPED
                   name: internal-some-name-users
                   optional: false
             - name: PBM_MONGODB_REPLSET

--- a/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0-sharding-enabled.yml
+++ b/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0-sharding-enabled.yml
@@ -161,13 +161,13 @@ spec:
             - name: PBM_AGENT_MONGODB_USERNAME
               valueFrom:
                 secretKeyRef:
-                  key: MONGODB_BACKUP_USER
+                  key: MONGODB_BACKUP_USER_ESCAPED
                   name: internal-some-name-users
                   optional: false
             - name: PBM_AGENT_MONGODB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  key: MONGODB_BACKUP_PASSWORD
+                  key: MONGODB_BACKUP_PASSWORD_ESCAPED
                   name: internal-some-name-users
                   optional: false
             - name: PBM_MONGODB_REPLSET

--- a/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0.yml
@@ -161,13 +161,13 @@ spec:
             - name: PBM_AGENT_MONGODB_USERNAME
               valueFrom:
                 secretKeyRef:
-                  key: MONGODB_BACKUP_USER
+                  key: MONGODB_BACKUP_USER_ESCAPED
                   name: internal-some-name-users
                   optional: false
             - name: PBM_AGENT_MONGODB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  key: MONGODB_BACKUP_PASSWORD
+                  key: MONGODB_BACKUP_PASSWORD_ESCAPED
                   name: internal-some-name-users
                   optional: false
             - name: PBM_MONGODB_REPLSET

--- a/e2e-tests/run-pr.csv
+++ b/e2e-tests/run-pr.csv
@@ -43,6 +43,7 @@ service-per-pod
 serviceless-external-nodes
 smart-update
 split-horizon
+stable-resource-version
 storage
 tls-issue-cert-manager
 upgrade

--- a/e2e-tests/run-release.csv
+++ b/e2e-tests/run-release.csv
@@ -44,6 +44,7 @@ service-per-pod
 serviceless-external-nodes
 smart-update
 split-horizon
+stable-resource-version
 storage
 tls-issue-cert-manager
 upgrade

--- a/e2e-tests/stable-resource-version/conf/some-name.yml
+++ b/e2e-tests/stable-resource-version/conf/some-name.yml
@@ -1,0 +1,74 @@
+apiVersion: psmdb.percona.com/v1
+kind: PerconaServerMongoDB
+metadata:
+  name: some-name
+spec:
+  #platform: openshift
+  image:
+  imagePullPolicy: Always
+
+  tls:
+    mode: requireTLS
+
+  sharding:
+    enabled: true
+
+    configsvrReplSet:
+      size: 3
+      affinity:
+        antiAffinityTopologyKey: none
+      volumeSpec:
+        persistentVolumeClaim:
+          resources:
+            requests:
+              storage: 3Gi
+
+    mongos:
+      size: 3
+      affinity:
+        antiAffinityTopologyKey: none
+      expose:
+        type: ClusterIP
+
+  replsets:
+
+  - name: rs0
+    affinity:
+      antiAffinityTopologyKey: none
+    resources:
+      limits:
+        cpu: 500m
+        memory: 1G
+      requests:
+        cpu: 100m
+        memory: 0.1G
+    volumeSpec:
+      persistentVolumeClaim:
+        resources:
+          requests:
+            storage: 1Gi
+    size: 3
+    configuration: |
+      operationProfiling:
+        mode: slowOp
+        slowOpThresholdMs: 100
+      security:
+        enableEncryption: true
+        redactClientLogData: false
+      setParameter:
+        ttlMonitorSleepSecs: 60
+        wiredTigerConcurrentReadTransactions: 128
+        wiredTigerConcurrentWriteTransactions: 128
+      storage:
+        engine: wiredTiger
+        wiredTiger:
+          collectionConfig:
+            blockCompressor: snappy
+          engineConfig:
+            directoryForIndexes: false
+            journalCompressor: snappy
+          indexConfig:
+            prefixCompression: true
+
+  secrets:
+    users: some-users

--- a/e2e-tests/stable-resource-version/run
+++ b/e2e-tests/stable-resource-version/run
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -o errexit
+
+test_dir=$(realpath $(dirname $0))
+. ${test_dir}/../functions
+set_debug
+
+cluster="some-name"
+
+create_infra ${namespace}
+
+desc "create PSMDB cluster ${cluster}"
+apply_cluster ${test_dir}/conf/${cluster}.yml
+
+desc 'check if all pods started'
+wait_for_running ${cluster}-rs0 3 "false"
+wait_for_running ${cluster}-cfg 3 "false"
+wait_for_running ${cluster}-mongos 3 "false"
+
+wait_cluster_consistency ${cluster}
+
+desc 'check if .metadata.resourceVersion is stable'
+
+initial_resource_version=$(kubectl_bin get psmdb ${cluster} -o jsonpath={.metadata.resourceVersion})
+for i in $(seq 1 5); do
+	sleep 7  # wait for a reconciliation loop
+	echo -n "check ${i}: expected resourceVersion is ${initial_resource_version}"
+	resource_version=$(kubectl_bin get psmdb ${cluster} -o jsonpath={.metadata.resourceVersion})
+	if [[ ${initial_resource_version} != ${resource_version} ]]; then
+		echo "...FAIL! .metadata.resourceVersion is ${resource_version}"
+		exit 1
+	fi
+	echo "...OK"
+done
+
+desc 'test passed'
+
+exit 0

--- a/pkg/apis/psmdb/v1/psmdb_types.go
+++ b/pkg/apis/psmdb/v1/psmdb_types.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/go-logr/logr"
@@ -1206,13 +1207,30 @@ func (cr *PerconaServerMongoDB) CanRestore(ctx context.Context) error {
 }
 
 func (s *PerconaServerMongoDBStatus) AddCondition(c ClusterCondition) {
-	for i, cond := range s.Conditions {
-		if cond.Type != c.Type {
-			continue
+	existingCondition := s.FindCondition(c.Type)
+	if existingCondition == nil {
+		if c.LastTransitionTime.IsZero() {
+			c.LastTransitionTime = metav1.NewTime(time.Now())
 		}
-		s.Conditions[i] = c
+		s.Conditions = append(s.Conditions, c)
+		return
 	}
-	s.Conditions = append(s.Conditions, c)
+
+	if existingCondition.Status != c.Status {
+		existingCondition.Status = c.Status
+		if !c.LastTransitionTime.IsZero() {
+			existingCondition.LastTransitionTime = c.LastTransitionTime
+		} else {
+			existingCondition.LastTransitionTime = metav1.NewTime(time.Now())
+		}
+	}
+
+	if existingCondition.Reason != c.Reason {
+		existingCondition.Reason = c.Reason
+	}
+	if existingCondition.Message != c.Message {
+		existingCondition.Message = c.Message
+	}
 }
 
 // GetExternalNodes returns all external nodes for all replsets

--- a/pkg/controller/perconaservermongodb/psmdb_controller.go
+++ b/pkg/controller/perconaservermongodb/psmdb_controller.go
@@ -1473,7 +1473,21 @@ func (r *ReconcilePerconaServerMongoDB) reconcilePDB(ctx context.Context, cr *ap
 }
 
 func (r *ReconcilePerconaServerMongoDB) createOrUpdate(ctx context.Context, obj client.Object) error {
-	_, err := util.Apply(ctx, r.client, obj)
+	log := logf.FromContext(ctx).WithValues(
+		"name", obj.GetName(),
+		"kind", obj.GetObjectKind(),
+		"generation", obj.GetGeneration(),
+		"resourceVersion", obj.GetResourceVersion(),
+	)
+
+	status, err := util.Apply(ctx, r.client, obj)
+
+	switch status {
+	case util.ApplyStatusCreated:
+		log.V(1).Info("Object created")
+	case util.ApplyStatusUpdated:
+		log.V(1).Info("Object updated")
+	}
 	return err
 }
 

--- a/pkg/controller/perconaservermongodb/version.go
+++ b/pkg/controller/perconaservermongodb/version.go
@@ -440,7 +440,7 @@ func (r *ReconcilePerconaServerMongoDB) scheduleTelemetryRequests(ctx context.Co
 			return
 		}
 
-		err = localCr.CheckNSetDefaults(r.serverVersion.Platform, log)
+		err = localCr.CheckNSetDefaults(ctx, r.serverVersion.Platform)
 		if err != nil {
 			log.Error(err, "failed to set defaults for CR")
 			return


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
Operator constantly updates status conditions.

**Solution:**
Fix the problem with updating conditions and add an e2e test to check if resourceVersion is stable.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
