### PR TITLE
K8SPSMDB-1248 Add wait_for_running check after cluster creation in self-healing-chaos tests

### DIFF
--- a/e2e-tests/self-healing-chaos/run
+++ b/e2e-tests/self-healing-chaos/run
@@ -30,10 +30,11 @@ setup_cluster() {
 	desc "create first PSMDB cluster $cluster"
 	apply_cluster $conf_dir/$cluster.yml
 
+	wait_for_running "$cluster" 3
+
 	desc "enable backups"
 	kubectl_bin patch psmdb some-name --type='merge' -p '{"spec":{"backup":{"enabled":true}}}'
 
-	# check if all 3 Pods started
 	wait_for_running "$cluster" 3
 
 	desc 'create user myApp'


### PR DESCRIPTION
[![K8SPSMDB-1248](https://badgen.net/badge/JIRA/K8SPSMDB-1248/green)](https://jira.percona.com/browse/K8SPSMDB-1248) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
Test case `wait_for_running` fails on Minikube just before [enable backups](https://github.com/percona/percona-server-mongodb-operator/blob/31622a4d2b8eb5e020dfe81227469ea9f546335c/e2e-tests/self-healing-chaos/run#L34) and the cluster ends up in "error" state.

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
I thought that we shouldn't care whether the cluster is ready or not and it's Kubernetes' duty to queue my requests and apply them when the right time comes. However, Kubernetes itself does not enforce application-specific logic. We should allow the initialization process to complete, ensuring the core components (e.g., the replica set, storage volumes) are fully operational and then enable backups. Adding `wait_for_running` before doing anything else just like in every test case.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-1248]: https://perconadev.atlassian.net/browse/K8SPSMDB-1248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ