### PR TITLE
CLOUD-869 invert the logic and make it an early return(moving to top), reducing nested ifs.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -280,58 +280,59 @@ void checkE2EIgnoreFiles() {
     }
 
     def e2eignoreFile = ".e2eignore"
-    if (fileExists(e2eignoreFile)) {
-        def excludedFiles = readFile(e2eignoreFile).split('\n').collect{it.trim()}
-        def lastProcessedCommitFile="last-processed-commit.txt"
-        def lastProcessedCommitHash = ""
-
-        def build = currentBuild.previousBuild
-        while (build != null) {
-            try {
-                echo "Checking previous build: #$build.number"
-                copyArtifacts(projectName: env.JOB_NAME, selector: specific("$build.number"), filter: lastProcessedCommitFile)
-                lastProcessedCommitHash = readFile(lastProcessedCommitFile).trim()
-                echo "Last processed commit hash: $lastProcessedCommitHash"
-                break
-            } catch (Exception e) {
-                echo "No $lastProcessedCommitFile found in build $build.number. Checking earlier builds."
-            }
-            build = build.previousBuild
-        }
-
-        if (lastProcessedCommitHash == "") {
-            echo "This is the first run. Using merge base as the starting point for the diff."
-            changedFiles = sh(script: "git diff --name-only \$(git merge-base HEAD origin/$CHANGE_TARGET)", returnStdout: true).trim().split('\n').findAll{it}
-        } else {
-            echo "Processing changes since last processed commit: $lastProcessedCommitHash"
-            changedFiles = sh(script: "git diff --name-only $lastProcessedCommitHash HEAD", returnStdout: true).trim().split('\n').findAll{it}
-        }
-
-        echo "Excluded files: $excludedFiles"
-        echo "Changed files: $changedFiles"
-
-        def excludedFilesRegex = excludedFiles.collect{it.replace("**", ".*").replace("*", "[^/]*")}
-        needToRunTests = !changedFiles.every{changed -> excludedFilesRegex.any{regex -> changed ==~ regex}}
-
-        if (needToRunTests) {
-            echo "Some changed files are outside of the e2eignore list. Proceeding with execution."
-        } else {
-            if (currentBuild.previousBuild?.result in ['FAILURE', 'ABORTED', 'UNSTABLE']) {
-                echo "All changed files are e2eignore files, and previous build was unsuccessful. Propagating previous state."
-                currentBuild.result = currentBuild.previousBuild?.result
-                error "Skipping execution as non-significant changes detected and previous build was unsuccessful."
-            } else {
-                echo "All changed files are e2eignore files. Aborting pipeline execution."
-            }
-        }
-
-        sh """
-            echo \$(git rev-parse HEAD) > $lastProcessedCommitFile
-        """
-        archiveArtifacts "$lastProcessedCommitFile"
-    } else {
+    if ( ! fileExists(e2eignoreFile) ) {
         echo "No $e2eignoreFile file found. Proceeding with execution."
+        return
     }
+
+    def excludedFiles = readFile(e2eignoreFile).split('\n').collect{it.trim()}
+    def lastProcessedCommitFile = "last-processed-commit.txt"
+    def lastProcessedCommitHash = ""
+
+    def build = currentBuild.previousBuild
+    while (build != null) {
+        try {
+            echo "Checking previous build: #$build.number"
+            copyArtifacts(projectName: env.JOB_NAME, selector: specific("$build.number"), filter: lastProcessedCommitFile)
+            lastProcessedCommitHash = readFile(lastProcessedCommitFile).trim()
+            echo "Last processed commit hash: $lastProcessedCommitHash"
+            break
+        } catch (Exception e) {
+            echo "No $lastProcessedCommitFile found in build $build.number. Checking earlier builds."
+        }
+        build = build.previousBuild
+    }
+
+    if (lastProcessedCommitHash == "") {
+        echo "This is the first run. Using merge base as the starting point for the diff."
+        changedFiles = sh(script: "git diff --name-only \$(git merge-base HEAD origin/$CHANGE_TARGET)", returnStdout: true).trim().split('\n').findAll{it}
+    } else {
+        echo "Processing changes since last processed commit: $lastProcessedCommitHash"
+        changedFiles = sh(script: "git diff --name-only $lastProcessedCommitHash HEAD", returnStdout: true).trim().split('\n').findAll{it}
+    }
+
+    echo "Excluded files: $excludedFiles"
+    echo "Changed files: $changedFiles"
+
+    def excludedFilesRegex = excludedFiles.collect{it.replace("**", ".*").replace("*", "[^/]*")}
+    needToRunTests = !changedFiles.every{changed -> excludedFilesRegex.any{regex -> changed ==~ regex}}
+
+    if (needToRunTests) {
+        echo "Some changed files are outside of the e2eignore list. Proceeding with execution."
+    } else {
+        if (currentBuild.previousBuild?.result in ['FAILURE', 'ABORTED', 'UNSTABLE']) {
+            echo "All changed files are e2eignore files, and previous build was unsuccessful. Propagating previous state."
+            currentBuild.result = currentBuild.previousBuild?.result
+            error "Skipping execution as non-significant changes detected and previous build was unsuccessful."
+        } else {
+            echo "All changed files are e2eignore files. Aborting pipeline execution."
+        }
+    }
+
+    sh """
+        echo \$(git rev-parse HEAD) > $lastProcessedCommitFile
+    """
+    archiveArtifacts "$lastProcessedCommitFile"
 }
 
 def isPRJob = false


### PR DESCRIPTION
[![CLOUD-869](https://badgen.net/badge/JIRA/CLOUD-869/green)](https://jira.percona.com/browse/CLOUD-869) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
*Short explanation of the problem.*

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[CLOUD-869]: https://perconadev.atlassian.net/browse/CLOUD-869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ