### PR TITLE
K8SPSMDB-1256 when PBM_AGENT_TLS_ENABLED is enabled, pbm status should be checked on e2e tests

### DIFF
--- a/e2e-tests/demand-backup-fs/run
+++ b/e2e-tests/demand-backup-fs/run
@@ -97,6 +97,8 @@ write_data 100500 ""
 wait_backup_agent ${cluster}-rs0-0
 wait_backup_agent ${cluster}-rs0-1
 wait_backup_agent ${cluster}-rs0-2
+# Given that PBM_AGENT_TLS_ENABLED=true, we are running the following to ensure that exec pbm status works with tls...
+wait_for_pbm_operations ${cluster}
 
 desc "CASE 1: Logical backup and restore"
 backup_name="backup-nfs-logical"

--- a/e2e-tests/demand-backup/run
+++ b/e2e-tests/demand-backup/run
@@ -171,6 +171,8 @@ compare_mongo_cmd "find" "myApp:myPass@$cluster-2.$cluster.$namespace"
 wait_backup_agent $cluster-0
 wait_backup_agent $cluster-1
 wait_backup_agent $cluster-2
+# Given that PBM_AGENT_TLS_ENABLED=true, we are running the following to ensure that exec pbm status works with tls...
+wait_for_pbm_operations ${cluster}
 
 backup_name_minio="backup-minio"
 if [ -z "$SKIP_BACKUPS_TO_AWS_GCP_AZURE" ]; then

--- a/e2e-tests/scheduled-backup/run
+++ b/e2e-tests/scheduled-backup/run
@@ -80,6 +80,8 @@ compare_mongo_cmd "find" "myApp:myPass@$cluster-2.$cluster.$namespace"
 wait_backup_agent $cluster-0
 wait_backup_agent $cluster-1
 wait_backup_agent $cluster-2
+# Given that PBM_AGENT_TLS_ENABLED=true, we are running the following to ensure that exec pbm status works with tls...
+wait_for_pbm_operations ${cluster}
 
 desc 'add backups schedule, wait for backups'
 apply_cluster "$test_dir/conf/$cluster-2.yml"


### PR DESCRIPTION
[![K8SPSMDB-1256](https://badgen.net/badge/JIRA/K8SPSMDB-1256/green)](https://jira.percona.com/browse/K8SPSMDB-1256) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
*Short explanation of the problem.*

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?