### PR TITLE
K8SPSMDB-1224: Update tests to Mongo 8.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ release: manifests
 		-e "s#initImage: .*#initImage: percona/percona-server-mongodb-operator:$(VERSION)#g" \
 		-e "/^  pmm:/,/^    image:/{s#image: .*#image: $(IMAGE_PMM_CLIENT)#}" deploy/cr.yaml
 	$(SED) -i \
-		-e "s|perconalab/percona-server-mongodb-operator:main-mongod7.0|$(IMAGE_MONGOD80)|g" \
+		-e "s|perconalab/percona-server-mongodb-operator:main-mongod8.0|$(IMAGE_MONGOD80)|g" \
 		-e "s|perconalab/percona-server-mongodb-operator:main-backup|$(IMAGE_BACKUP)|g" \
 		-e "s|perconalab/percona-server-mongodb-operator:main|$(IMAGE_OPERATOR)|g" \
 		pkg/controller/perconaservermongodb/testdata/reconcile-statefulset/*.yaml

--- a/e2e-tests/demand-backup-fs/conf/some-name.yaml
+++ b/e2e-tests/demand-backup-fs/conf/some-name.yaml
@@ -22,7 +22,7 @@ spec:
     volumeMounts:
     - mountPath: /mnt/nfs/
       name: backup-nfs
-  image: perconalab/percona-server-mongodb-operator:main-mongod7.0
+  image: perconalab/percona-server-mongodb-operator:main-mongod8.0
   imagePullPolicy: Always
   pmm:
     enabled: false

--- a/e2e-tests/replset-overrides/conf/some-name-overridden.yml
+++ b/e2e-tests/replset-overrides/conf/some-name-overridden.yml
@@ -5,7 +5,7 @@ metadata:
   - percona.com/delete-psmdb-pvc
   name: some-name
 spec:
-  image: perconalab/percona-server-mongodb-operator:main-mongod7.0
+  image: perconalab/percona-server-mongodb-operator:main-mongod8.0
   imagePullPolicy: Always
   backup:
     enabled: true

--- a/e2e-tests/replset-overrides/conf/some-name-override-priority.yml
+++ b/e2e-tests/replset-overrides/conf/some-name-override-priority.yml
@@ -5,7 +5,7 @@ metadata:
   - percona.com/delete-psmdb-pvc
   name: some-name
 spec:
-  image: perconalab/percona-server-mongodb-operator:main-mongod7.0
+  image: perconalab/percona-server-mongodb-operator:main-mongod8.0
   imagePullPolicy: Always
   backup:
     enabled: true

--- a/e2e-tests/replset-overrides/conf/some-name.yml
+++ b/e2e-tests/replset-overrides/conf/some-name.yml
@@ -5,7 +5,7 @@ metadata:
   - percona.com/delete-psmdb-pvc
   name: some-name
 spec:
-  image: perconalab/percona-server-mongodb-operator:main-mongod7.0
+  image: perconalab/percona-server-mongodb-operator:main-mongod8.0
   imagePullPolicy: Always
   backup:
     enabled: true

--- a/e2e-tests/version-service/conf/operator.9.9.9.psmdb-operator.json
+++ b/e2e-tests/version-service/conf/operator.9.9.9.psmdb-operator.json
@@ -5,6 +5,12 @@
       "product": "psmdb-operator",
       "matrix": {
         "mongod": {
+          "8.0.4-1": {
+            "image_path": "percona/percona-server-mongodb:8.0.4-1-multi",
+            "image_hash": "873b201ce3d66d97b1225c26db392c5043a73cc19ee8db6f2dc1b8efd4783bcf",
+            "status": "recommended",
+            "critical": false
+          },
           "7.0.7-4": {
             "image_path": "percona/percona-server-mongodb:7.0.7-4",
             "image_hash": "36b99f78b13871e5caf458faaec83176c90271586010fa3130d1a544f31d06f4",

--- a/e2e-tests/version-service/run
+++ b/e2e-tests/version-service/run
@@ -143,7 +143,7 @@ kubectl_bin delete pod -l run=version-service ${OPERATOR_NS:+-n $OPERATOR_NS}
 check_telemetry_transfer "http://version-service-cr:11000" "disabled" "disabled"
 
 cases=("version-service-exact" "version-service-recommended" "version-service-latest" "version-service-major" "version-service-unreachable")
-expected_images=("percona/percona-server-mongodb:6.0.3-2" "percona/percona-server-mongodb:7.0.5-3" "percona/percona-server-mongodb:7.0.7-4" "percona/percona-server-mongodb:5.0.14-12" "$IMAGE_MONGOD")
+expected_images=("percona/percona-server-mongodb:6.0.3-2" "percona/percona-server-mongodb:8.0.4-1-multi" "percona/percona-server-mongodb:8.0.4-1-multi" "percona/percona-server-mongodb:5.0.14-12" "$IMAGE_MONGOD")
 
 for i in "${!cases[@]}"; do
 	desc "test ${cases[$i]}"

--- a/pkg/psmdb/backup/testdata/cr-with-pbm-config.yaml
+++ b/pkg/psmdb/backup/testdata/cr-with-pbm-config.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: test-namespace
 spec:
   crVersion: 1.16.0
-  image: perconalab/percona-server-mongodb-operator:main-mongod7.0
+  image: perconalab/percona-server-mongodb-operator:main-mongod8.0
   imagePullPolicy: Always
   allowUnsafeConfigurations: false
   updateStrategy: SmartUpdate


### PR DESCRIPTION
[![K8SPSMDB-1224](https://badgen.net/badge/JIRA/K8SPSMDB-1224/green)](https://jira.percona.com/browse/K8SPSMDB-1224) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
Tests were using Mongo 7.0 image, but now we have Mongo 8.0 support.

**Solution:**
Change tests to use Mongo 8.0 image.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-1224]: https://perconadev.atlassian.net/browse/K8SPSMDB-1224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ