### PR TITLE
K8SPSMDB-1249: Fix smart update for pods that are not member of replset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ uninstall: manifests ## Uninstall CRDs, rbac
 deploy: ## Deploy operator
 	yq eval '(.spec.template.spec.containers[] | select(.name=="percona-server-mongodb-operator")).image = "$(IMAGE)"' $(DEPLOYDIR)/operator.yaml \
 		| yq eval '(.spec.template.spec.containers[] | select(.name=="percona-server-mongodb-operator").env[] | select(.name=="LOG_LEVEL")).value="DEBUG"' - \
+		| yq eval '(.spec.template.spec.containers[] | select(.name=="percona-server-mongodb-operator").env[] | select(.name=="DISABLE_TELEMETRY")).value="true"' - \
 		| kubectl apply -f -
 
 undeploy: ## Undeploy operator

--- a/config/crd/bases/psmdb.percona.com_perconaservermongodbs.yaml
+++ b/config/crd/bases/psmdb.percona.com_perconaservermongodbs.yaml
@@ -18849,14 +18849,16 @@ spec:
                     initialized:
                       type: boolean
                     members:
-                      items:
+                      additionalProperties:
                         properties:
                           name:
                             type: string
-                          version:
+                          state:
+                            type: integer
+                          stateStr:
                             type: string
                         type: object
-                      type: array
+                      type: object
                     message:
                       type: string
                     ready:

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -19545,14 +19545,16 @@ spec:
                     initialized:
                       type: boolean
                     members:
-                      items:
+                      additionalProperties:
                         properties:
                           name:
                             type: string
-                          version:
+                          state:
+                            type: integer
+                          stateStr:
                             type: string
                         type: object
-                      type: array
+                      type: object
                     message:
                       type: string
                     ready:

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -19545,14 +19545,16 @@ spec:
                     initialized:
                       type: boolean
                     members:
-                      items:
+                      additionalProperties:
                         properties:
                           name:
                             type: string
-                          version:
+                          state:
+                            type: integer
+                          stateStr:
                             type: string
                         type: object
-                      type: array
+                      type: object
                     message:
                       type: string
                     ready:

--- a/deploy/cw-bundle.yaml
+++ b/deploy/cw-bundle.yaml
@@ -19545,14 +19545,16 @@ spec:
                     initialized:
                       type: boolean
                     members:
-                      items:
+                      additionalProperties:
                         properties:
                           name:
                             type: string
-                          version:
+                          state:
+                            type: integer
+                          stateStr:
                             type: string
                         type: object
-                      type: array
+                      type: object
                     message:
                       type: string
                     ready:

--- a/e2e-tests/default-cr/run
+++ b/e2e-tests/default-cr/run
@@ -43,7 +43,27 @@ function start_cluster() {
 }
 
 function main() {
-	create_infra "$namespace"
+	delete_crd
+	check_crd_for_deletion "${GIT_BRANCH}"
+	kubectl_bin apply ${OPERATOR_NS:+-n $OPERATOR_NS} --server-side --force-conflicts -f $deploy_dir/crd.yaml
+
+	if [ -n "$OPERATOR_NS" ]; then
+		create_namespace $OPERATOR_NS
+		create_namespace ${namespace}
+		apply_rbac cw-rbac
+		yq eval '
+			((.. | select(.[] == "DISABLE_TELEMETRY")) |= .value="true") |
+			((.. | select(.[] == "LOG_LEVEL")) |= .value="DEBUG")' ${src_dir}/deploy/cw-operator.yaml \
+			| kubectl_bin apply -f -
+	else
+		create_namespace ${namespace}
+		apply_rbac rbac
+		yq eval '
+			((.. | select(.[] == "DISABLE_TELEMETRY")) |= .value="true") |
+			((.. | select(.[] == "LOG_LEVEL")) |= .value="DEBUG")' ${src_dir}/deploy/operator.yaml \
+			| kubectl_bin apply -f -
+	fi
+
 	cluster="my-cluster-name"
 
 	desc 'create secrets and start client'
@@ -51,16 +71,6 @@ function main() {
 	kubectl_bin apply -f $conf_dir/client.yml
 
 	desc "create first PSMDB cluster $cluster"
-	kubectl_bin apply ${OPERATOR_NS:+-n $OPERATOR_NS} --server-side --force-conflicts -f $deploy_dir/crd.yaml
-	if [ -n "$OPERATOR_NS" ]; then
-		apply_rbac cw-rbac
-		kubectl_bin apply -n ${OPERATOR_NS} -f $deploy_dir/cw-operator.yaml
-	else
-		apply_rbac rbac
-		yq eval '((.. | select(.[] == "DISABLE_TELEMETRY")) |= .value="true")' "$deploy_dir/operator.yaml" \
-			| kubectl_bin apply -f -
-	fi
-
 	yq eval '.spec.upgradeOptions.versionServiceEndpoint = "https://check-dev.percona.com" |
 		.spec.replsets[].affinity.antiAffinityTopologyKey = "none" |
 		.spec.replsets[].nonvoting.affinity.antiAffinityTopologyKey = "none" |

--- a/e2e-tests/default-cr/run
+++ b/e2e-tests/default-cr/run
@@ -50,17 +50,6 @@ function main() {
 	kubectl_bin apply -f $deploy_dir/secrets.yaml
 	kubectl_bin apply -f $conf_dir/client.yml
 
-	desc "create first PSMDB cluster $cluster"
-	kubectl_bin apply ${OPERATOR_NS:+-n $OPERATOR_NS} --server-side --force-conflicts -f $deploy_dir/crd.yaml
-	if [ -n "$OPERATOR_NS" ]; then
-		apply_rbac cw-rbac
-		kubectl_bin apply -n ${OPERATOR_NS} -f $deploy_dir/cw-operator.yaml
-	else
-		apply_rbac rbac
-		yq eval '((.. | select(.[] == "DISABLE_TELEMETRY")) |= .value="true")' "$deploy_dir/operator.yaml" \
-			| kubectl_bin apply -f -
-	fi
-
 	yq eval '.spec.upgradeOptions.versionServiceEndpoint = "https://check-dev.percona.com" |
 		.spec.replsets[].affinity.antiAffinityTopologyKey = "none" |
 		.spec.replsets[].nonvoting.affinity.antiAffinityTopologyKey = "none" |

--- a/e2e-tests/default-cr/run
+++ b/e2e-tests/default-cr/run
@@ -50,6 +50,17 @@ function main() {
 	kubectl_bin apply -f $deploy_dir/secrets.yaml
 	kubectl_bin apply -f $conf_dir/client.yml
 
+	desc "create first PSMDB cluster $cluster"
+	kubectl_bin apply ${OPERATOR_NS:+-n $OPERATOR_NS} --server-side --force-conflicts -f $deploy_dir/crd.yaml
+	if [ -n "$OPERATOR_NS" ]; then
+		apply_rbac cw-rbac
+		kubectl_bin apply -n ${OPERATOR_NS} -f $deploy_dir/cw-operator.yaml
+	else
+		apply_rbac rbac
+		yq eval '((.. | select(.[] == "DISABLE_TELEMETRY")) |= .value="true")' "$deploy_dir/operator.yaml" \
+			| kubectl_bin apply -f -
+	fi
+
 	yq eval '.spec.upgradeOptions.versionServiceEndpoint = "https://check-dev.percona.com" |
 		.spec.replsets[].affinity.antiAffinityTopologyKey = "none" |
 		.spec.replsets[].nonvoting.affinity.antiAffinityTopologyKey = "none" |

--- a/e2e-tests/preinit-updates/conf/some-name.yml
+++ b/e2e-tests/preinit-updates/conf/some-name.yml
@@ -1,0 +1,55 @@
+apiVersion: psmdb.percona.com/v1
+kind: PerconaServerMongoDB
+metadata:
+  name: some-name
+spec:
+  #platform: openshift
+  image:
+  imagePullPolicy: Always
+  allowUnsafeConfigurations: false
+  updateStrategy: SmartUpdate
+  backup:
+    enabled: false
+    image: perconalab/percona-server-mongodb-operator:0.4.0-backup
+  replsets:
+  - name: rs0
+    # readinessDelaySec: 40
+    # livenessDelaySec: 120
+    affinity:
+      antiAffinityTopologyKey: none
+    resources:
+      limits:
+        cpu: 500m
+        memory: 0.5G
+      requests:
+        cpu: 100m
+        memory: 0.1G
+    configuration: |
+      operationProfiling:
+        mode: slowOp
+        slowOpThresholdMs: 100
+      security:
+        enableEncryption: true
+        redactClientLogData: false
+      setParameter:
+        ttlMonitorSleepSecs: 60
+        wiredTigerConcurrentReadTransactions: 128
+        wiredTigerConcurrentWriteTransactions: 128
+      storage:
+        engine: wiredTiger
+        wiredTiger:
+          collectionConfig:
+            blockCompressor: snappy
+          engineConfig:
+            directoryForIndexes: false
+            journalCompressor: snappy
+          indexConfig:
+            prefixCompression: true
+    volumeSpec:
+      persistentVolumeClaim:
+        resources:
+          requests:
+            storage: 1Gi
+    size: 3
+  secrets:
+    users: some-users

--- a/e2e-tests/preinit-updates/run
+++ b/e2e-tests/preinit-updates/run
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -o errexit
+
+test_dir=$(realpath $(dirname $0))
+. ${test_dir}/../functions
+set_debug
+
+create_infra ${namespace}
+
+cluster="some-name"
+desc "test starts on cluster: ${cluster}"
+
+apply_cluster ${test_dir}/conf/${cluster}.yml
+wait_for_running ${cluster}-rs0 1 "false"
+echo "enabling backups"
+kubectl_bin patch psmdb ${cluster} --type=merge -p '{"spec":{"backup":{"enabled":true}}}'
+echo "sleeping for 7 seconds..."
+sleep 7
+echo "changing rs0 resources"
+kubectl_bin patch psmdb ${cluster} --type=json -p '[{"op":"replace","path":"/spec/replsets/0/resources/limits/cpu","value":"550m"}]'
+
+wait_for_running ${cluster}-rs0 3
+wait_cluster_consistency "${cluster}"
+
+desc 'test passed'
+
+destroy $namespace

--- a/e2e-tests/run-pr.csv
+++ b/e2e-tests/run-pr.csv
@@ -31,6 +31,7 @@ operator-self-healing-chaos
 pitr
 pitr-sharded
 pitr-physical
+preinit-updates
 pvc-resize
 recover-no-primary
 replset-overrides

--- a/e2e-tests/run-release.csv
+++ b/e2e-tests/run-release.csv
@@ -32,6 +32,7 @@ operator-self-healing-chaos
 pitr
 pitr-sharded
 pitr-physical
+preinit-updates
 pvc-resize
 recover-no-primary
 replset-overrides

--- a/e2e-tests/version-service/conf/crd.yaml
+++ b/e2e-tests/version-service/conf/crd.yaml
@@ -19545,14 +19545,16 @@ spec:
                     initialized:
                       type: boolean
                     members:
-                      items:
+                      additionalProperties:
                         properties:
                           name:
                             type: string
-                          version:
+                          state:
+                            type: integer
+                          stateStr:
                             type: string
                         type: object
-                      type: array
+                      type: object
                     message:
                       type: string
                     ready:

--- a/pkg/apis/psmdb/v1/psmdb_types.go
+++ b/pkg/apis/psmdb/v1/psmdb_types.go
@@ -28,6 +28,7 @@ import (
 	"github.com/percona/percona-backup-mongodb/pbm/defs"
 
 	"github.com/percona/percona-server-mongodb-operator/pkg/mcs"
+	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb/mongo"
 	"github.com/percona/percona-server-mongodb-operator/pkg/util/numstr"
 	"github.com/percona/percona-server-mongodb-operator/version"
 )
@@ -234,8 +235,9 @@ type UpgradeOptions struct {
 }
 
 type ReplsetMemberStatus struct {
-	Name    string `json:"name,omitempty"`
-	Version string `json:"version,omitempty"`
+	Name     string            `json:"name,omitempty"`
+	State    mongo.MemberState `json:"state,omitempty"`
+	StateStr string            `json:"stateStr,omitempty"`
 }
 
 type MongosStatus struct {
@@ -246,8 +248,8 @@ type MongosStatus struct {
 }
 
 type ReplsetStatus struct {
-	Members     []*ReplsetMemberStatus `json:"members,omitempty"`
-	ClusterRole ClusterRole            `json:"clusterRole,omitempty"`
+	Members     map[string]ReplsetMemberStatus `json:"members,omitempty"`
+	ClusterRole ClusterRole                    `json:"clusterRole,omitempty"`
 
 	Initialized  bool     `json:"initialized,omitempty"`
 	AddedAsShard *bool    `json:"added_as_shard,omitempty"`

--- a/pkg/apis/psmdb/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/psmdb/v1/zz_generated.deepcopy.go
@@ -1633,13 +1633,9 @@ func (in *ReplsetStatus) DeepCopyInto(out *ReplsetStatus) {
 	*out = *in
 	if in.Members != nil {
 		in, out := &in.Members, &out.Members
-		*out = make([]*ReplsetMemberStatus, len(*in))
-		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(ReplsetMemberStatus)
-				**out = **in
-			}
+		*out = make(map[string]ReplsetMemberStatus, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
 		}
 	}
 	if in.AddedAsShard != nil {

--- a/pkg/controller/perconaservermongodb/finalizers.go
+++ b/pkg/controller/perconaservermongodb/finalizers.go
@@ -120,7 +120,7 @@ func (r *ReconcilePerconaServerMongoDB) deletePSMDBPods(ctx context.Context, cr 
 			rsDeleted = false
 			switch err {
 			case errWaitingTermination, errWaitingFirstPrimary:
-				log.Error(err, "rs", rs.Name)
+				log.Error(err, "deleting rs pods", "rs", rs.Name)
 				continue
 			default:
 				log.Error(err, "failed to delete rs pods", "rs", rs.Name)

--- a/pkg/controller/perconaservermongodb/finalizers.go
+++ b/pkg/controller/perconaservermongodb/finalizers.go
@@ -120,7 +120,7 @@ func (r *ReconcilePerconaServerMongoDB) deletePSMDBPods(ctx context.Context, cr 
 			rsDeleted = false
 			switch err {
 			case errWaitingTermination, errWaitingFirstPrimary:
-				log.Error(err, "deleting rs pods", "rs", rs.Name)
+				log.Info("deleting rs pods", "rs", rs.Name, "status", err.Error())
 				continue
 			default:
 				log.Error(err, "failed to delete rs pods", "rs", rs.Name)

--- a/pkg/controller/perconaservermongodb/mgo.go
+++ b/pkg/controller/perconaservermongodb/mgo.go
@@ -525,8 +525,6 @@ func (r *ReconcilePerconaServerMongoDB) updateConfigMembers(ctx context.Context,
 			}
 		}
 
-		log.V(1).Info("Member state", "member", member.Name, "state", member.State, "stateStr", member.StateStr)
-
 		switch member.State {
 		case mongo.MemberStatePrimary, mongo.MemberStateSecondary, mongo.MemberStateArbiter:
 			liveMembers++

--- a/pkg/controller/perconaservermongodb/mgo.go
+++ b/pkg/controller/perconaservermongodb/mgo.go
@@ -136,7 +136,7 @@ func (r *ReconcilePerconaServerMongoDB) reconcileCluster(ctx context.Context, cr
 			LastTransitionTime: metav1.NewTime(time.Now()),
 		})
 
-		return api.AppStateInit, nil, nil
+		return api.AppStateInit, rs.Members, nil
 	}
 	defer func() {
 		if err := cli.Disconnect(ctx); err != nil {

--- a/pkg/controller/perconaservermongodb/mgo.go
+++ b/pkg/controller/perconaservermongodb/mgo.go
@@ -27,7 +27,7 @@ import (
 
 var errReplsetLimit = fmt.Errorf("maximum replset member (%d) count reached", mongo.MaxMembers)
 
-func (r *ReconcilePerconaServerMongoDB) reconcileCluster(ctx context.Context, cr *api.PerconaServerMongoDB, replset *api.ReplsetSpec, mongosPods []corev1.Pod) (api.AppState, error) {
+func (r *ReconcilePerconaServerMongoDB) reconcileCluster(ctx context.Context, cr *api.PerconaServerMongoDB, replset *api.ReplsetSpec, mongosPods []corev1.Pod) (api.AppState, map[string]api.ReplsetMemberStatus, error) {
 	log := logf.FromContext(ctx)
 
 	replsetSize := replset.Size
@@ -42,20 +42,20 @@ func (r *ReconcilePerconaServerMongoDB) reconcileCluster(ctx context.Context, cr
 
 	restoreInProgress, err := r.restoreInProgress(ctx, cr, replset)
 	if err != nil {
-		return api.AppStateError, errors.Wrap(err, "check if restore in progress")
+		return api.AppStateError, nil, errors.Wrap(err, "check if restore in progress")
 	}
 
 	if restoreInProgress {
-		return api.AppStateInit, nil
+		return api.AppStateInit, nil, nil
 	}
 
 	if replsetSize == 0 {
-		return api.AppStateReady, nil
+		return api.AppStateReady, nil, nil
 	}
 
 	pods, err := psmdb.GetRSPods(ctx, r.client, cr, replset.Name)
 	if err != nil {
-		return api.AppStateInit, errors.Wrap(err, "failed to get replset pods")
+		return api.AppStateInit, nil, errors.Wrap(err, "failed to get replset pods")
 	}
 
 	// all pods needs to be scheduled to reconcile
@@ -63,33 +63,33 @@ func (r *ReconcilePerconaServerMongoDB) reconcileCluster(ctx context.Context, cr
 		for _, pod := range pods.Items {
 			for _, containerStatus := range pod.Status.ContainerStatuses {
 				if containerStatus.State.Waiting != nil && containerStatus.State.Waiting.Reason == "CrashLoopBackOff" {
-					return api.AppStateError, errors.Errorf("pod %s is in CrashLoopBackOff state", pod.Name)
+					return api.AppStateError, nil, errors.Errorf("pod %s is in CrashLoopBackOff state", pod.Name)
 				}
 			}
 		}
 		log.Info("Waiting for the pods", "replset", replset.Name, "size", replsetSize, "pods", len(pods.Items))
-		return api.AppStateInit, nil
+		return api.AppStateInit, nil, nil
 	}
 
 	if cr.MCSEnabled() {
 		seList, err := psmdb.GetExportedServices(ctx, r.client, cr)
 		if err != nil {
-			return api.AppStateError, errors.Wrap(err, "get exported services")
+			return api.AppStateError, nil, errors.Wrap(err, "get exported services")
 		}
 
 		if len(seList.Items) == 0 {
 			log.Info("waiting for service exports")
-			return api.AppStateInit, nil
+			return api.AppStateInit, nil, nil
 		}
 
 		for _, se := range seList.Items {
 			imported, err := psmdb.IsServiceImported(ctx, r.client, cr, se.Name)
 			if err != nil {
-				return api.AppStateError, errors.Wrapf(err, "check if service is imported for %s", se.Name)
+				return api.AppStateError, nil, errors.Wrapf(err, "check if service is imported for %s", se.Name)
 			}
 			if !imported {
 				log.Info("waiting for service import", "replset", replset.Name, "serviceExport", se.Name)
-				return api.AppStateInit, nil
+				return api.AppStateInit, nil, nil
 			}
 		}
 	}
@@ -97,7 +97,7 @@ func (r *ReconcilePerconaServerMongoDB) reconcileCluster(ctx context.Context, cr
 	cli, err := r.mongoClientWithRole(ctx, cr, replset, api.RoleClusterAdmin)
 	if err != nil {
 		if cr.Spec.Unmanaged {
-			return api.AppStateInit, nil
+			return api.AppStateInit, nil, nil
 		}
 		if cr.Status.Replsets[replset.Name].Initialized {
 			if errors.Is(err, topology.ErrServerSelectionTimeout) && strings.Contains(err.Error(), "ReplicaSetNoPrimary") {
@@ -105,23 +105,23 @@ func (r *ReconcilePerconaServerMongoDB) reconcileCluster(ctx context.Context, cr
 
 				err := r.handleReplicaSetNoPrimary(ctx, cr, replset, pods.Items)
 				if err != nil {
-					return api.AppStateError, errors.Wrap(err, "handle ReplicaSetNoPrimary")
+					return api.AppStateError, nil, errors.Wrap(err, "handle ReplicaSetNoPrimary")
 				}
 
-				return api.AppStateError, nil
+				return api.AppStateError, nil, nil
 			}
 
-			return api.AppStateError, errors.Wrap(err, "dial")
+			return api.AppStateError, nil, errors.Wrap(err, "dial")
 		}
 
 		err := r.handleReplsetInit(ctx, cr, replset, pods.Items)
 		if err != nil {
-			return api.AppStateInit, errors.Wrap(err, "handleReplsetInit")
+			return api.AppStateInit, nil, errors.Wrap(err, "handleReplsetInit")
 		}
 
 		err = r.createOrUpdateSystemUsers(ctx, cr, replset)
 		if err != nil {
-			return api.AppStateInit, errors.Wrap(err, "create system users")
+			return api.AppStateInit, nil, errors.Wrap(err, "create system users")
 		}
 
 		rs := cr.Status.Replsets[replset.Name]
@@ -135,7 +135,7 @@ func (r *ReconcilePerconaServerMongoDB) reconcileCluster(ctx context.Context, cr
 			LastTransitionTime: metav1.NewTime(time.Now()),
 		})
 
-		return api.AppStateInit, nil
+		return api.AppStateInit, nil, nil
 	}
 	defer func() {
 		if err := cli.Disconnect(ctx); err != nil {
@@ -146,16 +146,16 @@ func (r *ReconcilePerconaServerMongoDB) reconcileCluster(ctx context.Context, cr
 	if cr.Spec.Unmanaged {
 		status, err := cli.RSStatus(ctx)
 		if err != nil {
-			return api.AppStateError, errors.Wrap(err, "failed to get rs status")
+			return api.AppStateError, nil, errors.Wrap(err, "failed to get rs status")
 		}
 		if status.Primary() == nil {
-			return api.AppStateInit, nil
+			return api.AppStateInit, nil, nil
 		}
-		return api.AppStateReady, nil
+		return api.AppStateReady, nil, nil
 	}
 	err = r.createOrUpdateSystemUsers(ctx, cr, replset)
 	if err != nil {
-		return api.AppStateInit, errors.Wrap(err, "create system users")
+		return api.AppStateInit, nil, errors.Wrap(err, "create system users")
 	}
 
 	// this can happen if cluster is initialized but status update failed
@@ -171,12 +171,12 @@ func (r *ReconcilePerconaServerMongoDB) reconcileCluster(ctx context.Context, cr
 			LastTransitionTime: metav1.NewTime(time.Now()),
 		})
 
-		return api.AppStateInit, nil
+		return api.AppStateInit, nil, nil
 	}
 
 	rstRunning, err := r.isRestoreRunning(ctx, cr)
 	if err != nil {
-		return api.AppStateInit, errors.Wrap(err, "failed to check running restore")
+		return api.AppStateInit, nil, errors.Wrap(err, "failed to check running restore")
 	}
 
 	if cr.Spec.Sharding.Enabled &&
@@ -190,7 +190,7 @@ func (r *ReconcilePerconaServerMongoDB) reconcileCluster(ctx context.Context, cr
 
 		mongosSession, err := r.mongosClientWithRole(ctx, cr, api.RoleClusterAdmin)
 		if err != nil {
-			return api.AppStateError, errors.Wrap(err, "failed to get mongos connection")
+			return api.AppStateError, nil, errors.Wrap(err, "failed to get mongos connection")
 		}
 
 		defer func() {
@@ -203,7 +203,7 @@ func (r *ReconcilePerconaServerMongoDB) reconcileCluster(ctx context.Context, cr
 		err = mongosSession.SetDefaultRWConcern(ctx, mongo.DefaultReadConcern, mongo.DefaultWriteConcern)
 		// SetDefaultRWConcern introduced in MongoDB 4.4
 		if err != nil && !strings.Contains(err.Error(), "CommandNotFound") {
-			return api.AppStateError, errors.Wrap(err, "set default RW concern")
+			return api.AppStateError, nil, errors.Wrap(err, "set default RW concern")
 		}
 
 		rsName := replset.Name
@@ -214,14 +214,14 @@ func (r *ReconcilePerconaServerMongoDB) reconcileCluster(ctx context.Context, cr
 
 		in, err := inShard(ctx, mongosSession, rsName)
 		if err != nil {
-			return api.AppStateError, errors.Wrap(err, "get shard")
+			return api.AppStateError, nil, errors.Wrap(err, "get shard")
 		}
 
 		if !in {
 			log.Info("adding rs to shard", "rs", rsName)
 			err := r.handleRsAddToShard(ctx, cr, replset, pods.Items[0], mongosPods[0])
 			if err != nil {
-				return api.AppStateError, errors.Wrap(err, "add shard")
+				return api.AppStateError, nil, errors.Wrap(err, "add shard")
 			}
 
 			log.Info("added to shard", "rs", rsName)
@@ -238,22 +238,31 @@ func (r *ReconcilePerconaServerMongoDB) reconcileCluster(ctx context.Context, cr
 		err := cli.SetDefaultRWConcern(ctx, mongo.DefaultReadConcern, mongo.DefaultWriteConcern)
 		// SetDefaultRWConcern introduced in MongoDB 4.4
 		if err != nil && !strings.Contains(err.Error(), "CommandNotFound") {
-			return api.AppStateError, errors.Wrap(err, "set default RW concern")
+			return api.AppStateError, nil, errors.Wrap(err, "set default RW concern")
 		}
 	}
 
-	membersLive, err := r.updateConfigMembers(ctx, cli, cr, replset)
+	rsMembers, err := r.updateConfigMembers(ctx, cli, cr, replset)
 	if err != nil {
-		return api.AppStateError, errors.Wrap(err, "failed to update config members")
+		return api.AppStateError, nil, errors.Wrap(err, "failed to update config members")
+	}
+
+	membersLive := 0
+	for _, member := range rsMembers {
+		switch member.State {
+		case mongo.MemberStatePrimary, mongo.MemberStateSecondary, mongo.MemberStateArbiter:
+			membersLive++
+		}
+
 	}
 
 	if membersLive == len(pods.Items) {
-		return api.AppStateReady, nil
+		return api.AppStateReady, rsMembers, nil
 	}
 
 	log.V(1).Info("Replset is not ready", "liveMembers", membersLive, "pods", len(pods.Items))
 
-	return api.AppStateInit, nil
+	return api.AppStateInit, rsMembers, nil
 }
 
 func (r *ReconcilePerconaServerMongoDB) getConfigMemberForPod(ctx context.Context, cr *api.PerconaServerMongoDB, rs *api.ReplsetSpec, id int, pod *corev1.Pod) (mongo.ConfigMember, error) {
@@ -364,7 +373,7 @@ func (r *ReconcilePerconaServerMongoDB) getConfigMemberForExternalNode(id int, e
 	return member
 }
 
-func (r *ReconcilePerconaServerMongoDB) updateConfigMembers(ctx context.Context, cli mongo.Client, cr *api.PerconaServerMongoDB, rs *api.ReplsetSpec) (int, error) {
+func (r *ReconcilePerconaServerMongoDB) updateConfigMembers(ctx context.Context, cli mongo.Client, cr *api.PerconaServerMongoDB, rs *api.ReplsetSpec) (map[string]api.ReplsetMemberStatus, error) {
 	log := logf.FromContext(ctx)
 	// Primary with a Secondary and an Arbiter (PSA)
 	unsafePSA := false
@@ -377,17 +386,17 @@ func (r *ReconcilePerconaServerMongoDB) updateConfigMembers(ctx context.Context,
 
 	pods, err := psmdb.GetRSPods(ctx, r.client, cr, rs.Name)
 	if err != nil {
-		return 0, errors.Wrap(err, "get rs pods")
+		return nil, errors.Wrap(err, "get rs pods")
 	}
 
 	cnf, err := cli.ReadConfig(ctx)
 	if err != nil {
-		return 0, errors.Wrap(err, "get replset config")
+		return nil, errors.Wrap(err, "get replset config")
 	}
 
 	rsStatus, err := cli.RSStatus(ctx)
 	if err != nil {
-		return 0, errors.Wrap(err, "get replset status")
+		return nil, errors.Wrap(err, "get replset status")
 	}
 
 	members := mongo.ConfigMembers{}
@@ -399,7 +408,7 @@ func (r *ReconcilePerconaServerMongoDB) updateConfigMembers(ctx context.Context,
 
 		member, err := r.getConfigMemberForPod(ctx, cr, rs, key, &pod)
 		if err != nil {
-			return 0, errors.Wrapf(err, "get config member for pod %s", pod.Name)
+			return nil, errors.Wrapf(err, "get config member for pod %s", pod.Name)
 		}
 
 		members = append(members, member)
@@ -424,7 +433,7 @@ func (r *ReconcilePerconaServerMongoDB) updateConfigMembers(ctx context.Context,
 		if member.State == mongo.MemberStatePrimary {
 			log.Info("Stepping down the primary", "member", member.Name)
 			if err := cli.StepDown(ctx, 60, false); err != nil {
-				return 0, errors.Wrap(err, "step down primary")
+				return nil, errors.Wrap(err, "step down primary")
 			}
 		}
 
@@ -433,10 +442,10 @@ func (r *ReconcilePerconaServerMongoDB) updateConfigMembers(ctx context.Context,
 		log.Info("Fixing hostname of member", "replset", rs.Name, "id", member.Id, "member", member.Name)
 
 		if err := cli.WriteConfig(ctx, cnf, false); err != nil {
-			return 0, errors.Wrap(err, "fix member hostname: write mongo config")
+			return nil, errors.Wrap(err, "fix member hostname: write mongo config")
 		}
 
-		return 0, nil
+		return nil, nil
 	}
 
 	if cnf.Members.FixMemberConfigs(ctx, members) {
@@ -445,7 +454,7 @@ func (r *ReconcilePerconaServerMongoDB) updateConfigMembers(ctx context.Context,
 		log.Info("Fixing member configurations", "replset", rs.Name)
 
 		if err := cli.WriteConfig(ctx, cnf, false); err != nil {
-			return 0, errors.Wrap(err, "fix member configurations: write mongo config")
+			return nil, errors.Wrap(err, "fix member configurations: write mongo config")
 		}
 	}
 
@@ -456,7 +465,7 @@ func (r *ReconcilePerconaServerMongoDB) updateConfigMembers(ctx context.Context,
 
 		err = cli.WriteConfig(ctx, cnf, false)
 		if err != nil {
-			return 0, errors.Wrap(err, "delete: write mongo config")
+			return nil, errors.Wrap(err, "delete: write mongo config")
 		}
 	}
 
@@ -467,7 +476,7 @@ func (r *ReconcilePerconaServerMongoDB) updateConfigMembers(ctx context.Context,
 
 		err = cli.WriteConfig(ctx, cnf, false)
 		if err != nil {
-			return 0, errors.Wrap(err, "add new: write mongo config")
+			return nil, errors.Wrap(err, "add new: write mongo config")
 		}
 	}
 
@@ -478,7 +487,7 @@ func (r *ReconcilePerconaServerMongoDB) updateConfigMembers(ctx context.Context,
 
 		err = cli.WriteConfig(ctx, cnf, false)
 		if err != nil {
-			return 0, errors.Wrap(err, "update external nodes: write mongo config")
+			return nil, errors.Wrap(err, "update external nodes: write mongo config")
 		}
 	}
 
@@ -491,16 +500,16 @@ func (r *ReconcilePerconaServerMongoDB) updateConfigMembers(ctx context.Context,
 
 		err := cli.WriteConfig(ctx, cnf, false)
 		if err != nil {
-			return 0, errors.Wrap(err, "set votes: write mongo config")
+			return nil, errors.Wrap(err, "set votes: write mongo config")
 		}
 	}
 
 	rsStatus, err = cli.RSStatus(ctx)
 	if err != nil {
-		return 0, errors.Wrap(err, "unable to get replset members")
+		return nil, errors.Wrap(err, "unable to get replset members")
 	}
 
-	membersLive := 0
+	rsMembers := make(map[string]api.ReplsetMemberStatus)
 	for _, member := range rsStatus.Members {
 		var tags mongo.ReplsetTags
 		for i := range cnf.Members {
@@ -513,22 +522,19 @@ func (r *ReconcilePerconaServerMongoDB) updateConfigMembers(ctx context.Context,
 			continue
 		}
 
-		switch member.State {
-		case mongo.MemberStatePrimary, mongo.MemberStateSecondary, mongo.MemberStateArbiter:
-			membersLive++
-		case mongo.MemberStateStartup,
-			mongo.MemberStateStartup2,
-			mongo.MemberStateRecovering,
-			mongo.MemberStateRollback,
-			mongo.MemberStateDown,
-			mongo.MemberStateUnknown:
+		podName, ok := tags["podName"]
+		if !ok {
+			continue
+		}
 
-			return 0, nil
-		default:
-			return 0, errors.Errorf("undefined state of the replset member %s: %v", member.Name, member.State)
+		rsMembers[podName] = api.ReplsetMemberStatus{
+			Name:     member.Name,
+			State:    member.State,
+			StateStr: member.StateStr,
 		}
 	}
-	return membersLive, nil
+
+	return rsMembers, nil
 }
 
 func inShard(ctx context.Context, client mongo.Client, rsName string) (bool, error) {

--- a/pkg/controller/perconaservermongodb/psmdb_controller.go
+++ b/pkg/controller/perconaservermongodb/psmdb_controller.go
@@ -567,9 +567,7 @@ func (r *ReconcilePerconaServerMongoDB) reconcileReplsets(ctx context.Context, c
 		}
 
 		if rs, ok := cr.Status.Replsets[replset.Name]; ok {
-			if rs.Members == nil {
-				rs.Members = make(map[string]api.ReplsetMemberStatus)
-			}
+			rs.Members = make(map[string]api.ReplsetMemberStatus)
 			for pod, member := range members {
 				rs.Members[pod] = member
 			}

--- a/pkg/controller/perconaservermongodb/psmdb_controller.go
+++ b/pkg/controller/perconaservermongodb/psmdb_controller.go
@@ -571,6 +571,7 @@ func (r *ReconcilePerconaServerMongoDB) reconcileReplsets(ctx context.Context, c
 			for pod, member := range members {
 				rs.Members[pod] = member
 			}
+			log.V(1).Info("Replset members", "rs", replset.Name, "initialized", rs.Initialized, "members", rs.Members)
 			cr.Status.Replsets[replset.Name] = rs
 		}
 	}

--- a/pkg/controller/perconaservermongodb/psmdb_controller.go
+++ b/pkg/controller/perconaservermongodb/psmdb_controller.go
@@ -546,7 +546,7 @@ func (r *ReconcilePerconaServerMongoDB) reconcileReplsets(ctx context.Context, c
 	var errs []error
 	clusterStatus := api.AppStateNone
 	for _, replset := range repls {
-		replsetStatus, err := r.reconcileCluster(ctx, cr, replset, mongosPods.Items)
+		replsetStatus, members, err := r.reconcileCluster(ctx, cr, replset, mongosPods.Items)
 		if err != nil {
 			log.Error(err, "failed to reconcile cluster", "replset", replset.Name)
 			errs = append(errs, err)
@@ -564,6 +564,16 @@ func (r *ReconcilePerconaServerMongoDB) reconcileReplsets(ctx context.Context, c
 				clusterStatus = s
 				break
 			}
+		}
+
+		if rs, ok := cr.Status.Replsets[replset.Name]; ok {
+			if rs.Members == nil {
+				rs.Members = make(map[string]api.ReplsetMemberStatus)
+			}
+			for pod, member := range members {
+				rs.Members[pod] = member
+			}
+			cr.Status.Replsets[replset.Name] = rs
 		}
 	}
 	return clusterStatus, stderrors.Join(errs...)
@@ -650,7 +660,7 @@ func (r *ReconcilePerconaServerMongoDB) reconcilePause(ctx context.Context, cr *
 
 	for _, rs := range cr.Spec.Replsets {
 		if cr.Status.State == api.AppStateStopping {
-			log.Info("Pausing cluster", "replset", rs.Name)
+			log.Info("pausing cluster", "replset", rs.Name)
 		}
 		rs.Arbiter.Enabled = false
 		rs.NonVoting.Enabled = false
@@ -658,7 +668,6 @@ func (r *ReconcilePerconaServerMongoDB) reconcilePause(ctx context.Context, cr *
 
 	if err := r.deletePSMDBPods(ctx, cr); err != nil {
 		if err == errWaitingTermination {
-			log.Info("pausing cluster", "error", err.Error())
 			return nil
 		}
 		return errors.Wrap(err, "delete psmdb pods")

--- a/pkg/controller/perconaservermongodb/smart.go
+++ b/pkg/controller/perconaservermongodb/smart.go
@@ -113,6 +113,7 @@ func (r *ReconcilePerconaServerMongoDB) smartUpdate(ctx context.Context, cr *api
 
 	if rsStatus, ok := cr.Status.Replsets[replset.Name]; !ok || !rsStatus.Initialized {
 		log.Info("replset wasn't initialized. Continuing smart update", "replset", replset.Name)
+
 		for _, pod := range list.Items {
 			log.Info("apply changes to pod", "pod", pod.Name)
 
@@ -120,7 +121,9 @@ func (r *ReconcilePerconaServerMongoDB) smartUpdate(ctx context.Context, cr *api
 				return err
 			}
 		}
+
 		log.Info("smart update finished for statefulset", "statefulset", sfs.Name)
+
 		return nil
 	}
 
@@ -128,9 +131,12 @@ func (r *ReconcilePerconaServerMongoDB) smartUpdate(ctx context.Context, cr *api
 		for _, pod := range list.Items {
 			if _, ok := rsStatus.Members[pod.Name]; !ok {
 				log.Info("pod is not a member of replset, updating it", "pod", pod.Name, "replset", replset.Name)
+
 				if err := updatePod(&pod); err != nil {
 					return err
 				}
+
+				return nil
 			}
 		}
 	}

--- a/pkg/controller/perconaservermongodb/status.go
+++ b/pkg/controller/perconaservermongodb/status.go
@@ -93,6 +93,7 @@ func (r *ReconcilePerconaServerMongoDB) updateStatus(ctx context.Context, cr *ap
 			currentRSstatus = api.ReplsetStatus{}
 		}
 
+		status.Members = currentRSstatus.Members
 		status.Initialized = currentRSstatus.Initialized
 		status.AddedAsShard = currentRSstatus.AddedAsShard
 


### PR DESCRIPTION
[![K8SPSMDB-1249](https://badgen.net/badge/JIRA/K8SPSMDB-1249/green)](https://jira.percona.com/browse/K8SPSMDB-1249) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
Operator can not finish smart update if update is triggered before replset is initialized.

Steps to reproduce:
1. Create a new cluster.
2. Immediately patch cluster to trigger smart update.
3. Operator detects the change but waits until all pods are up to start smart update.
4. Wait until all pods are up and running.
5. Operator initializes replset in `cluster1-cfg-0` and creates users there. As of now, replset has only one member: `cluster1-cfg-0`.
6. Once replset is initialized, operator starts smart update.
7. Smart update starts from last pod which is `cluster1-cfg-2`.
8. operator tries to connect to pod to check if it's primary or not but fails to connect because `cluster1-cfg-2` is not added to replset yet.

**Solution:**
Maintain a map of members in cluster status and check if pod is a member of replset using this map. If pod is not a member, operator doesn't need to check if pod is primary and just update it.

> [!WARNING]
> Arbiter members won't show up in members map in status. It's because we use pod names as keys to map and we get this information from member tags in replset configuration but arbiters are not allowed to have tags.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-1249]: https://perconadev.atlassian.net/browse/K8SPSMDB-1249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ