### PR TITLE
K8SPSMDB-1164: Prevent $external DB user from dealing with passwords

### DIFF
--- a/pkg/apis/psmdb/v1/psmdb_types.go
+++ b/pkg/apis/psmdb/v1/psmdb_types.go
@@ -119,6 +119,10 @@ func (u *User) UserID() string {
 	return u.DB + "." + u.Name
 }
 
+func (u *User) IsExternalDB() bool {
+	return u.DB == "$external"
+}
+
 type RoleAuthenticationRestriction struct {
 	ClientSource  []string `json:"clientSource,omitempty"`
 	ServerAddress []string `json:"serverAddress,omitempty"`


### PR DESCRIPTION
[![K8SPSMDB-1164](https://badgen.net/badge/JIRA/K8SPSMDB-1164/green)](https://jira.percona.com/browse/K8SPSMDB-1164) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
In certain situations, the operator can attempt to update the password for a user with a `$external` DB set. Also, for this user the operator generates the password and stores it in the generated custom user secret.

The `$externalDB` user's password is in an external system like LDAB and the operator shouldn't do anything password-related for users like this.


**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?
- [x] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files?
- [x] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [x] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported MongoDB version?
- [x] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-1164]: https://perconadev.atlassian.net/browse/K8SPSMDB-1164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ