### PR TITLE
K8SPSMDB-1366: Fix reconfiguring PBM after sharding is toggled

### DIFF
--- a/e2e-tests/init-deploy/compare/backup-80.json
+++ b/e2e-tests/init-deploy/compare/backup-80.json
@@ -135,6 +135,15 @@
       },
       {
         "resource": {
+          "db": "",
+          "collection": "system.views"
+        },
+        "actions": [
+          "dropCollection"
+        ]
+      },
+      {
+        "resource": {
           "db": "admin",
           "collection": ""
         },
@@ -241,15 +250,6 @@
           "find",
           "insert",
           "updateSearchIndex"
-        ]
-      },
-      {
-        "resource": {
-          "db": "admin",
-          "collection": "system.views"
-        },
-        "actions": [
-          "dropCollection"
         ]
       },
       {

--- a/e2e-tests/rs-shard-migration/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/rs-shard-migration/compare/statefulset_some-name-rs0.yml
@@ -55,7 +55,6 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
-            - --config=/etc/mongodb-config/mongod.conf
             - --quiet
           command:
             - /opt/percona/ps-entry.sh
@@ -132,8 +131,6 @@ spec:
             - mountPath: /etc/mongodb-ssl-internal
               name: ssl-internal
               readOnly: true
-            - mountPath: /etc/mongodb-config
-              name: config
             - mountPath: /opt/percona
               name: bin
             - mountPath: /etc/mongodb-encryption
@@ -142,6 +139,57 @@ spec:
             - mountPath: /etc/users-secret
               name: users-secret-file
           workingDir: /data/db
+        - args:
+            - pbm-agent-entrypoint
+          command:
+            - /opt/percona/pbm-entry.sh
+          env:
+            - name: PBM_AGENT_MONGODB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  key: MONGODB_BACKUP_USER_ESCAPED
+                  name: internal-some-name-users
+                  optional: false
+            - name: PBM_AGENT_MONGODB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: MONGODB_BACKUP_PASSWORD_ESCAPED
+                  name: internal-some-name-users
+                  optional: false
+            - name: PBM_MONGODB_REPLSET
+              value: rs0
+            - name: PBM_MONGODB_PORT
+              value: "27017"
+            - name: PBM_AGENT_SIDECAR
+              value: "true"
+            - name: PBM_AGENT_SIDECAR_SLEEP
+              value: "5"
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: PBM_MONGODB_URI
+              value: mongodb://$(PBM_AGENT_MONGODB_USERNAME):$(PBM_AGENT_MONGODB_PASSWORD)@localhost:$(PBM_MONGODB_PORT)/?tls=true&tlsCertificateKeyFile=/tmp/tls.pem&tlsCAFile=/etc/mongodb-ssl/ca.crt&tlsInsecure=true
+            - name: PBM_AGENT_TLS_ENABLED
+              value: "true"
+          imagePullPolicy: Always
+          name: backup-agent
+          resources: {}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /etc/mongodb-ssl
+              name: ssl
+              readOnly: true
+            - mountPath: /opt/percona
+              name: bin
+              readOnly: true
+            - mountPath: /data/db
+              name: mongod-data
       dnsPolicy: ClusterFirst
       initContainers:
         - command:
@@ -177,11 +225,6 @@ spec:
             secretName: some-name-mongodb-keyfile
         - emptyDir: {}
           name: bin
-        - configMap:
-            defaultMode: 420
-            name: some-name-rs0-mongod
-            optional: true
-          name: config
         - name: some-name-mongodb-encryption-key
           secret:
             defaultMode: 288

--- a/e2e-tests/rs-shard-migration/conf/backup-minio.yml
+++ b/e2e-tests/rs-shard-migration/conf/backup-minio.yml
@@ -1,0 +1,9 @@
+apiVersion: psmdb.percona.com/v1
+kind: PerconaServerMongoDBBackup
+metadata:
+  finalizers:
+    - percona.com/delete-backup
+  name: backup-minio
+spec:
+  clusterName: some-name
+  storageName: minio

--- a/e2e-tests/rs-shard-migration/conf/some-name.yml
+++ b/e2e-tests/rs-shard-migration/conf/some-name.yml
@@ -1,0 +1,40 @@
+apiVersion: psmdb.percona.com/v1
+kind: PerconaServerMongoDB
+metadata:
+  name: some-name
+spec:
+  #platform: openshift
+  image:
+  imagePullPolicy: Always
+  allowUnsafeConfigurations: false
+  backup:
+    enabled: true
+    image: perconalab/percona-server-mongodb-operator:0.4.0-backup
+    storages:
+      minio:
+        type: s3
+        s3:
+          credentialsSecret: minio-secret
+          region: us-east-1
+          bucket: operator-testing
+          endpointUrl: http://minio-service:9000/
+          insecureSkipTLSVerify: false
+  replsets:
+  - name: rs0
+    affinity:
+      antiAffinityTopologyKey: none
+    resources:
+      limits:
+        cpu: 500m
+        memory: 0.5G
+      requests:
+        cpu: 100m
+        memory: 0.1G
+    volumeSpec:
+      persistentVolumeClaim:
+        resources:
+          requests:
+            storage: 1Gi
+    size: 3
+  secrets:
+    users: some-users

--- a/e2e-tests/rs-shard-migration/run
+++ b/e2e-tests/rs-shard-migration/run
@@ -15,20 +15,27 @@ function get_shard_parameter() {
 }
 
 function main() {
+	cluster="some-name"
+	CLUSTER_SIZE=3
+
 	create_infra $namespace
 
 	desc 'create secrets and start client'
 	kubectl_bin apply -f $conf_dir/secrets.yml -f $conf_dir/client.yml
-	cluster="some-name"
-	CLUSTER_SIZE=3
 
-	spinup_psmdb ${cluster}-rs0 $conf_dir/${cluster}-rs0.yml
+	apply_s3_storage_secrets
+	deploy_minio
+
+	spinup_psmdb ${cluster}-rs0 ${test_dir}/conf/${cluster}.yml
 
 	desc 'check if statefulset created with expected config'
 	compare_kubectl "statefulset/${cluster}-rs0"
 
 	desc 'write data, read from all'
 	simple_data_check "${cluster}-rs0" ${CLUSTER_SIZE}
+
+	run_backup "minio" "backup-minio-1"
+	wait_backup "backup-minio-1"
 
 	desc 'initiate migration from replicaset to sharded cluster'
 	kubectl_bin patch psmdb/${cluster} --type json -p='[{"op":"add","path":"/spec/sharding","value":{"configsvrReplSet":{"size":'${CLUSTER_SIZE}',"volumeSpec":{"persistentVolumeClaim":{"resources":{"requests":{"storage":"3Gi"}}}}},"enabled":true,"mongos":{"size":1}}}]'
@@ -58,6 +65,9 @@ function main() {
 		exit 1
 	fi
 
+	run_backup "minio" "backup-minio-2"
+	wait_backup "backup-minio-2"
+
 	desc 'get back from sharded cluster to replicaset'
 	kubectl_bin patch psmdb/${cluster} --type json -p='[{"op":"remove","path":"/spec/sharding"}]'
 	sleep 20
@@ -73,6 +83,9 @@ function main() {
 		echo "Transition to replicaset cluster has not been done well. Cluster does not work properly or some leftovers still exist"
 		exit 1
 	fi
+
+	run_backup "minio" "backup-minio-3"
+	wait_backup "backup-minio-3"
 
 	desc 'cleanup CRDs and RBAC'
 	kubectl_bin delete -f "${src_dir}/deploy/crd.yaml" || :


### PR DESCRIPTION
[![K8SPSMDB-1366](https://badgen.net/badge/JIRA/K8SPSMDB-1366/green)](https://jira.percona.com/browse/K8SPSMDB-1366) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
Operator doesn't understand that it needs to reconfigure PBM after sharding status is toggled.

**Cause:**
If sharding is enabled PBM stores its configuration and metadata in config server replset. If sharding is disabled, config server is deleted and PBM configuration is gone. 

Operator stores PBM config hash in `status.backupConfigHash` and since nothing changed in the config, it doesn't understand PBM needs to be reconfigured.

**Solution:**
Remove `status.backupConfigHash` if sharding is toggled.

This PR also fixes toggling logic as it didn't work properly.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-1366]: https://perconadev.atlassian.net/browse/K8SPSMDB-1366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ