### PR TITLE
K8SPSMDB-1329: Add loadBalancerClass

### DIFF
--- a/config/crd/bases/psmdb.percona.com_perconaservermongodbs.yaml
+++ b/config/crd/bases/psmdb.percona.com_perconaservermongodbs.yaml
@@ -3431,6 +3431,8 @@ spec:
                           additionalProperties:
                             type: string
                           type: object
+                        loadBalancerClass:
+                          type: string
                         loadBalancerSourceRanges:
                           items:
                             type: string
@@ -11195,6 +11197,8 @@ spec:
                             additionalProperties:
                               type: string
                             type: object
+                          loadBalancerClass:
+                            type: string
                           loadBalancerSourceRanges:
                             items:
                               type: string
@@ -16651,6 +16655,8 @@ spec:
                             additionalProperties:
                               type: string
                             type: object
+                          loadBalancerClass:
+                            type: string
                           loadBalancerSourceRanges:
                             items:
                               type: string

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -4129,6 +4129,8 @@ spec:
                           additionalProperties:
                             type: string
                           type: object
+                        loadBalancerClass:
+                          type: string
                         loadBalancerSourceRanges:
                           items:
                             type: string
@@ -11893,6 +11895,8 @@ spec:
                             additionalProperties:
                               type: string
                             type: object
+                          loadBalancerClass:
+                            type: string
                           loadBalancerSourceRanges:
                             items:
                               type: string
@@ -17349,6 +17353,8 @@ spec:
                             additionalProperties:
                               type: string
                             type: object
+                          loadBalancerClass:
+                            type: string
                           loadBalancerSourceRanges:
                             items:
                               type: string

--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -224,6 +224,7 @@ spec:
     expose:
       enabled: false
       type: ClusterIP
+#      loadBalancerClass: "eks.amazonaws.com/nlb"
 #      loadBalancerSourceRanges:
 #        - 10.0.0.0/8
 #      annotations:
@@ -437,6 +438,7 @@ spec:
       expose:
         enabled: false
         type: ClusterIP
+#        loadBalancerClass: "eks.amazonaws.com/nlb"
 #        loadBalancerSourceRanges:
 #          - 10.0.0.0/8
 #        annotations:
@@ -548,6 +550,7 @@ spec:
       expose:
         type: ClusterIP
 #        servicePerPod: true
+#        loadBalancerClass: "eks.amazonaws.com/nlb"
 #        loadBalancerSourceRanges:
 #          - 10.0.0.0/8
 #        annotations:

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -4129,6 +4129,8 @@ spec:
                           additionalProperties:
                             type: string
                           type: object
+                        loadBalancerClass:
+                          type: string
                         loadBalancerSourceRanges:
                           items:
                             type: string
@@ -11893,6 +11895,8 @@ spec:
                             additionalProperties:
                               type: string
                             type: object
+                          loadBalancerClass:
+                            type: string
                           loadBalancerSourceRanges:
                             items:
                               type: string
@@ -17349,6 +17353,8 @@ spec:
                             additionalProperties:
                               type: string
                             type: object
+                          loadBalancerClass:
+                            type: string
                           loadBalancerSourceRanges:
                             items:
                               type: string

--- a/deploy/cw-bundle.yaml
+++ b/deploy/cw-bundle.yaml
@@ -4129,6 +4129,8 @@ spec:
                           additionalProperties:
                             type: string
                           type: object
+                        loadBalancerClass:
+                          type: string
                         loadBalancerSourceRanges:
                           items:
                             type: string
@@ -11893,6 +11895,8 @@ spec:
                             additionalProperties:
                               type: string
                             type: object
+                          loadBalancerClass:
+                            type: string
                           loadBalancerSourceRanges:
                             items:
                               type: string
@@ -17349,6 +17353,8 @@ spec:
                             additionalProperties:
                               type: string
                             type: object
+                          loadBalancerClass:
+                            type: string
                           loadBalancerSourceRanges:
                             items:
                               type: string

--- a/e2e-tests/version-service/conf/crd.yaml
+++ b/e2e-tests/version-service/conf/crd.yaml
@@ -4129,6 +4129,8 @@ spec:
                           additionalProperties:
                             type: string
                           type: object
+                        loadBalancerClass:
+                          type: string
                         loadBalancerSourceRanges:
                           items:
                             type: string
@@ -11893,6 +11895,8 @@ spec:
                             additionalProperties:
                               type: string
                             type: object
+                          loadBalancerClass:
+                            type: string
                           loadBalancerSourceRanges:
                             items:
                               type: string
@@ -17349,6 +17353,8 @@ spec:
                             additionalProperties:
                               type: string
                             type: object
+                          loadBalancerClass:
+                            type: string
                           loadBalancerSourceRanges:
                             items:
                               type: string

--- a/pkg/apis/psmdb/v1/psmdb_types.go
+++ b/pkg/apis/psmdb/v1/psmdb_types.go
@@ -1107,6 +1107,12 @@ type Expose struct {
 
 	LoadBalancerSourceRanges []string `json:"loadBalancerSourceRanges,omitempty"`
 
+	// LoadBalancerClass is the class of the load balancer implementation the Service belongs to.
+	// This field can only be set when the Service type is 'LoadBalancer'.
+	// This field can only be set when creating or updating a Service to type 'LoadBalancer'.
+	// Once set, it can not be changed.
+	LoadBalancerClass *string `json:"loadBalancerClass,omitempty"`
+
 	ServiceAnnotations           map[string]string `json:"annotations,omitempty"`
 	DeprecatedServiceAnnotations map[string]string `json:"serviceAnnotations,omitempty"`
 

--- a/pkg/apis/psmdb/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/psmdb/v1/zz_generated.deepcopy.go
@@ -306,6 +306,11 @@ func (in *Expose) DeepCopyInto(out *Expose) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.LoadBalancerClass != nil {
+		in, out := &in.LoadBalancerClass, &out.LoadBalancerClass
+		*out = new(string)
+		**out = **in
+	}
 	if in.ServiceAnnotations != nil {
 		in, out := &in.ServiceAnnotations, &out.ServiceAnnotations
 		*out = make(map[string]string, len(*in))

--- a/pkg/psmdb/mongos.go
+++ b/pkg/psmdb/mongos.go
@@ -476,6 +476,9 @@ func MongosServiceSpec(cr *api.PerconaServerMongoDB, podName string) corev1.Serv
 			spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeCluster
 		}
 		spec.LoadBalancerSourceRanges = cr.Spec.Sharding.Mongos.Expose.LoadBalancerSourceRanges
+		if cr.CompareVersion("1.20.0") >= 0 {
+			spec.LoadBalancerClass = cr.Spec.Sharding.Mongos.Expose.LoadBalancerClass
+		}
 	default:
 		spec.Type = corev1.ServiceTypeClusterIP
 	}

--- a/pkg/psmdb/mongos_test.go
+++ b/pkg/psmdb/mongos_test.go
@@ -1,187 +1,33 @@
 package psmdb
 
 import (
-	"context"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/ptr"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
 	"github.com/percona/percona-server-mongodb-operator/version"
 )
 
-func TestMongosHost(t *testing.T) {
-	ctx := context.Background()
-
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "mongos-0",
-			Namespace: "default",
-		},
-	}
-
-	tests := map[string]struct {
-		init          func(cl client.Client)
-		cr            *api.PerconaServerMongoDB
-		expectedHost  string
-		expectedError error
-	}{
-		"service not found": {
-			init: func(cl client.Client) {},
-			cr: &api.PerconaServerMongoDB{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-cluster",
-					Namespace: "default",
-				},
-				Spec: api.PerconaServerMongoDBSpec{
-					ClusterServiceDNSSuffix: "svc.cluster.local",
-					Sharding: api.Sharding{
-						Mongos: &api.MongosSpec{
-							Expose: api.MongosExpose{
-								ServicePerPod: false,
-							},
-						},
-					},
-				},
-			},
-			expectedHost: "",
-		},
-		"clusterip service type": {
-			init: func(cl client.Client) {
-				svc := &corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-cluster-mongos",
-						Namespace: "default",
-					},
-					Spec: corev1.ServiceSpec{
-						Type: corev1.ServiceTypeClusterIP,
-						Ports: []corev1.ServicePort{
-							{
-								Name: "mongos",
-								Port: 27018,
-							},
-							{
-								Name: "random",
-								Port: 12345,
-							},
-						},
-					},
-				}
-				assert.NoError(t, cl.Create(ctx, svc))
-			},
-			cr: &api.PerconaServerMongoDB{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-cluster",
-					Namespace: "default",
-				},
-				Spec: api.PerconaServerMongoDBSpec{
-					ClusterServiceDNSSuffix: "svc.cluster.local",
-					Sharding: api.Sharding{
-						Mongos: &api.MongosSpec{
-							Expose: api.MongosExpose{
-								ServicePerPod: false,
-							},
-						},
-					},
-				},
-			},
-			expectedHost: "test-cluster-mongos.default.svc.cluster.local:27018",
-		},
-		"err: clusterip service type and port not found": {
-			init: func(cl client.Client) {
-				svc := &corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-cluster-mongos",
-						Namespace: "default",
-					},
-					Spec: corev1.ServiceSpec{
-						Type: corev1.ServiceTypeClusterIP,
-						Ports: []corev1.ServicePort{
-							{
-								Name: "random",
-								Port: 12345,
-							},
-						},
-					},
-				}
-				assert.NoError(t, cl.Create(ctx, svc))
-			},
-			cr: &api.PerconaServerMongoDB{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-cluster",
-					Namespace: "default",
-				},
-				Spec: api.PerconaServerMongoDBSpec{
-					ClusterServiceDNSSuffix: "svc.cluster.local",
-					Sharding: api.Sharding{
-						Mongos: &api.MongosSpec{
-							Expose: api.MongosExpose{
-								ServicePerPod: false,
-							},
-						},
-					},
-				},
-			},
-			expectedError: errors.New("mongos port not found in service"),
-		},
-	}
-	for name, tt := range tests {
-		t.Run(name, func(t *testing.T) {
-			s := scheme.Scheme
-			cl := fake.NewClientBuilder().WithScheme(s).Build()
-			assert.NotNil(t, cl)
-			tt.init(cl)
-
-			host, err := MongosHost(ctx, cl, tt.cr, pod, false)
-			if tt.expectedError != nil {
-				assert.Empty(t, host)
-				assert.EqualError(t, err, tt.expectedError.Error())
-				return
-			}
-			assert.Equal(t, tt.expectedHost, host)
-			assert.NoError(t, err)
-		})
-	}
-}
-
 func TestMongosService(t *testing.T) {
 	tests := map[string]struct {
-		cr           *api.PerconaServerMongoDB
+		expose       api.Expose
 		podName      string
 		expectedSpec corev1.ServiceSpec
 	}{
 		"ClusterIP": {
-			cr: &api.PerconaServerMongoDB{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-cr",
-					Namespace: "test-ns",
+			expose: api.Expose{
+				ServiceLabels: map[string]string{
+					"percona.com/test": "label",
 				},
-				Spec: api.PerconaServerMongoDBSpec{
-					CRVersion: version.Version,
-					Sharding: api.Sharding{
-						Mongos: &api.MongosSpec{
-							Expose: api.MongosExpose{
-								Expose: api.Expose{
-									ServiceLabels: map[string]string{
-										"percona.com/test": "label",
-									},
-									ServiceAnnotations: map[string]string{
-										"percona.com/test": "annotation",
-									},
-									ExposeType: corev1.ServiceTypeClusterIP,
-								},
-							},
-						},
-					},
+				ServiceAnnotations: map[string]string{
+					"percona.com/test": "annotation",
 				},
+				ExposeType: corev1.ServiceTypeClusterIP,
 			},
 			podName: "test-cr-mongos-0",
 			expectedSpec: corev1.ServiceSpec{
@@ -204,29 +50,14 @@ func TestMongosService(t *testing.T) {
 			},
 		},
 		"NodePort": {
-			cr: &api.PerconaServerMongoDB{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-cr",
-					Namespace: "test-ns",
+			expose: api.Expose{
+				ServiceLabels: map[string]string{
+					"percona.com/test": "label",
 				},
-				Spec: api.PerconaServerMongoDBSpec{
-					CRVersion: version.Version,
-					Sharding: api.Sharding{
-						Mongos: &api.MongosSpec{
-							Expose: api.MongosExpose{
-								Expose: api.Expose{
-									ServiceLabels: map[string]string{
-										"percona.com/test": "label",
-									},
-									ServiceAnnotations: map[string]string{
-										"percona.com/test": "annotation",
-									},
-									ExposeType: corev1.ServiceTypeNodePort,
-								},
-							},
-						},
-					},
+				ServiceAnnotations: map[string]string{
+					"percona.com/test": "annotation",
 				},
+				ExposeType: corev1.ServiceTypeNodePort,
 			},
 			podName: "test-cr-mongos-0",
 			expectedSpec: corev1.ServiceSpec{
@@ -250,31 +81,16 @@ func TestMongosService(t *testing.T) {
 			},
 		},
 		"LoadBalancer": {
-			cr: &api.PerconaServerMongoDB{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-cr",
-					Namespace: "test-ns",
+			expose: api.Expose{
+				ServiceLabels: map[string]string{
+					"percona.com/test": "label",
 				},
-				Spec: api.PerconaServerMongoDBSpec{
-					CRVersion: version.Version,
-					Sharding: api.Sharding{
-						Mongos: &api.MongosSpec{
-							Expose: api.MongosExpose{
-								Expose: api.Expose{
-									ServiceLabels: map[string]string{
-										"percona.com/test": "label",
-									},
-									ServiceAnnotations: map[string]string{
-										"percona.com/test": "annotation",
-									},
-									ExposeType:               corev1.ServiceTypeLoadBalancer,
-									LoadBalancerClass:        ptr.To("eks.amazonaws.com/nlb"),
-									LoadBalancerSourceRanges: []string{"10.0.0.0/16"},
-								},
-							},
-						},
-					},
+				ServiceAnnotations: map[string]string{
+					"percona.com/test": "annotation",
 				},
+				ExposeType:               corev1.ServiceTypeLoadBalancer,
+				LoadBalancerClass:        ptr.To("eks.amazonaws.com/nlb"),
+				LoadBalancerSourceRanges: []string{"10.0.0.0/16"},
 			},
 			podName: "test-cr-mongos-0",
 			expectedSpec: corev1.ServiceSpec{
@@ -302,7 +118,23 @@ func TestMongosService(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			spec := MongosServiceSpec(tt.cr, tt.podName)
+			cr := &api.PerconaServerMongoDB{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cr",
+					Namespace: "test-ns",
+				},
+				Spec: api.PerconaServerMongoDBSpec{
+					CRVersion: version.Version,
+					Sharding: api.Sharding{
+						Mongos: &api.MongosSpec{
+							Expose: api.MongosExpose{
+								Expose: tt.expose,
+							},
+						},
+					},
+				},
+			}
+			spec := MongosServiceSpec(cr, tt.podName)
 			assert.Equal(t, tt.expectedSpec, spec)
 		})
 	}

--- a/pkg/psmdb/mongos_test.go
+++ b/pkg/psmdb/mongos_test.go
@@ -1,0 +1,310 @@
+package psmdb
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
+	"github.com/percona/percona-server-mongodb-operator/version"
+)
+
+func TestMongosHost(t *testing.T) {
+	ctx := context.Background()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mongos-0",
+			Namespace: "default",
+		},
+	}
+
+	tests := map[string]struct {
+		init          func(cl client.Client)
+		cr            *api.PerconaServerMongoDB
+		expectedHost  string
+		expectedError error
+	}{
+		"service not found": {
+			init: func(cl client.Client) {},
+			cr: &api.PerconaServerMongoDB{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "default",
+				},
+				Spec: api.PerconaServerMongoDBSpec{
+					ClusterServiceDNSSuffix: "svc.cluster.local",
+					Sharding: api.Sharding{
+						Mongos: &api.MongosSpec{
+							Expose: api.MongosExpose{
+								ServicePerPod: false,
+							},
+						},
+					},
+				},
+			},
+			expectedHost: "",
+		},
+		"clusterip service type": {
+			init: func(cl client.Client) {
+				svc := &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-cluster-mongos",
+						Namespace: "default",
+					},
+					Spec: corev1.ServiceSpec{
+						Type: corev1.ServiceTypeClusterIP,
+						Ports: []corev1.ServicePort{
+							{
+								Name: "mongos",
+								Port: 27018,
+							},
+							{
+								Name: "random",
+								Port: 12345,
+							},
+						},
+					},
+				}
+				assert.NoError(t, cl.Create(ctx, svc))
+			},
+			cr: &api.PerconaServerMongoDB{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "default",
+				},
+				Spec: api.PerconaServerMongoDBSpec{
+					ClusterServiceDNSSuffix: "svc.cluster.local",
+					Sharding: api.Sharding{
+						Mongos: &api.MongosSpec{
+							Expose: api.MongosExpose{
+								ServicePerPod: false,
+							},
+						},
+					},
+				},
+			},
+			expectedHost: "test-cluster-mongos.default.svc.cluster.local:27018",
+		},
+		"err: clusterip service type and port not found": {
+			init: func(cl client.Client) {
+				svc := &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-cluster-mongos",
+						Namespace: "default",
+					},
+					Spec: corev1.ServiceSpec{
+						Type: corev1.ServiceTypeClusterIP,
+						Ports: []corev1.ServicePort{
+							{
+								Name: "random",
+								Port: 12345,
+							},
+						},
+					},
+				}
+				assert.NoError(t, cl.Create(ctx, svc))
+			},
+			cr: &api.PerconaServerMongoDB{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "default",
+				},
+				Spec: api.PerconaServerMongoDBSpec{
+					ClusterServiceDNSSuffix: "svc.cluster.local",
+					Sharding: api.Sharding{
+						Mongos: &api.MongosSpec{
+							Expose: api.MongosExpose{
+								ServicePerPod: false,
+							},
+						},
+					},
+				},
+			},
+			expectedError: errors.New("mongos port not found in service"),
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			s := scheme.Scheme
+			cl := fake.NewClientBuilder().WithScheme(s).Build()
+			assert.NotNil(t, cl)
+			tt.init(cl)
+
+			host, err := MongosHost(ctx, cl, tt.cr, pod, false)
+			if tt.expectedError != nil {
+				assert.Empty(t, host)
+				assert.EqualError(t, err, tt.expectedError.Error())
+				return
+			}
+			assert.Equal(t, tt.expectedHost, host)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestMongosService(t *testing.T) {
+	tests := map[string]struct {
+		cr           *api.PerconaServerMongoDB
+		podName      string
+		expectedSpec corev1.ServiceSpec
+	}{
+		"ClusterIP": {
+			cr: &api.PerconaServerMongoDB{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cr",
+					Namespace: "test-ns",
+				},
+				Spec: api.PerconaServerMongoDBSpec{
+					CRVersion: version.Version,
+					Sharding: api.Sharding{
+						Mongos: &api.MongosSpec{
+							Expose: api.MongosExpose{
+								Expose: api.Expose{
+									ServiceLabels: map[string]string{
+										"percona.com/test": "label",
+									},
+									ServiceAnnotations: map[string]string{
+										"percona.com/test": "annotation",
+									},
+									ExposeType: corev1.ServiceTypeClusterIP,
+								},
+							},
+						},
+					},
+				},
+			},
+			podName: "test-cr-mongos-0",
+			expectedSpec: corev1.ServiceSpec{
+				PublishNotReadyAddresses: false,
+				Ports: []corev1.ServicePort{
+					{
+						Name:       "mongos",
+						Port:       27017,
+						TargetPort: intstr.FromInt(27017),
+					},
+				},
+				Selector: map[string]string{
+					"app.kubernetes.io/component":  "mongos",
+					"app.kubernetes.io/instance":   "test-cr",
+					"app.kubernetes.io/managed-by": "percona-server-mongodb-operator",
+					"app.kubernetes.io/name":       "percona-server-mongodb",
+					"app.kubernetes.io/part-of":    "percona-server-mongodb",
+				},
+				Type: corev1.ServiceTypeClusterIP,
+			},
+		},
+		"NodePort": {
+			cr: &api.PerconaServerMongoDB{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cr",
+					Namespace: "test-ns",
+				},
+				Spec: api.PerconaServerMongoDBSpec{
+					CRVersion: version.Version,
+					Sharding: api.Sharding{
+						Mongos: &api.MongosSpec{
+							Expose: api.MongosExpose{
+								Expose: api.Expose{
+									ServiceLabels: map[string]string{
+										"percona.com/test": "label",
+									},
+									ServiceAnnotations: map[string]string{
+										"percona.com/test": "annotation",
+									},
+									ExposeType: corev1.ServiceTypeNodePort,
+								},
+							},
+						},
+					},
+				},
+			},
+			podName: "test-cr-mongos-0",
+			expectedSpec: corev1.ServiceSpec{
+				PublishNotReadyAddresses: false,
+				Ports: []corev1.ServicePort{
+					{
+						Name:       "mongos",
+						Port:       27017,
+						TargetPort: intstr.FromInt(27017),
+					},
+				},
+				Selector: map[string]string{
+					"app.kubernetes.io/component":  "mongos",
+					"app.kubernetes.io/instance":   "test-cr",
+					"app.kubernetes.io/managed-by": "percona-server-mongodb-operator",
+					"app.kubernetes.io/name":       "percona-server-mongodb",
+					"app.kubernetes.io/part-of":    "percona-server-mongodb",
+				},
+				Type:                  corev1.ServiceTypeNodePort,
+				ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyCluster,
+			},
+		},
+		"LoadBalancer": {
+			cr: &api.PerconaServerMongoDB{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cr",
+					Namespace: "test-ns",
+				},
+				Spec: api.PerconaServerMongoDBSpec{
+					CRVersion: version.Version,
+					Sharding: api.Sharding{
+						Mongos: &api.MongosSpec{
+							Expose: api.MongosExpose{
+								Expose: api.Expose{
+									ServiceLabels: map[string]string{
+										"percona.com/test": "label",
+									},
+									ServiceAnnotations: map[string]string{
+										"percona.com/test": "annotation",
+									},
+									ExposeType:               corev1.ServiceTypeLoadBalancer,
+									LoadBalancerClass:        ptr.To("eks.amazonaws.com/nlb"),
+									LoadBalancerSourceRanges: []string{"10.0.0.0/16"},
+								},
+							},
+						},
+					},
+				},
+			},
+			podName: "test-cr-mongos-0",
+			expectedSpec: corev1.ServiceSpec{
+				PublishNotReadyAddresses: false,
+				Ports: []corev1.ServicePort{
+					{
+						Name:       "mongos",
+						Port:       27017,
+						TargetPort: intstr.FromInt(27017),
+					},
+				},
+				Selector: map[string]string{
+					"app.kubernetes.io/component":  "mongos",
+					"app.kubernetes.io/instance":   "test-cr",
+					"app.kubernetes.io/managed-by": "percona-server-mongodb-operator",
+					"app.kubernetes.io/name":       "percona-server-mongodb",
+					"app.kubernetes.io/part-of":    "percona-server-mongodb",
+				},
+				Type:                     corev1.ServiceTypeLoadBalancer,
+				ExternalTrafficPolicy:    corev1.ServiceExternalTrafficPolicyLocal,
+				LoadBalancerClass:        ptr.To("eks.amazonaws.com/nlb"),
+				LoadBalancerSourceRanges: []string{"10.0.0.0/16"},
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			spec := MongosServiceSpec(tt.cr, tt.podName)
+			assert.Equal(t, tt.expectedSpec, spec)
+		})
+	}
+
+}

--- a/pkg/psmdb/service.go
+++ b/pkg/psmdb/service.go
@@ -120,6 +120,9 @@ func ExternalService(cr *api.PerconaServerMongoDB, replset *api.ReplsetSpec, pod
 			svc.Spec.ExternalTrafficPolicy = corev1.ServiceExternalTrafficPolicyTypeCluster
 		}
 		svc.Spec.LoadBalancerSourceRanges = replset.Expose.LoadBalancerSourceRanges
+		if cr.CompareVersion("1.20.0") >= 0 {
+			svc.Spec.LoadBalancerClass = replset.Expose.LoadBalancerClass
+		}
 	default:
 		svc.Spec.Type = corev1.ServiceTypeClusterIP
 	}

--- a/pkg/psmdb/service_test.go
+++ b/pkg/psmdb/service_test.go
@@ -1,150 +1,220 @@
 package psmdb
 
 import (
-	"context"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 
 	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
+	"github.com/percona/percona-server-mongodb-operator/version"
 )
 
-func TestMongosHost(t *testing.T) {
-	ctx := context.Background()
-
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "mongos-0",
-			Namespace: "default",
-		},
-	}
-
+func TestExternalService(t *testing.T) {
 	tests := map[string]struct {
-		init          func(cl client.Client)
-		cr            *api.PerconaServerMongoDB
-		expectedHost  string
-		expectedError error
+		cr          *api.PerconaServerMongoDB
+		replset     *api.ReplsetSpec
+		podName     string
+		expectedSvc *corev1.Service
 	}{
-		"service not found": {
-			init: func(cl client.Client) {},
+		"ClusterIP": {
 			cr: &api.PerconaServerMongoDB{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-cluster",
-					Namespace: "default",
+					Name:      "test-cr",
+					Namespace: "test-ns",
 				},
 				Spec: api.PerconaServerMongoDBSpec{
-					ClusterServiceDNSSuffix: "svc.cluster.local",
-					Sharding: api.Sharding{
-						Mongos: &api.MongosSpec{
-							Expose: api.MongosExpose{
-								ServicePerPod: false,
-							},
+					CRVersion: version.Version,
+				},
+			},
+			replset: &api.ReplsetSpec{
+				Name: "rs0",
+				Expose: api.ExposeTogglable{
+					Enabled: true,
+					Expose: api.Expose{
+						ServiceLabels: map[string]string{
+							"percona.com/test": "label",
 						},
+						ServiceAnnotations: map[string]string{
+							"percona.com/test": "annotation",
+						},
+						ExposeType: corev1.ServiceTypeClusterIP,
 					},
 				},
 			},
-			expectedHost: "",
+			podName: "test-cr-rs0-0",
+			expectedSvc: &corev1.Service{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Service",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cr-rs0-0",
+					Namespace: "test-ns",
+					Labels: map[string]string{
+						"app.kubernetes.io/component":  "external-service",
+						"app.kubernetes.io/instance":   "test-cr",
+						"app.kubernetes.io/managed-by": "percona-server-mongodb-operator",
+						"app.kubernetes.io/name":       "percona-server-mongodb",
+						"app.kubernetes.io/part-of":    "percona-server-mongodb",
+						"app.kubernetes.io/replset":    "rs0",
+						"percona.com/test":             "label",
+					},
+					Annotations: map[string]string{
+						"percona.com/test": "annotation",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					PublishNotReadyAddresses: true,
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "mongodb",
+							Port:       27017,
+							TargetPort: intstr.FromInt(27017),
+						},
+					},
+					Selector: map[string]string{"statefulset.kubernetes.io/pod-name": "test-cr-rs0-0"},
+					Type:     corev1.ServiceTypeClusterIP,
+				},
+			},
 		},
-		"clusterip service type": {
-			init: func(cl client.Client) {
-				svc := &corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-cluster-mongos",
-						Namespace: "default",
-					},
-					Spec: corev1.ServiceSpec{
-						Type: corev1.ServiceTypeClusterIP,
-						Ports: []corev1.ServicePort{
-							{
-								Name: "mongos",
-								Port: 27018,
-							},
-							{
-								Name: "random",
-								Port: 12345,
-							},
-						},
-					},
-				}
-				assert.NoError(t, cl.Create(ctx, svc))
-			},
+		"NodePort": {
 			cr: &api.PerconaServerMongoDB{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-cluster",
-					Namespace: "default",
+					Name:      "test-cr",
+					Namespace: "test-ns",
 				},
 				Spec: api.PerconaServerMongoDBSpec{
-					ClusterServiceDNSSuffix: "svc.cluster.local",
-					Sharding: api.Sharding{
-						Mongos: &api.MongosSpec{
-							Expose: api.MongosExpose{
-								ServicePerPod: false,
-							},
+					CRVersion: version.Version,
+				},
+			},
+			replset: &api.ReplsetSpec{
+				Name: "rs0",
+				Expose: api.ExposeTogglable{
+					Enabled: true,
+					Expose: api.Expose{
+						ServiceLabels: map[string]string{
+							"percona.com/test": "label",
 						},
+						ServiceAnnotations: map[string]string{
+							"percona.com/test": "annotation",
+						},
+						ExposeType: corev1.ServiceTypeNodePort,
 					},
 				},
 			},
-			expectedHost: "test-cluster-mongos.default.svc.cluster.local:27018",
+			podName: "test-cr-rs0-0",
+			expectedSvc: &corev1.Service{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Service",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cr-rs0-0",
+					Namespace: "test-ns",
+					Labels: map[string]string{
+						"app.kubernetes.io/component":  "external-service",
+						"app.kubernetes.io/instance":   "test-cr",
+						"app.kubernetes.io/managed-by": "percona-server-mongodb-operator",
+						"app.kubernetes.io/name":       "percona-server-mongodb",
+						"app.kubernetes.io/part-of":    "percona-server-mongodb",
+						"app.kubernetes.io/replset":    "rs0",
+						"percona.com/test":             "label",
+					},
+					Annotations: map[string]string{
+						"percona.com/test": "annotation",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					PublishNotReadyAddresses: true,
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "mongodb",
+							Port:       27017,
+							TargetPort: intstr.FromInt(27017),
+						},
+					},
+					Selector:              map[string]string{"statefulset.kubernetes.io/pod-name": "test-cr-rs0-0"},
+					Type:                  corev1.ServiceTypeNodePort,
+					ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyCluster,
+				},
+			},
 		},
-		"err: clusterip service type and port not found": {
-			init: func(cl client.Client) {
-				svc := &corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-cluster-mongos",
-						Namespace: "default",
-					},
-					Spec: corev1.ServiceSpec{
-						Type: corev1.ServiceTypeClusterIP,
-						Ports: []corev1.ServicePort{
-							{
-								Name: "random",
-								Port: 12345,
-							},
-						},
-					},
-				}
-				assert.NoError(t, cl.Create(ctx, svc))
-			},
+		"LoadBalancer": {
 			cr: &api.PerconaServerMongoDB{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-cluster",
-					Namespace: "default",
+					Name:      "test-cr",
+					Namespace: "test-ns",
 				},
 				Spec: api.PerconaServerMongoDBSpec{
-					ClusterServiceDNSSuffix: "svc.cluster.local",
-					Sharding: api.Sharding{
-						Mongos: &api.MongosSpec{
-							Expose: api.MongosExpose{
-								ServicePerPod: false,
-							},
+					CRVersion: version.Version,
+				},
+			},
+			replset: &api.ReplsetSpec{
+				Name: "rs0",
+				Expose: api.ExposeTogglable{
+					Enabled: true,
+					Expose: api.Expose{
+						ServiceLabels: map[string]string{
+							"percona.com/test": "label",
 						},
+						ServiceAnnotations: map[string]string{
+							"percona.com/test": "annotation",
+						},
+						ExposeType:               corev1.ServiceTypeLoadBalancer,
+						LoadBalancerClass:        ptr.To("eks.amazonaws.com/nlb"),
+						LoadBalancerSourceRanges: []string{"10.0.0.0/16"},
 					},
 				},
 			},
-			expectedError: errors.New("mongos port not found in service"),
+			podName: "test-cr-rs0-0",
+			expectedSvc: &corev1.Service{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Service",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cr-rs0-0",
+					Namespace: "test-ns",
+					Labels: map[string]string{
+						"app.kubernetes.io/component":  "external-service",
+						"app.kubernetes.io/instance":   "test-cr",
+						"app.kubernetes.io/managed-by": "percona-server-mongodb-operator",
+						"app.kubernetes.io/name":       "percona-server-mongodb",
+						"app.kubernetes.io/part-of":    "percona-server-mongodb",
+						"app.kubernetes.io/replset":    "rs0",
+						"percona.com/test":             "label",
+					},
+					Annotations: map[string]string{
+						"percona.com/test": "annotation",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					PublishNotReadyAddresses: true,
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "mongodb",
+							Port:       27017,
+							TargetPort: intstr.FromInt(27017),
+						},
+					},
+					Selector:                 map[string]string{"statefulset.kubernetes.io/pod-name": "test-cr-rs0-0"},
+					Type:                     corev1.ServiceTypeLoadBalancer,
+					ExternalTrafficPolicy:    corev1.ServiceExternalTrafficPolicyLocal,
+					LoadBalancerClass:        ptr.To("eks.amazonaws.com/nlb"),
+					LoadBalancerSourceRanges: []string{"10.0.0.0/16"},
+				},
+			},
 		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			s := scheme.Scheme
-			cl := fake.NewClientBuilder().WithScheme(s).Build()
-			assert.NotNil(t, cl)
-			tt.init(cl)
-
-			host, err := MongosHost(ctx, cl, tt.cr, pod, false)
-			if tt.expectedError != nil {
-				assert.Empty(t, host)
-				assert.EqualError(t, err, tt.expectedError.Error())
-				return
-			}
-			assert.Equal(t, tt.expectedHost, host)
-			assert.NoError(t, err)
+			svc := ExternalService(tt.cr, tt.replset, tt.podName)
+			assert.Equal(t, tt.expectedSvc, svc)
 		})
 	}
+
 }


### PR DESCRIPTION
[![K8SPSMDB-1329](https://badgen.net/badge/JIRA/K8SPSMDB-1329/green)](https://jira.percona.com/browse/K8SPSMDB-1329) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
Support [loadBalancerClass](https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-class) in expose sections.

Helm chart PR: https://github.com/percona/percona-helm-charts/pull/525

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-1329]: https://perconadev.atlassian.net/browse/K8SPSMDB-1329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ