### PR TITLE
K8SPSMDB-1224 Add retry mechanism for AWS CLI command in upgrade run script

### DIFF
--- a/e2e-tests/upgrade/run
+++ b/e2e-tests/upgrade/run
@@ -219,7 +219,7 @@ function main() {
 	run_mongo 'use myApp\n db.test.drop()' "myApp:myPass@${cluster}-rs0.${namespace}"
 
 	backup_dest_minio=$(get_backup_dest "$backup_name_minio")
-	kubectl_bin run -i --rm aws-cli --image=perconalab/awscli --restart=Never -- \
+	retry 3 5 kubectl_bin run -i --rm aws-cli --image=perconalab/awscli --restart=Never -- \
 		/usr/bin/env AWS_ACCESS_KEY_ID=some-access-key AWS_SECRET_ACCESS_KEY=some-secret-key AWS_DEFAULT_REGION=us-east-1 \
 		/usr/bin/aws --endpoint-url http://minio-service:9000 s3 ls s3://${backup_dest_minio}/rs0/ \
 		| grep myApp.test.gz


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
`upgrade` test fails very often, because it needs to wait a little bit before listing contects of S3 bucket.

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
I added retry just like in [upgrade-sharded](https://github.com/percona/percona-server-mongodb-operator/blob/92cb7e66d06120ca6c25c060fcf2b6f21b5aa2b5/e2e-tests/upgrade-sharded/run#L266) instead of just adding a "dumb" `sleep <seconds>` and it should be more stable now

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?