### PR TITLE
K8SPSMDB-1109: Fix demand-backup-fs on EKS

### DIFF
--- a/e2e-tests/demand-backup-fs/run
+++ b/e2e-tests/demand-backup-fs/run
@@ -10,8 +10,8 @@ deploy_nfs_server() {
 	kubectl_bin create namespace storage
 	kubectl_bin apply -n storage -f ${test_dir}/conf/nfs-server.yaml
 	sleep 5 # wait for NFS server pod to be created
-	local nfsPod=$(kubectl_bin get pod -n storage -l app=nfs-server -o jsonpath={.items[].metadata.name})
 
+	local nfsPod=$(kubectl_bin get pod -n storage -l app=nfs-server -o jsonpath={.items[].metadata.name})
 	until [[ "$(kubectl_bin get pod ${nfsPod} -n storage -o jsonpath={.status.phase})" == "Running" ]]; do
 		log "Waiting for ${nfsPod} to start Running"
 		sleep 1
@@ -50,6 +50,11 @@ create_infra ${namespace}
 
 kubectl_bin delete ns storage || :
 
+if [[ $EKS == 1 || -n ${OPENSHIFT} ]]; then
+	sc=$(kubectl_bin get storageclass | tail -1  | awk '{print $1}')
+	kubectl_bin annotate storageclass ${sc} storageclass.kubernetes.io/is-default-class=true
+fi
+
 log "deploying NFS server"
 deploy_nfs_server
 
@@ -59,13 +64,21 @@ kubectl_bin apply \
 	-f "${conf_dir}/client.yml"
 
 log "creating PSMDB cluster ${cluster}"
-apply_cluster ${test_dir}/conf/${cluster}.yaml
+if [[ $EKS == 1 || -n ${OPENSHIFT} ]]; then
+	nfs_ip=$(kubectl_bin -n storage get svc nfs-service -o jsonpath={.spec.clusterIP})
+	sed "s/nfs-service.storage.svc.cluster.local/${nfs_ip}/g" ${test_dir}/conf/${cluster}.yaml \
+		| kubectl_bin apply -f -
+else
+	apply_cluster ${test_dir}/conf/${cluster}.yaml
+fi
 
 log 'wait for all 3 pods to start'
 wait_for_running ${cluster}-rs0 3
 
-log 'checking if statefulset created with expected config'
-compare_kubectl statefulset/${cluster}-rs0
+if [[ $EKS -ne 1 && -z ${OPENSHIFT} ]]; then
+	log 'checking if statefulset created with expected config'
+	compare_kubectl statefulset/${cluster}-rs0
+fi
 
 log 'creating user'
 run_mongo \


### PR DESCRIPTION
[![K8SPSMDB-1109](https://badgen.net/badge/JIRA/K8SPSMDB-1109/green)](https://jira.percona.com/browse/K8SPSMDB-1109) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
Two problems on EKS:
1. There's no default storage class.
2. NFS mounts using FQDN of the service doesn't work.

**Solution:**
1. Set default storage class.
2. Use IP instead of FQDN for NFS mount.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-1109]: https://perconadev.atlassian.net/browse/K8SPSMDB-1109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ