### PR TITLE
K8SPSMDB-1294: Use server's preferred version of MCS APIs

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -136,6 +136,9 @@ func main() {
 	}
 
 	if mcs.IsAvailable() {
+		setupLog.Info("Multi cluster services available",
+			"group", mcs.MCSSchemeGroupVersion.Group,
+			"version", mcs.MCSSchemeGroupVersion.Version)
 		if err := mcs.AddToScheme(mgr.GetScheme()); err != nil {
 			setupLog.Error(err, "")
 			os.Exit(1)

--- a/pkg/mcs/register.go
+++ b/pkg/mcs/register.go
@@ -1,8 +1,6 @@
 package mcs
 
 import (
-	"strings"
-
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -36,7 +34,7 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 }
 
 func Register(dc *discovery.DiscoveryClient) error {
-	_, resources, err := dc.ServerGroupsAndResources()
+	resources, err := dc.ServerPreferredResources()
 	if err != nil {
 		return errors.Wrap(err, "get api groups and resources")
 	}
@@ -45,10 +43,8 @@ outer:
 	for _, r := range resources {
 		for _, resource := range r.APIResources {
 			if resource.Kind == "ServiceExport" {
-				gv := strings.Split(r.GroupVersion, "/")
-
-				MCSSchemeGroupVersion.Group = gv[0]
-				MCSSchemeGroupVersion.Version = gv[1]
+				MCSSchemeGroupVersion.Group = resource.Group
+				MCSSchemeGroupVersion.Version = resource.Version
 
 				break outer
 			}


### PR DESCRIPTION
[![K8SPSMDB-1294](https://badgen.net/badge/JIRA/K8SPSMDB-1294/green)](https://jira.percona.com/browse/K8SPSMDB-1294) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
Operator registers MCS APIs using `net.gke.io/v1alpha1` even though `kubectl api-resources` show `net.gke.io/v1`.

**Solution:**
Looking at the [kubectl code](https://github.com/kubernetes/kubernetes/blob/afc57a752110ac0633ff5df896ebe02ee1b19ec5/staging/src/k8s.io/kubectl/pkg/cmd/apiresources/apiresources.go#L168) shows that it uses `DiscoveryClient.ServerPreferredResources` instead of `ServerGroupsAndResources`. We need to use this method.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-1294]: https://perconadev.atlassian.net/browse/K8SPSMDB-1294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ