### PR TITLE
K8SPSMDB-1224 add credentialsSecret to S3 configuration and apply storage secrets in run script

### DIFF
--- a/e2e-tests/pitr-sharded/conf/eks-some-name-rs0.yml
+++ b/e2e-tests/pitr-sharded/conf/eks-some-name-rs0.yml
@@ -16,6 +16,7 @@ spec:
           region: us-east-1
           bucket: operator-testing
           prefix: psmdb-pitr-demand-backup-eks-credentials
+          credentialsSecret: aws-s3-secret
     pitr:
       enabled: false
       oplogSpanMin: 2

--- a/e2e-tests/pitr-sharded/run
+++ b/e2e-tests/pitr-sharded/run
@@ -81,8 +81,7 @@ main() {
 	desc 'create secrets and start client'
 	kubectl_bin apply \
 		-f "$conf_dir/secrets.yml" \
-		-f "$conf_dir/client.yml" \
-		-f $conf_dir/minio-secret.yml
+		-f "$conf_dir/client.yml"
 	apply_s3_storage_secrets
 
 	desc 'create custom RuntimeClass'

--- a/e2e-tests/pitr-sharded/run
+++ b/e2e-tests/pitr-sharded/run
@@ -83,6 +83,7 @@ main() {
 		-f "$conf_dir/secrets.yml" \
 		-f "$conf_dir/client.yml" \
 		-f $conf_dir/minio-secret.yml
+	apply_s3_storage_secrets
 
 	desc 'create custom RuntimeClass'
 	if version_gt "1.19" && [ $EKS -ne 1 ]; then


### PR DESCRIPTION
[![K8SPSMDB-1224](https://badgen.net/badge/JIRA/K8SPSMDB-1224/green)](https://jira.percona.com/browse/K8SPSMDB-1224) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
Test fails because of access denied in S3 bucket.

**Cause:**
We [removed](https://github.com/Percona-Lab/jenkins-pipelines/commit/f66eda69b9cb82ef7bda53ab0328609e7a9571ac) the option: `- arn:aws:iam::aws:policy/AmazonS3FullAccess` when creating the EKS cluster because of the [IRSA test](https://github.com/percona/percona-server-mongodb-operator/blob/main/e2e-tests/demand-backup-eks-credentials-irsa/run)

**Solution:**
Adding spec.backup.storages.aws-s3.s3.credentialsSecret: aws-s3-secret and also calling [apply_s3_storage_secrets](https://github.com/percona/percona-server-mongodb-operator/blob/e4254e1f962989cfe30bcb93c44357a2bd9f92f6/e2e-tests/functions#L92) at the beginning of the test.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-1224]: https://perconadev.atlassian.net/browse/K8SPSMDB-1224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ