### PR TITLE
K8SPSMDB-1306: Fix panic if user has a custom PBM config without timeouts

### DIFF
--- a/pkg/controller/perconaservermongodb/pbm.go
+++ b/pkg/controller/perconaservermongodb/pbm.go
@@ -119,8 +119,9 @@ func (r *ReconcilePerconaServerMongoDB) reconcilePBMConfig(ctx context.Context, 
 		return errors.Wrap(err, "set config")
 	}
 
-	if !reflect.DeepEqual(currentCfg.Storage, main.Storage) {
+	if isResyncNeeded(currentCfg, &main) {
 		log.Info("resync storage", "storage", mainStgName)
+		log.V(1).Info("main storage changed", "old", currentCfg.Storage, "new", main.Storage)
 
 		if err := pbm.ResyncMainStorage(ctx); err != nil {
 			return errors.Wrap(err, "resync")
@@ -139,6 +140,52 @@ func hashPBMConfiguration(c []config.Config) (string, error) {
 	}
 
 	return sha256Hash(v), nil
+}
+
+func isResyncNeeded(currentCfg *config.Config, newCfg *config.Config) bool {
+	if currentCfg.Storage.Type != newCfg.Storage.Type {
+		return true
+	}
+
+	if currentCfg.Storage.S3 != nil && newCfg.Storage.S3 != nil {
+		if currentCfg.Storage.S3.Bucket != newCfg.Storage.S3.Bucket {
+			return true
+		}
+
+		if currentCfg.Storage.S3.Region != newCfg.Storage.S3.Region {
+			return true
+		}
+
+		if currentCfg.Storage.S3.EndpointURL != newCfg.Storage.S3.EndpointURL {
+			return true
+		}
+
+		if currentCfg.Storage.S3.Prefix != newCfg.Storage.S3.Prefix {
+			return true
+		}
+	}
+
+	if currentCfg.Storage.Azure != nil && newCfg.Storage.Azure != nil {
+		if currentCfg.Storage.Azure.EndpointURL != newCfg.Storage.Azure.EndpointURL {
+			return true
+		}
+
+		if currentCfg.Storage.Azure.Container != newCfg.Storage.Azure.Container {
+			return true
+		}
+
+		if currentCfg.Storage.Azure.Account != newCfg.Storage.Azure.Account {
+			return true
+		}
+	}
+
+	if currentCfg.Storage.Filesystem != nil && newCfg.Storage.Filesystem != nil {
+		if currentCfg.Storage.Filesystem.Path != newCfg.Storage.Filesystem.Path {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (r *ReconcilePerconaServerMongoDB) reconcilePiTRConfig(ctx context.Context, cr *psmdbv1.PerconaServerMongoDB) error {

--- a/pkg/controller/perconaservermongodb/pbm_test.go
+++ b/pkg/controller/perconaservermongodb/pbm_test.go
@@ -1,0 +1,261 @@
+package perconaservermongodb
+
+import (
+	"testing"
+
+	"github.com/percona/percona-backup-mongodb/pbm/config"
+	"github.com/percona/percona-backup-mongodb/pbm/storage"
+	"github.com/percona/percona-backup-mongodb/pbm/storage/azure"
+	"github.com/percona/percona-backup-mongodb/pbm/storage/fs"
+	"github.com/percona/percona-backup-mongodb/pbm/storage/s3"
+)
+
+func TestIsResyncNeeded(t *testing.T) {
+	tests := []struct {
+		name       string
+		currentCfg *config.Config
+		newCfg     *config.Config
+		expected   bool
+	}{
+		{
+			"storage type changed",
+			&config.Config{
+				Storage: config.StorageConf{
+					Type: storage.S3,
+					S3: &s3.Config{
+						Bucket: "operator-testing",
+						Region: "us-east-1",
+					},
+				},
+			},
+			&config.Config{
+				Storage: config.StorageConf{
+					Type: storage.Azure,
+					Azure: &azure.Config{
+						Account:     "operator-account",
+						Container:   "operator-testing",
+						EndpointURL: "https://accountName.blob.core.windows.net",
+					},
+				},
+			},
+			true,
+		},
+		{
+			"s3: bucket changed",
+			&config.Config{
+				Storage: config.StorageConf{
+					Type: storage.S3,
+					S3: &s3.Config{
+						Bucket: "operator-testing",
+						Region: "us-east-1",
+					},
+				},
+			},
+			&config.Config{
+				Storage: config.StorageConf{
+					Type: storage.S3,
+					S3: &s3.Config{
+						Bucket: "operator-testing-1",
+						Region: "us-east-1",
+					},
+				},
+			},
+			true,
+		},
+		{
+			"s3: region changed",
+			&config.Config{
+				Storage: config.StorageConf{
+					Type: storage.S3,
+					S3: &s3.Config{
+						Bucket: "operator-testing",
+						Region: "us-east-1",
+					},
+				},
+			},
+			&config.Config{
+				Storage: config.StorageConf{
+					Type: storage.S3,
+					S3: &s3.Config{
+						Bucket: "operator-testing",
+						Region: "us-east-2",
+					},
+				},
+			},
+			true,
+		},
+		{
+			"s3: endpointUrl changed",
+			&config.Config{
+				Storage: config.StorageConf{
+					Type: storage.S3,
+					S3: &s3.Config{
+						Bucket: "operator-testing",
+						Region: "us-east-1",
+					},
+				},
+			},
+			&config.Config{
+				Storage: config.StorageConf{
+					Type: storage.S3,
+					S3: &s3.Config{
+						Bucket:      "operator-testing",
+						Region:      "us-east-1",
+						EndpointURL: "https://s3.us-east-1.amazonaws.com",
+					},
+				},
+			},
+			true,
+		},
+		{
+			"s3: prefix changed",
+			&config.Config{
+				Storage: config.StorageConf{
+					Type: storage.S3,
+					S3: &s3.Config{
+						Bucket:      "operator-testing",
+						Region:      "us-east-1",
+						EndpointURL: "https://s3.amazonaws.com",
+					},
+				},
+			},
+			&config.Config{
+				Storage: config.StorageConf{
+					Type: storage.S3,
+					S3: &s3.Config{
+						Bucket:      "operator-testing",
+						Region:      "us-east-1",
+						EndpointURL: "https://s3.amazonaws.com",
+						Prefix:      "prefix",
+					},
+				},
+			},
+			true,
+		},
+		{
+			"s3: maxUploadParts changed",
+			&config.Config{
+				Storage: config.StorageConf{
+					Type: storage.S3,
+					S3: &s3.Config{
+						Bucket:      "operator-testing",
+						Region:      "us-east-1",
+						EndpointURL: "https://s3.amazonaws.com",
+					},
+				},
+			},
+			&config.Config{
+				Storage: config.StorageConf{
+					Type: storage.S3,
+					S3: &s3.Config{
+						Bucket:         "operator-testing",
+						Region:         "us-east-1",
+						EndpointURL:    "https://s3.amazonaws.com",
+						MaxUploadParts: 2000,
+					},
+				},
+			},
+			false,
+		},
+		{
+			"azure: endpointUrl changed",
+			&config.Config{
+				Storage: config.StorageConf{
+					Type: storage.Azure,
+					Azure: &azure.Config{
+						Account:     "operator-account",
+						Container:   "operator-testing",
+						EndpointURL: "https://accountName.blob.core.windows.net",
+					},
+				},
+			},
+			&config.Config{
+				Storage: config.StorageConf{
+					Type: storage.Azure,
+					Azure: &azure.Config{
+						Account:     "operator-account",
+						Container:   "operator-testing",
+						EndpointURL: "https://accountName-1.blob.core.windows.net",
+					},
+				},
+			},
+			true,
+		},
+		{
+			"azure: container changed",
+			&config.Config{
+				Storage: config.StorageConf{
+					Type: storage.Azure,
+					Azure: &azure.Config{
+						Account:     "operator-account",
+						Container:   "operator-testing",
+						EndpointURL: "https://accountName.blob.core.windows.net",
+					},
+				},
+			},
+			&config.Config{
+				Storage: config.StorageConf{
+					Type: storage.Azure,
+					Azure: &azure.Config{
+						Account:     "operator-account",
+						Container:   "operator-testing-1",
+						EndpointURL: "https://accountName.blob.core.windows.net",
+					},
+				},
+			},
+			true,
+		},
+		{
+			"azure: account changed",
+			&config.Config{
+				Storage: config.StorageConf{
+					Type: storage.Azure,
+					Azure: &azure.Config{
+						Account:     "operator-account",
+						Container:   "operator-testing",
+						EndpointURL: "https://accountName.blob.core.windows.net",
+					},
+				},
+			},
+			&config.Config{
+				Storage: config.StorageConf{
+					Type: storage.Azure,
+					Azure: &azure.Config{
+						Account:     "operator-account-1",
+						Container:   "operator-testing",
+						EndpointURL: "https://accountName.blob.core.windows.net",
+					},
+				},
+			},
+			true,
+		},
+		{
+			"fs: path changed",
+			&config.Config{
+				Storage: config.StorageConf{
+					Type: storage.Filesystem,
+					Filesystem: &fs.Config{
+						Path: "/mnt/backups",
+					},
+				},
+			},
+			&config.Config{
+				Storage: config.StorageConf{
+					Type: storage.Filesystem,
+					Filesystem: &fs.Config{
+						Path: "/mnt/backups-1",
+					},
+				},
+			},
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isResyncNeeded(tt.currentCfg, tt.newCfg); got != tt.expected {
+				t.Errorf("%s: got %v, want %v", tt.name, got, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/psmdb/backup/pbm.go
+++ b/pkg/psmdb/backup/pbm.go
@@ -281,17 +281,20 @@ func GetPBMConfig(ctx context.Context, k8sclient client.Client, cluster *api.Per
 		},
 	}
 
-	if cluster.Spec.Backup.Configuration.BackupOptions != nil {
+	if opts := cluster.Spec.Backup.Configuration.BackupOptions; opts != nil {
 		conf.Backup = &config.BackupConf{
-			OplogSpanMin:           cluster.Spec.Backup.Configuration.BackupOptions.OplogSpanMin,
-			NumParallelCollections: cluster.Spec.Backup.Configuration.BackupOptions.NumParallelCollections,
-			Timeouts: &config.BackupTimeouts{
-				Starting: cluster.Spec.Backup.Configuration.BackupOptions.Timeouts.Starting,
-			},
+			OplogSpanMin:           opts.OplogSpanMin,
+			NumParallelCollections: opts.NumParallelCollections,
 		}
 
-		if cluster.Spec.Backup.Configuration.BackupOptions.Priority != nil {
-			conf.Backup.Priority = cluster.Spec.Backup.Configuration.BackupOptions.Priority
+		if opts.Timeouts != nil {
+			conf.Backup.Timeouts = &config.BackupTimeouts{
+				Starting: opts.Timeouts.Starting,
+			}
+		}
+
+		if opts.Priority != nil {
+			conf.Backup.Priority = opts.Priority
 		} else {
 			priority, err := GetPriorities(ctx, k8sclient, cluster)
 			if err != nil {


### PR DESCRIPTION
[![K8SPSMDB-1306](https://badgen.net/badge/JIRA/K8SPSMDB-1306/green)](https://jira.percona.com/browse/K8SPSMDB-1306) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

These changes also fix mistakenly starting resync when there's no need.


**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-1306]: https://perconadev.atlassian.net/browse/K8SPSMDB-1306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ