### PR TITLE
K8SPSMDB-1224 - Fix Openshift Tests

### DIFF
--- a/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0-oc.yml
@@ -225,6 +225,7 @@ spec:
             - mountPath: /opt/percona
               name: bin
       restartPolicy: Always
+      runtimeClassName: container-rc
       schedulerName: default-scheduler
       securityContext: {}
       serviceAccount: default

--- a/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0-sharding-disabled-oc.yml
+++ b/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0-sharding-disabled-oc.yml
@@ -222,6 +222,7 @@ spec:
             - mountPath: /opt/percona
               name: bin
       restartPolicy: Always
+      runtimeClassName: container-rc
       schedulerName: default-scheduler
       securityContext: {}
       serviceAccount: default

--- a/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0-sharding-enabled-oc.yml
+++ b/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0-sharding-enabled-oc.yml
@@ -225,6 +225,7 @@ spec:
             - mountPath: /opt/percona
               name: bin
       restartPolicy: Always
+      runtimeClassName: container-rc
       schedulerName: default-scheduler
       securityContext: {}
       serviceAccount: default

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1170-oc.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1170-oc.yml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations: {}
-  generation: 5
+  generation: 3
   labels:
     app.kubernetes.io/component: cfg
     app.kubernetes.io/instance: some-name

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1180-oc.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1180-oc.yml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations: {}
-  generation: 7
+  generation: 5
   labels:
     app.kubernetes.io/component: cfg
     app.kubernetes.io/instance: some-name

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1170-oc.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1170-oc.yml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations: {}
-  generation: 5
+  generation: 3
   labels:
     app.kubernetes.io/component: mongod
     app.kubernetes.io/instance: some-name

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1180-oc.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1180-oc.yml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations: {}
-  generation: 7
+  generation: 5
   labels:
     app.kubernetes.io/component: mongod
     app.kubernetes.io/instance: some-name


### PR DESCRIPTION
[![K8SPSMDB-1224](https://badgen.net/badge/JIRA/K8SPSMDB-1224/green)](https://jira.percona.com/browse/K8SPSMDB-1224) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
*Short explanation of the problem.*

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-1224]: https://perconadev.atlassian.net/browse/K8SPSMDB-1224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ