### PR TITLE
K8SPSMDB-1237: fix .keep for incremental backups

### DIFF
--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -731,7 +731,6 @@ spec:
 #      - name: weekly-s3-us-west-incremental
 #        enabled: false
 #        schedule: "0 1 * * *"
-#        keep: 5
 #        type: incremental
 #        storageName: s3-us-west
 #        compressionType: gzip


### PR DESCRIPTION
[![K8SPSMDB-1237](https://badgen.net/badge/JIRA/K8SPSMDB-1237/green)](https://jira.percona.com/browse/K8SPSMDB-1237) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://perconadev.atlassian.net/browse/K8SPSMDB-1237

**DESCRIPTION**
---
This PR fixes the implementation of commit https://github.com/percona/percona-server-mongodb-operator/pull/1836#discussion_r1981247701. It was intended to disable the `.spec.backup.tasks.[].keep` option for `incremental` backups, but instead it was implemented in a part of the code that is no longer used.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-1237]: https://perconadev.atlassian.net/browse/K8SPSMDB-1237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ