### PR TITLE
K8SPSMDB-1097 add NumParallelCollections to CR

### DIFF
--- a/config/crd/bases/psmdb.percona.com_perconaservermongodbs.yaml
+++ b/config/crd/bases/psmdb.percona.com_perconaservermongodbs.yaml
@@ -50,6 +50,8 @@ spec:
                     properties:
                       backupOptions:
                         properties:
+                          numParallelCollections:
+                            type: integer
                           oplogSpanMin:
                             type: number
                           priority:
@@ -82,6 +84,8 @@ spec:
                           numDownloadWorkers:
                             type: integer
                           numInsertionWorkers:
+                            type: integer
+                          numParallelCollections:
                             type: integer
                         type: object
                     type: object

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -746,6 +746,8 @@ spec:
                     properties:
                       backupOptions:
                         properties:
+                          numParallelCollections:
+                            type: integer
                           oplogSpanMin:
                             type: number
                           priority:
@@ -778,6 +780,8 @@ spec:
                           numDownloadWorkers:
                             type: integer
                           numInsertionWorkers:
+                            type: integer
+                          numParallelCollections:
                             type: integer
                         type: object
                     type: object

--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -688,10 +688,12 @@ spec:
 #        timeouts:
 #          startingStatus: 33
 #        oplogSpanMin: 10
+#        numParallelCollections: 2
 #      restoreOptions:
 #        batchSize: 500
 #        numInsertionWorkers: 10
 #        numDownloadWorkers: 4
+#        numParallelCollections: 2
 #        maxDownloadBufferMb: 0
 #        downloadChunkMb: 32
 #        mongodLocation: /usr/bin/mongo

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -746,6 +746,8 @@ spec:
                     properties:
                       backupOptions:
                         properties:
+                          numParallelCollections:
+                            type: integer
                           oplogSpanMin:
                             type: number
                           priority:
@@ -778,6 +780,8 @@ spec:
                           numDownloadWorkers:
                             type: integer
                           numInsertionWorkers:
+                            type: integer
+                          numParallelCollections:
                             type: integer
                         type: object
                     type: object

--- a/deploy/cw-bundle.yaml
+++ b/deploy/cw-bundle.yaml
@@ -746,6 +746,8 @@ spec:
                     properties:
                       backupOptions:
                         properties:
+                          numParallelCollections:
+                            type: integer
                           oplogSpanMin:
                             type: number
                           priority:
@@ -778,6 +780,8 @@ spec:
                           numDownloadWorkers:
                             type: integer
                           numInsertionWorkers:
+                            type: integer
+                          numParallelCollections:
                             type: integer
                         type: object
                     type: object

--- a/e2e-tests/version-service/conf/crd.yaml
+++ b/e2e-tests/version-service/conf/crd.yaml
@@ -746,6 +746,8 @@ spec:
                     properties:
                       backupOptions:
                         properties:
+                          numParallelCollections:
+                            type: integer
                           oplogSpanMin:
                             type: number
                           priority:
@@ -778,6 +780,8 @@ spec:
                           numDownloadWorkers:
                             type: integer
                           numInsertionWorkers:
+                            type: integer
+                          numParallelCollections:
                             type: integer
                         type: object
                     type: object

--- a/pkg/apis/psmdb/v1/psmdb_types.go
+++ b/pkg/apis/psmdb/v1/psmdb_types.go
@@ -1003,19 +1003,21 @@ type BackupTimeouts struct {
 }
 
 type BackupOptions struct {
-	OplogSpanMin float64            `json:"oplogSpanMin"`
-	Priority     map[string]float64 `json:"priority,omitempty"`
-	Timeouts     *BackupTimeouts    `json:"timeouts,omitempty"`
+	OplogSpanMin           float64            `json:"oplogSpanMin"`
+	NumParallelCollections int                `json:"numParallelCollections,omitempty"`
+	Priority               map[string]float64 `json:"priority,omitempty"`
+	Timeouts               *BackupTimeouts    `json:"timeouts,omitempty"`
 }
 
 type RestoreOptions struct {
-	BatchSize           int               `json:"batchSize,omitempty"`
-	NumInsertionWorkers int               `json:"numInsertionWorkers,omitempty"`
-	NumDownloadWorkers  int               `json:"numDownloadWorkers,omitempty"`
-	MaxDownloadBufferMb int               `json:"maxDownloadBufferMb,omitempty"`
-	DownloadChunkMb     int               `json:"downloadChunkMb,omitempty"`
-	MongodLocation      string            `json:"mongodLocation,omitempty"`
-	MongodLocationMap   map[string]string `json:"mongodLocationMap,omitempty"`
+	BatchSize              int               `json:"batchSize,omitempty"`
+	NumInsertionWorkers    int               `json:"numInsertionWorkers,omitempty"`
+	NumDownloadWorkers     int               `json:"numDownloadWorkers,omitempty"`
+	NumParallelCollections int               `json:"numParallelCollections,omitempty"`
+	MaxDownloadBufferMb    int               `json:"maxDownloadBufferMb,omitempty"`
+	DownloadChunkMb        int               `json:"downloadChunkMb,omitempty"`
+	MongodLocation         string            `json:"mongodLocation,omitempty"`
+	MongodLocationMap      map[string]string `json:"mongodLocationMap,omitempty"`
 }
 
 type BackupConfig struct {

--- a/pkg/psmdb/backup/pbm.go
+++ b/pkg/psmdb/backup/pbm.go
@@ -251,7 +251,8 @@ func GetPBMConfig(ctx context.Context, k8sclient client.Client, cluster *api.Per
 
 	if cluster.Spec.Backup.Configuration.BackupOptions != nil {
 		conf.Backup = &config.BackupConf{
-			OplogSpanMin: cluster.Spec.Backup.Configuration.BackupOptions.OplogSpanMin,
+			OplogSpanMin:           cluster.Spec.Backup.Configuration.BackupOptions.OplogSpanMin,
+			NumParallelCollections: cluster.Spec.Backup.Configuration.BackupOptions.NumParallelCollections,
 			Timeouts: &config.BackupTimeouts{
 				Starting: cluster.Spec.Backup.Configuration.BackupOptions.Timeouts.Starting,
 			},
@@ -270,13 +271,14 @@ func GetPBMConfig(ctx context.Context, k8sclient client.Client, cluster *api.Per
 
 	if cluster.Spec.Backup.Configuration.RestoreOptions != nil {
 		conf.Restore = &config.RestoreConf{
-			BatchSize:           cluster.Spec.Backup.Configuration.RestoreOptions.BatchSize,
-			NumInsertionWorkers: cluster.Spec.Backup.Configuration.RestoreOptions.NumInsertionWorkers,
-			NumDownloadWorkers:  cluster.Spec.Backup.Configuration.RestoreOptions.NumDownloadWorkers,
-			MaxDownloadBufferMb: cluster.Spec.Backup.Configuration.RestoreOptions.MaxDownloadBufferMb,
-			DownloadChunkMb:     cluster.Spec.Backup.Configuration.RestoreOptions.DownloadChunkMb,
-			MongodLocation:      cluster.Spec.Backup.Configuration.RestoreOptions.MongodLocation,
-			MongodLocationMap:   cluster.Spec.Backup.Configuration.RestoreOptions.MongodLocationMap,
+			BatchSize:              cluster.Spec.Backup.Configuration.RestoreOptions.BatchSize,
+			NumInsertionWorkers:    cluster.Spec.Backup.Configuration.RestoreOptions.NumInsertionWorkers,
+			NumDownloadWorkers:     cluster.Spec.Backup.Configuration.RestoreOptions.NumDownloadWorkers,
+			NumParallelCollections: cluster.Spec.Backup.Configuration.RestoreOptions.NumParallelCollections,
+			MaxDownloadBufferMb:    cluster.Spec.Backup.Configuration.RestoreOptions.MaxDownloadBufferMb,
+			DownloadChunkMb:        cluster.Spec.Backup.Configuration.RestoreOptions.DownloadChunkMb,
+			MongodLocation:         cluster.Spec.Backup.Configuration.RestoreOptions.MongodLocation,
+			MongodLocationMap:      cluster.Spec.Backup.Configuration.RestoreOptions.MongodLocationMap,
 		}
 	}
 

--- a/pkg/psmdb/backup/pbm_test.go
+++ b/pkg/psmdb/backup/pbm_test.go
@@ -53,6 +53,10 @@ func TestApplyCustomPBMConfig(t *testing.T) {
 		t.Errorf("expected %d, got %d", expectedBackupOptions.Timeouts.Starting, config.Backup.Timeouts.Starting)
 	}
 
+	if expectedBackupOptions.NumParallelCollections != config.Backup.NumParallelCollections {
+		t.Errorf("expected %d, got %d", expectedBackupOptions.NumParallelCollections, config.Backup.NumParallelCollections)
+	}
+
 	expectedRestoreOptions := cr.Spec.Backup.Configuration.RestoreOptions
 	if expectedRestoreOptions.BatchSize != config.Restore.BatchSize {
 		t.Errorf("expected %d, got %d", expectedRestoreOptions.BatchSize, config.Restore.BatchSize)
@@ -63,6 +67,11 @@ func TestApplyCustomPBMConfig(t *testing.T) {
 	if expectedRestoreOptions.NumDownloadWorkers != config.Restore.NumDownloadWorkers {
 		t.Errorf("expected %d, got %d", expectedRestoreOptions.NumDownloadWorkers, config.Restore.NumDownloadWorkers)
 	}
+
+	if expectedRestoreOptions.NumParallelCollections != config.Restore.NumParallelCollections {
+		t.Errorf("expected %d, got %d", expectedRestoreOptions.NumParallelCollections, config.Restore.NumParallelCollections)
+	}
+
 	if expectedRestoreOptions.MaxDownloadBufferMb != config.Restore.MaxDownloadBufferMb {
 		t.Errorf("expected %d, got %d", expectedRestoreOptions.MaxDownloadBufferMb, config.Restore.MaxDownloadBufferMb)
 	}

--- a/pkg/psmdb/backup/testdata/cr-with-pbm-config.yaml
+++ b/pkg/psmdb/backup/testdata/cr-with-pbm-config.yaml
@@ -153,10 +153,12 @@ spec:
         timeouts:
           startingStatus: 33
         oplogSpanMin: 20
+        numParallelCollections: 2
       restoreOptions:
         batchSize: 500
         numInsertionWorkers: 10
         numDownloadWorkers: 4
+        numParallelCollections: 2
         maxDownloadBufferMb: 0
         downloadChunkMb: 32
         mongodLocation: /usr/bin/mongo


### PR DESCRIPTION
[![K8SPSMDB-1097](https://badgen.net/badge/JIRA/K8SPSMDB-1097/green)](https://jira.percona.com/browse/K8SPSMDB-1097) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
Optimize PBM’s resource usage to achieve faster backups without negatively affecting MongoDB’s performance. 

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
Adding the field NumParallelCollections to pbm configuration.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-1097]: https://perconadev.atlassian.net/browse/K8SPSMDB-1097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ