### PR TITLE
K8SPSMDB-1347 When password does not exist, properly update the secret and set the boolean to true

### DIFF
--- a/pkg/controller/perconaservermongodb/custom_users.go
+++ b/pkg/controller/perconaservermongodb/custom_users.go
@@ -505,6 +505,8 @@ func getCustomUserSecret(ctx context.Context, cl client.Client, cr *api.PerconaS
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to update user secret")
 		}
+		// given that the secret was updated, the password now exists
+		hasPass = true
 	}
 
 	// pass key should be present in the user provided secret


### PR DESCRIPTION
[![K8SPSMDB-1347](https://badgen.net/badge/JIRA/K8SPSMDB-1347/green)](https://jira.percona.com/browse/K8SPSMDB-1347) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**

  logs in PSMDB for each additional user we try to create with automatically generated passwords.
 
```
2025-04-15T14:47:50.313Z	ERROR	failed to get user secret	{"controller": "psmdb-controller", "controllerGroup": "psmdb.percona.com", "controllerKind": "PerconaServerMongoDB", "PerconaServerMongoDB": {"name":"my-cluster-name","namespace":"test4"}, "namespace": "test4", "name": "my-cluster-name", "reconcileID": "4a9d2f89-5e2c-4df9-969e-51952d5c35b7", "user": {"name":"my-usr","db":"admin","roles":[{"name":"dbOwner","db":"sometest"}]}, "error": "password key not found in secret", "errorVerbose": "password key not found in secret
2025-04-15T14:47:50.330Z	ERROR	failed to get user secret	{"controller": "psmdb-controller", "controllerGroup": "psmdb.percona.com", "controllerKind": "PerconaServerMongoDB", "PerconaServerMongoDB": {"name":"my-cluster-name","namespace":"test4"}, "namespace": "test4", "name": "my-cluster-name", "reconcileID": "4a9d2f89-5e2c-4df9-969e-51952d5c35b7", "user": {"name":"my-usR","db":"admin","roles":[{"name":"dbOwner","db":"sometest"}]}, "error": "password key not found in secret", "errorVerbose": "password key not found in secret
```

This error log just doesn't appear for the first user in the map, it appears for every other(so if we create 10 users, it will appear 9 error logs).



The issue can be reproduced with this config on main:

```
users:
  - name: my-user
    db: admin
    roles:
      - name: clusterAdmin
        db: admin
      - name: userAdminAnyDatabase
        db: admin
  - name: my-usr
    db: admin
    roles:
      - name: dbOwner
        db: sometest
  - name: my-usR
    db: admin
    roles:
      - name: dbOwner
        db: sometest
```

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
properly set the boolean when the password is updated in the secret that exists.

Image used: `percona-server-mongodb-operator:K8SPSMDB-1164-1`

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-1347]: https://perconadev.atlassian.net/browse/K8SPSMDB-1347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ