### PR TITLE
K8SPSMDB-1245 Telemetry ClusterWideEnabled not handling multiple comma-separated namespaces

### DIFF
--- a/pkg/controller/perconaservermongodb/version.go
+++ b/pkg/controller/perconaservermongodb/version.go
@@ -264,7 +264,7 @@ func (r *ReconcilePerconaServerMongoDB) getVersionMeta(ctx context.Context, cr *
 		BackupVersion:          cr.Status.BackupVersion,
 		BackupsEnabled:         cr.Spec.Backup.Enabled && len(cr.Spec.Backup.Storages) > 0,
 		ShardingEnabled:        cr.Spec.Sharding.Enabled,
-		ClusterWideEnabled:     len(watchNs) == 0,
+		ClusterWideEnabled:     watchNs == "" || strings.Contains(watchNs, ","),
 		HashicorpVaultEnabled:  len(cr.Spec.Secrets.Vault) > 0,
 		RoleManagementEnabled:  len(cr.Spec.Roles) > 0,
 		UserManagementEnabled:  len(cr.Spec.Users) > 0,

--- a/pkg/controller/perconaservermongodb/version.go
+++ b/pkg/controller/perconaservermongodb/version.go
@@ -250,7 +250,6 @@ func (r *ReconcilePerconaServerMongoDB) getVersionMeta(ctx context.Context, cr *
 	if err != nil {
 		return VersionMeta{}, errors.Wrap(err, "get WATCH_NAMESPACE env variable")
 	}
-	log := logf.FromContext(ctx)
 	vm := VersionMeta{
 		Apply:                  string(cr.Spec.UpgradeOptions.Apply),
 		CRUID:                  string(cr.GetUID()),
@@ -271,7 +270,7 @@ func (r *ReconcilePerconaServerMongoDB) getVersionMeta(ctx context.Context, cr *
 		UserManagementEnabled:  len(cr.Spec.Users) > 0,
 		VolumeExpansionEnabled: cr.Spec.VolumeExpansionEnabled,
 	}
-	log.Info("ClusterWideEnabled test", "ClusterWideEnabled", vm.ClusterWideEnabled)
+
 	if cr.Spec.Platform != nil {
 		vm.Platform = string(*cr.Spec.Platform)
 	}

--- a/pkg/controller/perconaservermongodb/version.go
+++ b/pkg/controller/perconaservermongodb/version.go
@@ -264,7 +264,7 @@ func (r *ReconcilePerconaServerMongoDB) getVersionMeta(ctx context.Context, cr *
 		BackupVersion:          cr.Status.BackupVersion,
 		BackupsEnabled:         cr.Spec.Backup.Enabled && len(cr.Spec.Backup.Storages) > 0,
 		ShardingEnabled:        cr.Spec.Sharding.Enabled,
-		ClusterWideEnabled:     watchNs == "" || strings.Contains(watchNs, ","),
+		ClusterWideEnabled:     len(strings.Split(watchNs, ",")) != 1,
 		HashicorpVaultEnabled:  len(cr.Spec.Secrets.Vault) > 0,
 		RoleManagementEnabled:  len(cr.Spec.Roles) > 0,
 		UserManagementEnabled:  len(cr.Spec.Users) > 0,

--- a/pkg/controller/perconaservermongodb/version.go
+++ b/pkg/controller/perconaservermongodb/version.go
@@ -250,6 +250,7 @@ func (r *ReconcilePerconaServerMongoDB) getVersionMeta(ctx context.Context, cr *
 	if err != nil {
 		return VersionMeta{}, errors.Wrap(err, "get WATCH_NAMESPACE env variable")
 	}
+	log := logf.FromContext(ctx)
 	vm := VersionMeta{
 		Apply:                  string(cr.Spec.UpgradeOptions.Apply),
 		CRUID:                  string(cr.GetUID()),
@@ -264,12 +265,13 @@ func (r *ReconcilePerconaServerMongoDB) getVersionMeta(ctx context.Context, cr *
 		BackupVersion:          cr.Status.BackupVersion,
 		BackupsEnabled:         cr.Spec.Backup.Enabled && len(cr.Spec.Backup.Storages) > 0,
 		ShardingEnabled:        cr.Spec.Sharding.Enabled,
-		ClusterWideEnabled:     len(strings.Split(watchNs, ",")) != 1,
+		ClusterWideEnabled:     len(watchNs) == 0 || len(strings.Split(watchNs, ",")) > 1,
 		HashicorpVaultEnabled:  len(cr.Spec.Secrets.Vault) > 0,
 		RoleManagementEnabled:  len(cr.Spec.Roles) > 0,
 		UserManagementEnabled:  len(cr.Spec.Users) > 0,
 		VolumeExpansionEnabled: cr.Spec.VolumeExpansionEnabled,
 	}
+	log.Info("ClusterWideEnabled test", "ClusterWideEnabled", vm.ClusterWideEnabled)
 	if cr.Spec.Platform != nil {
 		vm.Platform = string(*cr.Spec.Platform)
 	}

--- a/pkg/controller/perconaservermongodb/version_test.go
+++ b/pkg/controller/perconaservermongodb/version_test.go
@@ -438,6 +438,7 @@ func TestVersionMeta(t *testing.T) {
 				PITREnabled:             true,
 				HelmDeployCR:            true,
 				PhysicalBackupScheduled: true,
+				ClusterWideEnabled:      false,
 			},
 			clusterWide:        false,
 			helmDeploy:         false,
@@ -513,7 +514,7 @@ func TestVersionMeta(t *testing.T) {
 			expectedNamespaces: []string{"test-namespace", "another-namespace"},
 		},
 		{
-			name: "Cluster-wide with specified namespaces and operator helm deploy",
+			name: "Cluster-wide and operator helm deploy",
 			cr: api.PerconaServerMongoDB{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "some-name",

--- a/pkg/controller/perconaservermongodb/version_test.go
+++ b/pkg/controller/perconaservermongodb/version_test.go
@@ -539,11 +539,10 @@ func TestVersionMeta(t *testing.T) {
 				ClusterWideEnabled: true,
 				ClusterSize:        4,
 			},
-			clusterWide:        true,
-			helmDeploy:         true,
-			namespace:          "test-namespace",
-			watchNamespaces:    "",
-			expectedNamespaces: []string{"test-namespace", "another-namespace"},
+			clusterWide:     true,
+			helmDeploy:      true,
+			namespace:       "test-namespace",
+			watchNamespaces: "",
 		},
 	}
 	size := int32(1)

--- a/pkg/controller/perconaservermongodb/version_test.go
+++ b/pkg/controller/perconaservermongodb/version_test.go
@@ -330,14 +330,13 @@ func Test_majorUpgradeRequested(t *testing.T) {
 
 func TestVersionMeta(t *testing.T) {
 	tests := []struct {
-		name               string
-		cr                 api.PerconaServerMongoDB
-		want               VersionMeta
-		clusterWide        bool
-		helmDeploy         bool
-		namespace          string
-		watchNamespaces    string
-		expectedNamespaces []string
+		name            string
+		cr              api.PerconaServerMongoDB
+		want            VersionMeta
+		clusterWide     bool
+		helmDeploy      bool
+		namespace       string
+		watchNamespaces string
 	}{
 		{
 			name: "Minimal CR",
@@ -364,8 +363,7 @@ func TestVersionMeta(t *testing.T) {
 				Version:     version.Version,
 				ClusterSize: 3,
 			},
-			namespace:          "test-namespace",
-			expectedNamespaces: []string{"test-namespace"},
+			namespace: "test-namespace",
 		},
 		{
 			name: "Full CR with old Version deployed with Helm",
@@ -440,10 +438,9 @@ func TestVersionMeta(t *testing.T) {
 				PhysicalBackupScheduled: true,
 				ClusterWideEnabled:      false,
 			},
-			clusterWide:        false,
-			helmDeploy:         false,
-			namespace:          "test-namespace",
-			expectedNamespaces: []string{"test-namespace"},
+			clusterWide: false,
+			helmDeploy:  false,
+			namespace:   "test-namespace",
 		},
 		{
 			name: "Disabled Backup with storage",
@@ -477,8 +474,7 @@ func TestVersionMeta(t *testing.T) {
 				ClusterSize:    3,
 				BackupsEnabled: false,
 			},
-			namespace:          "test-namespace",
-			expectedNamespaces: []string{"test-namespace"},
+			namespace: "test-namespace",
 		},
 		{
 			name: "Cluster-wide with specified namespaces and operator helm deploy",
@@ -507,11 +503,10 @@ func TestVersionMeta(t *testing.T) {
 				ClusterWideEnabled: true,
 				ClusterSize:        4,
 			},
-			clusterWide:        true,
-			helmDeploy:         true,
-			namespace:          "test-namespace",
-			watchNamespaces:    "test-namespace,another-namespace",
-			expectedNamespaces: []string{"test-namespace", "another-namespace"},
+			clusterWide:     true,
+			helmDeploy:      true,
+			namespace:       "test-namespace",
+			watchNamespaces: "test-namespace,another-namespace",
 		},
 		{
 			name: "Cluster-wide and operator helm deploy",

--- a/pkg/controller/perconaservermongodb/version_test.go
+++ b/pkg/controller/perconaservermongodb/version_test.go
@@ -335,6 +335,7 @@ func TestVersionMeta(t *testing.T) {
 		want        VersionMeta
 		clusterWide bool
 		helmDeploy  bool
+		currentNs   string
 	}{
 		{
 			name: "Minimal CR",
@@ -361,6 +362,7 @@ func TestVersionMeta(t *testing.T) {
 				Version:     version.Version,
 				ClusterSize: 3,
 			},
+			currentNs: "test-namespace",
 		},
 		{
 			name: "Full CR with old Version deployed with Helm",
@@ -436,6 +438,7 @@ func TestVersionMeta(t *testing.T) {
 			},
 			clusterWide: false,
 			helmDeploy:  false,
+			currentNs:   "test-namespace",
 		},
 		{
 			name: "Disabled Backup with storage",
@@ -469,6 +472,7 @@ func TestVersionMeta(t *testing.T) {
 				ClusterSize:    3,
 				BackupsEnabled: false,
 			},
+			currentNs: "test-namespace",
 		},
 		{
 			name: "Cluster-wide and operator helm deploy",
@@ -499,15 +503,16 @@ func TestVersionMeta(t *testing.T) {
 			},
 			clusterWide: true,
 			helmDeploy:  true,
+			currentNs:   "test-namespace",
 		},
 	}
-	currentNs := "test-namespace"
+
 	size := int32(1)
 	operatorName := "percona-server-mongodb-operator"
 	operatorDepl := appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      operatorName,
-			Namespace: currentNs,
+			Namespace: "",
 			Labels:    make(map[string]string),
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -537,7 +542,7 @@ func TestVersionMeta(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv(k8s.WatchNamespaceEnvVar, currentNs)
+			t.Setenv(k8s.WatchNamespaceEnvVar, tt.currentNs)
 			if tt.clusterWide {
 				t.Setenv(k8s.WatchNamespaceEnvVar, "")
 			}


### PR DESCRIPTION
[![K8SPSMDB-1245](https://badgen.net/badge/JIRA/K8SPSMDB-1245/green)](https://jira.percona.com/browse/K8SPSMDB-1245) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

…a-separated namespaces

**CHANGE DESCRIPTION**
---
**Problem:**
Telemetry ClusterWideEnabled not handling multiple comma-separated namespaces

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
Update value for ClusterWideEnabled

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-1245]: https://perconadev.atlassian.net/browse/K8SPSMDB-1245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ