### PR TITLE
K8SPSMDB-1224: Fix secretKeyRef key in demand-backup-eks-credentials-irsa test

### DIFF
--- a/e2e-tests/demand-backup-eks-credentials-irsa/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/demand-backup-eks-credentials-irsa/compare/statefulset_some-name-rs0.yml
@@ -150,13 +150,13 @@ spec:
             - name: PBM_AGENT_MONGODB_USERNAME
               valueFrom:
                 secretKeyRef:
-                  key: MONGODB_BACKUP_USER
+                  key: MONGODB_BACKUP_USER_ESCAPED
                   name: internal-some-name-users
                   optional: false
             - name: PBM_AGENT_MONGODB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  key: MONGODB_BACKUP_PASSWORD
+                  key: MONGODB_BACKUP_PASSWORD_ESCAPED
                   name: internal-some-name-users
                   optional: false
             - name: PBM_MONGODB_REPLSET


### PR DESCRIPTION
[![K8SPSMDB-1224](https://badgen.net/badge/JIRA/K8SPSMDB-1224/green)](https://jira.percona.com/browse/K8SPSMDB-1224) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
Compare file is using outdated backup user and password.

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
Update to the correct user and password.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-1224]: https://perconadev.atlassian.net/browse/K8SPSMDB-1224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ