### PR TITLE
K8SPSMDB-1325: Add directShardOperation role to clusterAdmin and clusterMonitor

### DIFF
--- a/e2e-tests/custom-replset-name/conf/some-name.yml
+++ b/e2e-tests/custom-replset-name/conf/some-name.yml
@@ -5,7 +5,7 @@ metadata:
 spec:
   backup:
     enabled: true
-    image: percona/percona-backup-mongodb:2.0.4
+    image:
     pitr:
       enabled: false
     serviceAccountName: percona-server-mongodb-operator
@@ -33,7 +33,7 @@ spec:
           bucket: operator-testing
           prefix: psmdb
           endpointUrl: https://storage.googleapis.com
-  image: percona/percona-server-mongodb:4.4.10-11
+  image:
   imagePullPolicy: Always
   pmm:
     enabled: false

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -881,7 +881,11 @@ compare_mongo_cmd() {
 		| $sed -re 's/ObjectId\("[0-9a-f]+"\)//; s/-[0-9]+.svc/-xxx.svc/' \
 			>$tmp_dir/${command}${postfix}
 
-	diff -u ${test_dir}/compare/${command}${postfix}.json $tmp_dir/${command}${postfix}
+	if [[ ${UPDATE_COMPARE_FILES} -eq 0 ]]; then
+		diff -u ${test_dir}/compare/${command}${postfix}.json $tmp_dir/${command}${postfix}
+	else
+		cp $tmp_dir/${command}${postfix} ${test_dir}/compare/${command}${postfix}.json
+	fi
 }
 
 compare_mongos_cmd() {
@@ -897,7 +901,12 @@ compare_mongos_cmd() {
 		| egrep -v 'I NETWORK|W NETWORK|Error saving history file|Percona Server for MongoDB|connecting to:|Unable to reach primary for set|Implicit session:|versions do not match|Error saving history file:' \
 		| $sed -re 's/ObjectId\("[0-9a-f]+"\)//; s/-[0-9]+.svc/-xxx.svc/' \
 			>$tmp_dir/${command}${postfix}
-	diff ${test_dir}/compare/${command}${postfix}.json $tmp_dir/${command}${postfix}
+
+	if [[ ${UPDATE_COMPARE_FILES} -eq 0 ]]; then
+		diff ${test_dir}/compare/${command}${postfix}.json $tmp_dir/${command}${postfix}
+	else
+		cp $tmp_dir/${command}${postfix} ${test_dir}/compare/${command}${postfix}.json
+	fi
 }
 
 get_mongo_primary_endpoint() {
@@ -959,7 +968,12 @@ compare_mongo_user() {
 		| sed -e '$s/,$/}/' \
 		| jq '.authInfo.authenticatedUserPrivileges|=sort_by(.resource.anyResource, .resource.cluster, .resource.db, .resource.collection)|.authInfo.authenticatedUserRoles|=sort_by(.role)' \
 			>$tmp_dir/$user.json
-	diff -u $expected_result $tmp_dir/$user.json
+
+	if [[ ${UPDATE_COMPARE_FILES} -eq 0 ]]; then
+		diff -u $expected_result $tmp_dir/$user.json
+	else
+		cp $tmp_dir/$user.json $expected_result
+	fi
 }
 
 start_gke() {

--- a/e2e-tests/init-deploy/compare/clusterAdmin-60.json
+++ b/e2e-tests/init-deploy/compare/clusterAdmin-60.json
@@ -10,6 +10,10 @@
       {
         "role": "clusterAdmin",
         "db": "admin"
+      },
+      {
+        "role": "directShardOperations",
+        "db": "admin"
       }
     ],
     "authenticatedUserPrivileges": [

--- a/e2e-tests/init-deploy/compare/clusterAdmin-70.json
+++ b/e2e-tests/init-deploy/compare/clusterAdmin-70.json
@@ -10,6 +10,10 @@
       {
         "role": "clusterAdmin",
         "db": "admin"
+      },
+      {
+        "role": "directShardOperations",
+        "db": "admin"
       }
     ],
     "authenticatedUserPrivileges": [
@@ -263,6 +267,7 @@
           "hostInfo",
           "inprog",
           "invalidateUserCache",
+          "issueDirectShardOperations",
           "killAnyCursor",
           "killAnySession",
           "killop",

--- a/e2e-tests/init-deploy/compare/clusterAdmin-80.json
+++ b/e2e-tests/init-deploy/compare/clusterAdmin-80.json
@@ -10,6 +10,10 @@
       {
         "role": "clusterAdmin",
         "db": "admin"
+      },
+      {
+        "role": "directShardOperations",
+        "db": "admin"
       }
     ],
     "authenticatedUserPrivileges": [
@@ -277,6 +281,7 @@
           "hostInfo",
           "inprog",
           "invalidateUserCache",
+          "issueDirectShardOperations",
           "killAnyCursor",
           "killAnySession",
           "killop",

--- a/e2e-tests/init-deploy/compare/clusterMonitor-60.json
+++ b/e2e-tests/init-deploy/compare/clusterMonitor-60.json
@@ -12,6 +12,10 @@
         "db": "admin"
       },
       {
+        "role": "directShardOperations",
+        "db": "admin"
+      },
+      {
         "role": "explainRole",
         "db": "admin"
       },

--- a/e2e-tests/init-deploy/compare/clusterMonitor-70.json
+++ b/e2e-tests/init-deploy/compare/clusterMonitor-70.json
@@ -12,6 +12,10 @@
         "db": "admin"
       },
       {
+        "role": "directShardOperations",
+        "db": "admin"
+      },
+      {
         "role": "explainRole",
         "db": "admin"
       },
@@ -191,6 +195,7 @@
           "getShardMap",
           "hostInfo",
           "inprog",
+          "issueDirectShardOperations",
           "listDatabases",
           "listSampledQueries",
           "listSessions",

--- a/e2e-tests/init-deploy/compare/clusterMonitor-80.json
+++ b/e2e-tests/init-deploy/compare/clusterMonitor-80.json
@@ -12,6 +12,10 @@
         "db": "admin"
       },
       {
+        "role": "directShardOperations",
+        "db": "admin"
+      },
+      {
         "role": "explainRole",
         "db": "admin"
       },
@@ -203,6 +207,7 @@
           "getShardMap",
           "hostInfo",
           "inprog",
+          "issueDirectShardOperations",
           "listDatabases",
           "listSampledQueries",
           "listSessions",

--- a/e2e-tests/version-service/conf/version-service-major-rs0.yml
+++ b/e2e-tests/version-service/conf/version-service-major-rs0.yml
@@ -13,7 +13,7 @@ spec:
   updateStrategy: SmartUpdate
   upgradeOptions:
     versionServiceEndpoint: http://version-service:11000
-    apply: 5.0-latest
+    apply: 6.0-latest
     schedule: "0 2 * * *"
   replsets:
   - name: rs0

--- a/e2e-tests/version-service/run
+++ b/e2e-tests/version-service/run
@@ -143,7 +143,7 @@ kubectl_bin delete pod -l run=version-service ${OPERATOR_NS:+-n $OPERATOR_NS}
 check_telemetry_transfer "http://version-service-cr:11000" "disabled" "disabled"
 
 cases=("version-service-exact" "version-service-recommended" "version-service-latest" "version-service-major" "version-service-unreachable")
-expected_images=("percona/percona-server-mongodb:6.0.3-2" "percona/percona-server-mongodb:8.0.4-1-multi" "percona/percona-server-mongodb:8.0.4-1-multi" "percona/percona-server-mongodb:5.0.14-12" "$IMAGE_MONGOD")
+expected_images=("percona/percona-server-mongodb:6.0.3-2" "percona/percona-server-mongodb:8.0.4-1-multi" "percona/percona-server-mongodb:8.0.4-1-multi" "percona/percona-server-mongodb:6.0.4-3" "$IMAGE_MONGOD")
 
 for i in "${!cases[@]}"; do
 	desc "test ${cases[$i]}"

--- a/pkg/controller/perconaservermongodb/connections_test.go
+++ b/pkg/controller/perconaservermongodb/connections_test.go
@@ -425,7 +425,7 @@ func (c *fakeMongoClient) GetRole(ctx context.Context, db, role string) (*mongo.
 
 func (c *fakeMongoClient) GetUserInfo(ctx context.Context, username, db string) (*mongo.User, error) {
 	return &mongo.User{
-		Roles: []map[string]interface{}{},
+		Roles: []mongo.Role{},
 	}, nil
 }
 

--- a/pkg/controller/perconaservermongodb/custom_users.go
+++ b/pkg/controller/perconaservermongodb/custom_users.go
@@ -345,23 +345,16 @@ func updatePass(
 	return nil
 }
 
-func updateRoles(
-	ctx context.Context,
-	mongoCli mongo.Client,
-	user *api.User,
-	userInfo *mongo.User) error {
+func updateRoles(ctx context.Context, mongoCli mongo.Client, user *api.User, userInfo *mongo.User) error {
 	log := logf.FromContext(ctx)
 
 	if userInfo == nil {
 		return nil
 	}
 
-	roles := make([]map[string]interface{}, 0)
+	roles := make([]mongo.Role, 0)
 	for _, role := range user.Roles {
-		roles = append(roles, map[string]interface{}{
-			"role": role.Name,
-			"db":   role.DB,
-		})
+		roles = append(roles, mongo.Role{DB: role.DB, Role: role.Name})
 	}
 
 	if reflect.DeepEqual(userInfo.Roles, roles) {
@@ -381,12 +374,9 @@ func updateRoles(
 func createExternalUser(ctx context.Context, mongoCli mongo.Client, user *api.User) error {
 	log := logf.FromContext(ctx)
 
-	roles := make([]map[string]interface{}, 0)
+	roles := make([]mongo.Role, 0)
 	for _, role := range user.Roles {
-		roles = append(roles, map[string]interface{}{
-			"role": role.Name,
-			"db":   role.DB,
-		})
+		roles = append(roles, mongo.Role{DB: role.DB, Role: role.Name})
 	}
 
 	log.Info("Creating user", "user", user.UserID())
@@ -408,12 +398,9 @@ func createUser(
 	annotationKey, passKey string) error {
 	log := logf.FromContext(ctx)
 
-	roles := make([]map[string]interface{}, 0)
+	roles := make([]mongo.Role, 0)
 	for _, role := range user.Roles {
-		roles = append(roles, map[string]interface{}{
-			"role": role.Name,
-			"db":   role.DB,
-		})
+		roles = append(roles, mongo.Role{DB: role.DB, Role: role.Name})
 	}
 
 	log.Info("Creating user", "user", user.UserID())

--- a/pkg/controller/perconaservermongodb/mgo.go
+++ b/pkg/controller/perconaservermongodb/mgo.go
@@ -784,11 +784,12 @@ func getRoles(cr *api.PerconaServerMongoDB, role api.SystemUserRole) []map[strin
 			{"role": string(api.RoleClusterMonitor), "db": "admin"},
 		}
 	case api.RoleClusterMonitor:
-		if cr.CompareVersion("1.12.0") >= 0 {
-			roles = []map[string]interface{}{
-				{"db": "admin", "role": "explainRole"},
-				{"db": "local", "role": "read"},
-			}
+		roles = []map[string]interface{}{
+			{"db": "admin", "role": "explainRole"},
+			{"db": "local", "role": "read"},
+		}
+		if cr.CompareVersion("1.20.0") >= 0 {
+			roles = append(roles, map[string]interface{}{"db": "admin", "role": "directShardOperations"})
 		}
 	case api.RoleBackup:
 		roles = []map[string]interface{}{
@@ -796,6 +797,12 @@ func getRoles(cr *api.PerconaServerMongoDB, role api.SystemUserRole) []map[strin
 			{"db": "admin", "role": string(api.RoleClusterMonitor)},
 			{"db": "admin", "role": "restore"},
 			{"db": "admin", "role": "pbmAnyAction"},
+		}
+	case api.RoleClusterAdmin:
+		if cr.CompareVersion("1.20.0") >= 0 {
+			roles = []map[string]interface{}{
+				{"db": "admin", "role": "directShardOperations"},
+			}
 		}
 	}
 	roles = append(roles, map[string]interface{}{"db": "admin", "role": string(role)})

--- a/pkg/controller/perconaservermongodb/mgo.go
+++ b/pkg/controller/perconaservermongodb/mgo.go
@@ -593,8 +593,13 @@ func (r *ReconcilePerconaServerMongoDB) removeRSFromShard(ctx context.Context, c
 			return nil
 		}
 
-		log.Info(resp.Msg, "shard", rsName,
-			"chunk remaining", resp.Remaining.Chunks, "jumbo chunks remaining", resp.Remaining.JumboChunks)
+		log.Info(resp.Msg,
+			"shard", rsName,
+			"note", resp.Note,
+			"dbsToMove", resp.DBsToMove,
+			"remaining dbs", resp.Remaining.DBs,
+			"remaining chunks", resp.Remaining.Chunks,
+			"remaining jumbo chunks", resp.Remaining.JumboChunks)
 
 		time.Sleep(10 * time.Second)
 	}

--- a/pkg/controller/perconaservermongodb/mgo.go
+++ b/pkg/controller/perconaservermongodb/mgo.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -776,41 +777,41 @@ func (r *ReconcilePerconaServerMongoDB) handleReplicaSetNoPrimary(ctx context.Co
 	return errNoRunningMongodContainers
 }
 
-func getRoles(cr *api.PerconaServerMongoDB, role api.SystemUserRole) []map[string]interface{} {
-	roles := make([]map[string]interface{}, 0)
+func getRoles(cr *api.PerconaServerMongoDB, role api.SystemUserRole) []mongo.Role {
+	roles := make([]mongo.Role, 0)
 	switch role {
 	case api.RoleDatabaseAdmin:
-		return []map[string]interface{}{
-			{"role": "readWriteAnyDatabase", "db": "admin"},
-			{"role": "readAnyDatabase", "db": "admin"},
-			{"role": "restore", "db": "admin"},
-			{"role": "backup", "db": "admin"},
-			{"role": "dbAdminAnyDatabase", "db": "admin"},
-			{"role": string(api.RoleClusterMonitor), "db": "admin"},
+		return []mongo.Role{
+			{DB: "admin", Role: "readWriteAnyDatabase"},
+			{DB: "admin", Role: "readAnyDatabase"},
+			{DB: "admin", Role: "restore"},
+			{DB: "admin", Role: "backup"},
+			{DB: "admin", Role: "dbAdminAnyDatabase"},
+			{DB: "admin", Role: string(api.RoleClusterMonitor)},
 		}
 	case api.RoleClusterMonitor:
-		roles = []map[string]interface{}{
-			{"db": "admin", "role": "explainRole"},
-			{"db": "local", "role": "read"},
+		roles = []mongo.Role{
+			{DB: "admin", Role: "explainRole"},
+			{DB: "local", Role: "read"},
 		}
 		if cr.CompareVersion("1.20.0") >= 0 {
-			roles = append(roles, map[string]interface{}{"db": "admin", "role": "directShardOperations"})
+			roles = append(roles, mongo.Role{DB: "admin", Role: "directShardOperations"})
 		}
 	case api.RoleBackup:
-		roles = []map[string]interface{}{
-			{"db": "admin", "role": "readWrite"},
-			{"db": "admin", "role": string(api.RoleClusterMonitor)},
-			{"db": "admin", "role": "restore"},
-			{"db": "admin", "role": "pbmAnyAction"},
+		roles = []mongo.Role{
+			{DB: "admin", Role: "readWrite"},
+			{DB: "admin", Role: string(api.RoleClusterMonitor)},
+			{DB: "admin", Role: "restore"},
+			{DB: "admin", Role: "pbmAnyAction"},
 		}
 	case api.RoleClusterAdmin:
 		if cr.CompareVersion("1.20.0") >= 0 {
-			roles = []map[string]interface{}{
-				{"db": "admin", "role": "directShardOperations"},
+			roles = []mongo.Role{
+				{DB: "admin", Role: "directShardOperations"},
 			}
 		}
 	}
-	roles = append(roles, map[string]interface{}{"db": "admin", "role": string(role)})
+	roles = append(roles, mongo.Role{DB: "admin", Role: string(role)})
 	return roles
 }
 
@@ -894,10 +895,22 @@ func (r *ReconcilePerconaServerMongoDB) createOrUpdateSystemRoles(ctx context.Co
 }
 
 // compareRoles compares 2 role arrays and returns true if they are equal
-func compareRoles(x []map[string]interface{}, y []map[string]interface{}) bool {
+func compareRoles(x []mongo.Role, y []mongo.Role) bool {
 	if len(x) != len(y) {
 		return false
 	}
+
+	sortFunc := func(a mongo.Role, b mongo.Role) int {
+		if a.DB < b.DB || a.Role < b.Role {
+			return -1
+		}
+
+		return 0
+	}
+
+	slices.SortFunc(x, sortFunc)
+	slices.SortFunc(y, sortFunc)
+
 	for i := range x {
 		if !reflect.DeepEqual(x[i], y[i]) {
 			return false
@@ -1010,6 +1023,7 @@ func (r *ReconcilePerconaServerMongoDB) createOrUpdateSystemUsers(ctx context.Co
 			return errors.Wrap(err, "get user info")
 		}
 		if user == nil {
+			log.Info("Creating user", "database", "admin", "user", creds.Username)
 			err = cli.CreateUser(ctx, "admin", creds.Username, creds.Password, getRoles(cr, role)...)
 			if err != nil {
 				return errors.Wrapf(err, "failed to create user %s", role)
@@ -1017,6 +1031,7 @@ func (r *ReconcilePerconaServerMongoDB) createOrUpdateSystemUsers(ctx context.Co
 			continue
 		}
 		if !compareRoles(user.Roles, getRoles(cr, role)) {
+			log.Info("Updating user roles", "database", "admin", "user", creds.Username, "currentRoles", user.Roles, "newRoles", getRoles(cr, role))
 			err = cli.UpdateUserRoles(ctx, "admin", creds.Username, getRoles(cr, role))
 			if err != nil {
 				return errors.Wrapf(err, "failed to create user %s", role)

--- a/pkg/controller/perconaservermongodb/mgo_test.go
+++ b/pkg/controller/perconaservermongodb/mgo_test.go
@@ -3,6 +3,8 @@ package perconaservermongodb
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
 	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb/mongo"
 )
@@ -53,6 +55,78 @@ func TestCompareTags(t *testing.T) {
 			if got := compareTags(tt.mongoTags, tt.selectorTags); got != tt.expected {
 				t.Errorf("compareTags() = %v, want %v", got, tt.expected)
 			}
+		})
+	}
+}
+
+func TestGetRoles(t *testing.T) {
+	tests := map[string]struct {
+		crVersion string
+		role      api.SystemUserRole
+		expected  []mongo.Role
+	}{
+		"RoleDatabaseAdmin": {
+			role: api.RoleDatabaseAdmin,
+			expected: []mongo.Role{
+				{DB: "admin", Role: "readWriteAnyDatabase"},
+				{DB: "admin", Role: "readAnyDatabase"},
+				{DB: "admin", Role: "restore"},
+				{DB: "admin", Role: "backup"},
+				{DB: "admin", Role: "dbAdminAnyDatabase"},
+				{DB: "admin", Role: string(api.RoleClusterMonitor)},
+			},
+		},
+		"RoleClusterMonitor with version >= 1.20.0": {
+			crVersion: "1.20.0",
+			role:      api.RoleClusterMonitor,
+			expected: []mongo.Role{
+				{DB: "admin", Role: "explainRole"},
+				{DB: "local", Role: "read"},
+				{DB: "admin", Role: "directShardOperations"},
+				{DB: "admin", Role: string(api.RoleClusterMonitor)},
+			},
+		},
+		"RoleClusterMonitor with version < 1.20.0": {
+			crVersion: "1.19.0",
+			role:      api.RoleClusterMonitor,
+			expected: []mongo.Role{
+				{DB: "admin", Role: "explainRole"},
+				{DB: "local", Role: "read"},
+				{DB: "admin", Role: string(api.RoleClusterMonitor)},
+			},
+		},
+		"RoleBackup": {
+			role: api.RoleBackup,
+			expected: []mongo.Role{
+				{DB: "admin", Role: "readWrite"},
+				{DB: "admin", Role: string(api.RoleClusterMonitor)},
+				{DB: "admin", Role: "restore"},
+				{DB: "admin", Role: "pbmAnyAction"},
+				{DB: "admin", Role: string(api.RoleBackup)},
+			},
+		},
+		"RoleClusterAdmin": {
+			crVersion: "1.19.0",
+			role:      api.RoleClusterAdmin,
+			expected: []mongo.Role{
+				{DB: "admin", Role: string(api.RoleClusterAdmin)},
+			},
+		},
+		"RoleClusterAdmin with version >= 1.20.0": {
+			crVersion: "1.20.0",
+			role:      api.RoleClusterAdmin,
+			expected: []mongo.Role{
+				{DB: "admin", Role: "directShardOperations"},
+				{DB: "admin", Role: string(api.RoleClusterAdmin)},
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			cr := &api.PerconaServerMongoDB{Spec: api.PerconaServerMongoDBSpec{CRVersion: tt.crVersion}}
+			actual := getRoles(cr, tt.role)
+			assert.Equal(t, tt.expected, actual)
 		})
 	}
 }

--- a/pkg/controller/perconaservermongodb/mgo_test.go
+++ b/pkg/controller/perconaservermongodb/mgo_test.go
@@ -130,3 +130,59 @@ func TestGetRoles(t *testing.T) {
 		})
 	}
 }
+
+func TestCompareRoles(t *testing.T) {
+	tests := map[string]struct {
+		x        []mongo.Role
+		y        []mongo.Role
+		expected bool
+	}{
+		"length is different": {
+			x: []mongo.Role{
+				{DB: "admin", Role: string(api.RoleClusterAdmin)},
+			},
+			y: []mongo.Role{
+				{DB: "admin", Role: "directShardOperations"},
+				{DB: "admin", Role: string(api.RoleClusterAdmin)},
+			},
+			expected: false,
+		},
+		"order is different": {
+			x: []mongo.Role{
+				{DB: "admin", Role: string(api.RoleClusterAdmin)},
+				{DB: "admin", Role: "directShardOperations"},
+			},
+			y: []mongo.Role{
+				{DB: "admin", Role: "directShardOperations"},
+				{DB: "admin", Role: string(api.RoleClusterAdmin)},
+			},
+			expected: true,
+		},
+		"one role is different": {
+			x: []mongo.Role{
+				{DB: "admin", Role: "readWriteAnyDatabase"},
+				{DB: "admin", Role: "readAnyDatabase"},
+				{DB: "admin", Role: "restore"},
+				{DB: "admin", Role: "backup"},
+				{DB: "admin", Role: "dbAdminAnyDatabase"},
+				{DB: "admin", Role: string(api.RoleClusterMonitor)},
+			},
+			y: []mongo.Role{
+				{DB: "admin", Role: "readWriteAnyDatabase"},
+				{DB: "admin", Role: "readAnyDatabase"},
+				{DB: "admin", Role: "restore"},
+				{DB: "admin", Role: "backup"},
+				{DB: "admin", Role: "dbAdminAnyDatabase2"},
+				{DB: "admin", Role: string(api.RoleClusterMonitor)},
+			},
+			expected: false,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			actual := compareRoles(tt.x, tt.y)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}

--- a/pkg/psmdb/mongo/fake/client.go
+++ b/pkg/psmdb/mongo/fake/client.go
@@ -70,7 +70,7 @@ func (c *fakeMongoClient) GetRole(ctx context.Context, db, role string) (*mongo.
 	return nil, nil
 }
 
-func (c *fakeMongoClient) CreateUser(ctx context.Context, db, user, pwd string, roles ...map[string]interface{}) error {
+func (c *fakeMongoClient) CreateUser(ctx context.Context, db, user, pwd string, roles ...mongo.Role) error {
 	return nil
 }
 
@@ -138,7 +138,7 @@ func (c *fakeMongoClient) GetUserInfo(ctx context.Context, username string, db s
 	return nil, nil
 }
 
-func (c *fakeMongoClient) UpdateUserRoles(ctx context.Context, db, username string, roles []map[string]interface{}) error {
+func (c *fakeMongoClient) UpdateUserRoles(ctx context.Context, db, username string, roles []mongo.Role) error {
 	return nil
 }
 

--- a/pkg/psmdb/mongo/models.go
+++ b/pkg/psmdb/mongo/models.go
@@ -277,8 +277,8 @@ type RoleInfo struct {
 }
 
 type User struct {
-	DB    string                   `bson:"db" json:"db"`
-	Roles []map[string]interface{} `bson:"roles" json:"roles"`
+	DB    string `bson:"db" json:"db"`
+	Roles []Role `bson:"roles" json:"roles"`
 }
 
 type UsersInfo struct {

--- a/pkg/psmdb/mongo/models.go
+++ b/pkg/psmdb/mongo/models.go
@@ -116,9 +116,12 @@ type FCV struct {
 const ShardRemoveCompleted string = "completed"
 
 type ShardRemoveResp struct {
-	Msg       string `json:"msg" bson:"msg"`
-	State     string `json:"state" bson:"state"`
+	Msg       string   `json:"msg" bson:"msg"`
+	State     string   `json:"state" bson:"state"`
+	Note      string   `json:"note" bson:"note"`
+	DBsToMove []string `json:"dbsToMove" bson:"dbsToMove"`
 	Remaining struct {
+		DBs         int `json:"dbs" bson:"dbs"`
 		Chunks      int `json:"chunks" bson:"chunks"`
 		JumboChunks int `json:"jumboChunks" bson:"jumboChunks"`
 	} `json:"remaining" bson:"remaining"`

--- a/pkg/psmdb/mongo/mongo.go
+++ b/pkg/psmdb/mongo/mongo.go
@@ -37,7 +37,7 @@ type Client interface {
 	CreateRole(ctx context.Context, db string, role Role) error
 	UpdateRole(ctx context.Context, db string, role Role) error
 	GetRole(ctx context.Context, db, role string) (*Role, error)
-	CreateUser(ctx context.Context, db, user, pwd string, roles ...map[string]interface{}) error
+	CreateUser(ctx context.Context, db, user, pwd string, roles ...Role) error
 	AddShard(ctx context.Context, rsName, host string) error
 	WriteConfig(ctx context.Context, cfg RSConfig, force bool) error
 	RSStatus(ctx context.Context) (Status, error)
@@ -54,7 +54,7 @@ type Client interface {
 	Freeze(ctx context.Context, seconds int) error
 	IsMaster(ctx context.Context) (*IsMasterResp, error)
 	GetUserInfo(ctx context.Context, username, db string) (*User, error)
-	UpdateUserRoles(ctx context.Context, db, username string, roles []map[string]interface{}) error
+	UpdateUserRoles(ctx context.Context, db, username string, roles []Role) error
 	UpdateUserPass(ctx context.Context, db, name, pass string) error
 	UpdateUser(ctx context.Context, currName, newName, pass string) error
 }
@@ -300,7 +300,7 @@ func (client *mongoClient) GetRole(ctx context.Context, db, role string) (*Role,
 	return r, nil
 }
 
-func (client *mongoClient) CreateUser(ctx context.Context, db, user, pwd string, roles ...map[string]interface{}) error {
+func (client *mongoClient) CreateUser(ctx context.Context, db, user, pwd string, roles ...Role) error {
 	resp := OKResponse{}
 
 	d := bson.D{
@@ -641,7 +641,7 @@ func (client *mongoClient) GetUserInfo(ctx context.Context, username, db string)
 	return &resp.Users[0], nil
 }
 
-func (client *mongoClient) UpdateUserRoles(ctx context.Context, db, username string, roles []map[string]interface{}) error {
+func (client *mongoClient) UpdateUserRoles(ctx context.Context, db, username string, roles []Role) error {
 	return client.Database(db).RunCommand(ctx, bson.D{{Key: "updateUser", Value: username}, {Key: "roles", Value: roles}}).Err()
 }
 


### PR DESCRIPTION
[![K8SPSMDB-1325](https://badgen.net/badge/JIRA/K8SPSMDB-1325/green)](https://jira.percona.com/browse/K8SPSMDB-1325) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
This PR fixes two problems:
1. MongoDB 8.0 added a new role called `directShardOperation`. Without this role, users won't be able to perform anything by directly connecting to shards in a sharded cluster.
2. When you try to remove a shard, operator infinitely prints `draining ongoing` in logs but shard is not removed and it's impossible to understand why the operation is stuck without manually running `removeShard` in mongos.

**Solution:**
1. Add `directShardOperation` to `clusterAdmin` and `clusterMonitor` users.
2. Improve `removeShard` logs.

Before:
```
2025-04-15T13:27:01.717Z        INFO    draining ongoing        {"controller": "psmdb-controller", "controllerGroup": "psmdb.percona.com", "controllerKind": "PerconaServerMongoDB", "PerconaServerMongoDB": {"name":"cluster1","namespace":"psmdb-2771"}, "namespace": "psmdb-2771", "name": "cluster1", "reconcileID": "1f661196-ab42-46d5-8fc1-77c22589b801", "shard": "rs1", "chunk remaining": 0, "jumbo chunks remaining": 0}
```

After:
```
2025-04-15T13:38:40.334Z        INFO    draining ongoing        {"controller": "psmdb-controller", "controllerGroup": "psmdb.percona.com", "controllerKind": "PerconaServerMongoDB", "PerconaServerMongoDB": {"name":"cluster1","namespace":"psmdb-2771"}, "namespace": "psmdb-2771", "name": "cluster1", "reconcileID": "b461b496-9753-44e8-a172-643db941 c760", "shard": "rs1", "note": "you need to drop or movePrimary these databases", "dbsToMove": ["test"], "remaining dbs": 1, "remaining chunks": 0, "remaining jumbo chunks": 0}
```

With new logs users will be able to understand that they need to run `db.adminCommand( { movePrimary : "test", to : "rs0" } )` in mongos to make the operation unstuck.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-1325]: https://perconadev.atlassian.net/browse/K8SPSMDB-1325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ