### PR TITLE
K8SPSMDB-1265: Fix compare files with correct PBM_MONGODB_URI

### DIFF
--- a/e2e-tests/default-cr/compare/statefulset_my-cluster-name-cfg-oc.yml
+++ b/e2e-tests/default-cr/compare/statefulset_my-cluster-name-cfg-oc.yml
@@ -172,7 +172,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.name
             - name: PBM_MONGODB_URI
-              value: mongodb://$(PBM_AGENT_MONGODB_USERNAME):$(PBM_AGENT_MONGODB_PASSWORD)@$(POD_NAME)
+              value: mongodb://$(PBM_AGENT_MONGODB_USERNAME):$(PBM_AGENT_MONGODB_PASSWORD)@localhost:$(PBM_MONGODB_PORT)/?tls=true&tlsCertificateKeyFile=/tmp/tls.pem&tlsCAFile=/etc/mongodb-ssl/ca.crt&tlsInsecure=true
             - name: PBM_AGENT_TLS_ENABLED
               value: "true"
           imagePullPolicy: Always

--- a/e2e-tests/default-cr/compare/statefulset_my-cluster-name-cfg.yml
+++ b/e2e-tests/default-cr/compare/statefulset_my-cluster-name-cfg.yml
@@ -173,7 +173,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.name
             - name: PBM_MONGODB_URI
-              value: mongodb://$(PBM_AGENT_MONGODB_USERNAME):$(PBM_AGENT_MONGODB_PASSWORD)@$(POD_NAME)
+              value: mongodb://$(PBM_AGENT_MONGODB_USERNAME):$(PBM_AGENT_MONGODB_PASSWORD)@localhost:$(PBM_MONGODB_PORT)/?tls=true&tlsCertificateKeyFile=/tmp/tls.pem&tlsCAFile=/etc/mongodb-ssl/ca.crt&tlsInsecure=true
             - name: PBM_AGENT_TLS_ENABLED
               value: "true"
           imagePullPolicy: Always

--- a/e2e-tests/default-cr/compare/statefulset_my-cluster-name-rs0-oc.yml
+++ b/e2e-tests/default-cr/compare/statefulset_my-cluster-name-rs0-oc.yml
@@ -172,7 +172,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.name
             - name: PBM_MONGODB_URI
-              value: mongodb://$(PBM_AGENT_MONGODB_USERNAME):$(PBM_AGENT_MONGODB_PASSWORD)@$(POD_NAME)
+              value: mongodb://$(PBM_AGENT_MONGODB_USERNAME):$(PBM_AGENT_MONGODB_PASSWORD)@localhost:$(PBM_MONGODB_PORT)/?tls=true&tlsCertificateKeyFile=/tmp/tls.pem&tlsCAFile=/etc/mongodb-ssl/ca.crt&tlsInsecure=true
             - name: PBM_AGENT_TLS_ENABLED
               value: "true"
           imagePullPolicy: Always

--- a/e2e-tests/default-cr/compare/statefulset_my-cluster-name-rs0.yml
+++ b/e2e-tests/default-cr/compare/statefulset_my-cluster-name-rs0.yml
@@ -173,7 +173,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.name
             - name: PBM_MONGODB_URI
-              value: mongodb://$(PBM_AGENT_MONGODB_USERNAME):$(PBM_AGENT_MONGODB_PASSWORD)@$(POD_NAME)
+              value: mongodb://$(PBM_AGENT_MONGODB_USERNAME):$(PBM_AGENT_MONGODB_PASSWORD)@localhost:$(PBM_MONGODB_PORT)/?tls=true&tlsCertificateKeyFile=/tmp/tls.pem&tlsCAFile=/etc/mongodb-ssl/ca.crt&tlsInsecure=true
             - name: PBM_AGENT_TLS_ENABLED
               value: "true"
           imagePullPolicy: Always

--- a/e2e-tests/demand-backup-eks-credentials-irsa/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/demand-backup-eks-credentials-irsa/compare/statefulset_some-name-rs0.yml
@@ -173,7 +173,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.name
             - name: PBM_MONGODB_URI
-              value: mongodb://$(PBM_AGENT_MONGODB_USERNAME):$(PBM_AGENT_MONGODB_PASSWORD)@$(POD_NAME)
+              value: mongodb://$(PBM_AGENT_MONGODB_USERNAME):$(PBM_AGENT_MONGODB_PASSWORD)@localhost:$(PBM_MONGODB_PORT)/?tls=true&tlsCertificateKeyFile=/tmp/tls.pem&tlsCAFile=/etc/mongodb-ssl/ca.crt&tlsInsecure=true
             - name: PBM_AGENT_TLS_ENABLED
               value: "true"
           imagePullPolicy: Always


### PR DESCRIPTION
[![K8SPSMDB-1265](https://badgen.net/badge/JIRA/K8SPSMDB-1265/green)](https://jira.percona.com/browse/K8SPSMDB-1265) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
`PBM_MONGODB_URI` was outdated

**Solution:**
Change it to correct one

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-1265]: https://perconadev.atlassian.net/browse/K8SPSMDB-1265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ