### PR TITLE
K8SPSMDB-1219: Main storage checks should only happen in versions >= 1.20

### DIFF
--- a/e2e-tests/custom-replset-name/conf/some-name.yml
+++ b/e2e-tests/custom-replset-name/conf/some-name.yml
@@ -3,7 +3,6 @@ kind: PerconaServerMongoDB
 metadata:
   name: some-name
 spec:
-  crVersion: 1.18.0
   backup:
     enabled: true
     image: percona/percona-backup-mongodb:2.0.4

--- a/pkg/apis/psmdb/v1/psmdb_defaults.go
+++ b/pkg/apis/psmdb/v1/psmdb_defaults.go
@@ -550,7 +550,7 @@ func (cr *PerconaServerMongoDB) CheckNSetDefaults(ctx context.Context, platform 
 			}
 		}
 
-		if len(cr.Spec.Backup.Storages) > 1 {
+		if cr.CompareVersion("1.20.0") >= 0 && len(cr.Spec.Backup.Storages) > 1 {
 			main := 0
 			for _, stg := range cr.Spec.Backup.Storages {
 				if stg.Main {

--- a/pkg/controller/perconaservermongodb/pbm.go
+++ b/pkg/controller/perconaservermongodb/pbm.go
@@ -24,8 +24,10 @@ func (r *ReconcilePerconaServerMongoDB) reconcilePBM(ctx context.Context, cr *ps
 	log := logf.FromContext(ctx).WithName("PBM")
 	ctx = logf.IntoContext(ctx, log)
 
-	if err := r.reconcilePBMConfig(ctx, cr); err != nil {
-		return errors.Wrap(err, "reconcile configuration")
+	if cr.CompareVersion("1.20.0") >= 0 {
+		if err := r.reconcilePBMConfig(ctx, cr); err != nil {
+			return errors.Wrap(err, "reconcile configuration")
+		}
 	}
 
 	if err := r.reconcilePiTRConfig(ctx, cr); err != nil {


### PR DESCRIPTION
[![K8SPSMDB-1219](https://badgen.net/badge/JIRA/K8SPSMDB-1219/green)](https://jira.percona.com/browse/K8SPSMDB-1219) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Only check main storage stuff if crVersion is >= 1.20

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-1219]: https://perconadev.atlassian.net/browse/K8SPSMDB-1219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ