### PR TITLE
K8SPSMDB-1265: clean up basmdb-backup and use kubectl wait for wait_restore

### DIFF
--- a/e2e-tests/demand-backup-incremental-sharded/run
+++ b/e2e-tests/demand-backup-incremental-sharded/run
@@ -56,7 +56,7 @@ run_recovery_check() {
 	fi
 	echo
 
-	wait_cluster_consistency ${cluster} 42
+	wait_cluster_consistency ${cluster} 60
 	wait_for_pbm_operations ${cluster}
 
 	if [[ $base == true ]]; then

--- a/e2e-tests/demand-backup-sharded/run
+++ b/e2e-tests/demand-backup-sharded/run
@@ -148,10 +148,18 @@ fi
 
 desc 'check backup and restore -- minio'
 backup_dest_minio=$(get_backup_dest "$backup_name_minio")
-kubectl_bin run -i --rm aws-cli --image=perconalab/awscli --restart=Never -- \
+retry=0
+until kubectl_bin run -i --rm aws-cli --image=perconalab/awscli --restart=Never -- \
 	/usr/bin/env AWS_ACCESS_KEY_ID=some-access-key AWS_SECRET_ACCESS_KEY=some-secret-key AWS_DEFAULT_REGION=us-east-1 \
 	/usr/bin/aws --endpoint-url http://minio-service:9000 s3 ls "s3://${backup_dest_minio}/rs0/" \
-	| grep "myApp.test.gz"
+	| grep "myApp.test.gz"; do
+	sleep 1
+	let retry+=1
+	if [ $retry -ge 60 ]; then
+		echo "max retry count $retry reached. something went wrong with writing backup"
+		exit 1
+	fi
+done
 insert_data_mongos "100501" "myApp" "" "$custom_port"
 insert_data_mongos "100501" "myApp1" "" "$custom_port"
 insert_data_mongos "100501" "myApp2" "" "$custom_port"

--- a/e2e-tests/demand-backup-sharded/run
+++ b/e2e-tests/demand-backup-sharded/run
@@ -156,7 +156,7 @@ until kubectl_bin run -i --rm aws-cli --image=perconalab/awscli --restart=Never 
 	sleep 1
 	let retry+=1
 	if [ $retry -ge 60 ]; then
-		echo "max retry count $retry reached. something went wrong with writing backup"
+		echo "Max retry count $retry reached. Something went wrong with writing backup"
 		exit 1
 	fi
 done

--- a/e2e-tests/demand-backup/run
+++ b/e2e-tests/demand-backup/run
@@ -303,6 +303,6 @@ fi
 desc 'check for passwords leak'
 check_passwords_leak
 
-# destroy $namespace
+destroy $namespace
 
-# desc 'test passed'
+desc 'test passed'

--- a/e2e-tests/demand-backup/run
+++ b/e2e-tests/demand-backup/run
@@ -303,6 +303,6 @@ fi
 desc 'check for passwords leak'
 check_passwords_leak
 
-destroy $namespace
+# destroy $namespace
 
-desc 'test passed'
+# desc 'test passed'

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -238,9 +238,11 @@ wait_backup() {
 				| grep -v 'level=debug' \
 				| grep -v 'Getting tasks for pod' \
 				| grep -v 'Getting pods from source' \
-				| tail -100
+				| tail -200
 			kubectl_bin get psmdb-backup
-			echo "Backup object psmdb-backup/${backup_name} is in ${current_state} state."
+			kubectl_bin logs ${OPERATOR_NS:+-n $OPERATOR_NS} $(get_operator_pod) \
+				| grep "\"previous\": \"requested\", \"current\": \"waiting\""
+			echo "Backup object psmdb-backup/${backup_name} is in ${current_status} state."
 			echo something went wrong with operator or kubernetes cluster
 			exit 1
 		fi

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -393,7 +393,6 @@ wait_restore() {
 			exit 1
 		fi
 	done
-
 	echo "OK"
 	set_debug
 

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -352,16 +352,16 @@ wait_restore() {
 	echo -n "Waiting for the psmdb-restore/restore-$backup_name object to be created"
 	retry_object=0
 	until [[ ${retry_object} == 60 ]]; do
-        echo -n .
-        if  kubectl_bin get psmdb-restore restore-$backup_name > /dev/null; then
-            echo "OK"
+		echo -n .
+		if kubectl_bin get psmdb-restore restore-$backup_name >/dev/null; then
+			echo "OK"
 			break
 		fi
-        let retry_object+=1
-        if [[ ${retry_object} == 60 ]]; then
-            echo "psmdb-restore/restore-$backup_name object was not created."
-            exit 1
-        fi
+		let retry_object+=1
+		if [[ ${retry_object} == 60 ]]; then
+			echo "psmdb-restore/restore-$backup_name object was not created."
+			exit 1
+		fi
 		sleep 1
 	done
 

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -366,7 +366,7 @@ wait_restore() {
 	echo -n "Waiting psmdb-restore/restore-${backup_name} to reach state \"${target_state}\" "
 	retry=0
 	retry_count=$((wait_time / 60))
-	until kubectl_bin wait psmdb-restore restore-${backup_name} --for=jsonpath='{.status.state}'=${target_state} --timeout=60s >/dev/null 2>&1; do
+	until kubectl wait psmdb-restore restore-${backup_name} --for=jsonpath='{.status.state}'=${target_state} --timeout=60s >/dev/null 2>&1; do
 		echo -n .
 		let retry+=1
 		current_state=$(kubectl_bin get psmdb-restore restore-$backup_name -o jsonpath='{.status.state}')
@@ -382,6 +382,7 @@ wait_restore() {
 				| grep -v 'Getting pods from source' \
 				| tail -100
 			kubectl_bin get psmdb-restore restore-${backup_name} -o yaml
+			kubectl_bin describe psmdb-restore restore-${backup_name}
 			echo "Restore object restore-${backup_name} is in ${current_state} state."
 			echo something went wrong with operator or kubernetes cluster
 			exit 1

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -396,6 +396,7 @@ wait_restore() {
 
 	echo "OK"
 	set_debug
+
 	if [[ $wait_cluster_consistency -eq 1 ]]; then
 		wait_cluster_consistency "${cluster_name}"
 	fi

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -240,8 +240,6 @@ wait_backup() {
 				| grep -v 'Getting pods from source' \
 				| tail -200
 			kubectl_bin get psmdb-backup
-			kubectl_bin logs ${OPERATOR_NS:+-n $OPERATOR_NS} $(get_operator_pod) \
-				| grep "\"previous\": \"requested\", \"current\": \"waiting\""
 			echo "Backup object psmdb-backup/${backup_name} is in ${current_status} state."
 			echo something went wrong with operator or kubernetes cluster
 			exit 1

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -232,7 +232,7 @@ wait_backup() {
 		echo -n .
 		let retry+=1
 		current_status=$(kubectl_bin get psmdb-backup $backup_name -o jsonpath='{.status.state}')
-		if [[ $retry -ge 360 || ${current_status} == 'error' ]]; then
+		if [[ $retry -ge 600 || ${current_status} == 'error' ]]; then
 			kubectl_bin logs ${OPERATOR_NS:+-n $OPERATOR_NS} $(get_operator_pod) \
 				| grep -v 'level=info' \
 				| grep -v 'level=debug' \

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -351,12 +351,7 @@ wait_restore() {
 	# We need to run wait till object is created, otherwise wait fails at once
 	echo -n "Waiting for the psmdb-restore/restore-$backup_name object to be created"
 	retry_object=0
-	until [[ ${retry_object} == 60 ]]; do
-		echo -n .
-		if kubectl_bin get psmdb-restore restore-$backup_name >/dev/null; then
-			echo "OK"
-			break
-		fi
+	until kubectl_bin get psmdb-restore restore-$backup_name >/dev/null; do
 		let retry_object+=1
 		if [[ ${retry_object} == 60 ]]; then
 			echo "psmdb-restore/restore-$backup_name object was not created."
@@ -368,13 +363,9 @@ wait_restore() {
 	echo -n "Waiting psmdb-restore/restore-${backup_name} to reach state \"${target_state}\" "
 	retry=0
 	retry_count=$((wait_time / 60))
-	until [[ ${retry} == ${retry_count} ]]; do
+	until kubectl_bin wait psmdb-restore restore-${backup_name} --for=jsonpath='{.status.state}'=${target_state} --timeout=60s 2>/dev/null; do
 		echo -n .
 		let retry+=1
-		if kubectl_bin wait psmdb-restore restore-${backup_name} --for=jsonpath='{.status.state}'=${target_state} --timeout=60s 2>/dev/null; then
-			echo "OK"
-			break
-		fi
 		current_state=$(kubectl_bin get psmdb-restore restore-$backup_name -o jsonpath='{.status.state}')
 		if [[ ${ok_if_ready} == 1 && ${current_state} == 'ready' ]]; then
 			echo "OK"

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -351,7 +351,8 @@ wait_restore() {
 	# We need to run wait till object is created, otherwise wait fails at once
 	echo -n "Waiting for the psmdb-restore/restore-$backup_name object to be created"
 	retry_object=0
-	until kubectl_bin get psmdb-restore restore-$backup_name >/dev/null; do
+	until kubectl_bin get psmdb-restore restore-$backup_name >/dev/null 2>&1; do
+		echo -n .
 		let retry_object+=1
 		if [[ ${retry_object} -ge 60 ]]; then
 			echo "psmdb-restore/restore-$backup_name object was not created."
@@ -359,11 +360,12 @@ wait_restore() {
 		fi
 		sleep 1
 	done
+	echo "OK"
 
 	echo -n "Waiting psmdb-restore/restore-${backup_name} to reach state \"${target_state}\" "
 	retry=0
 	retry_count=$((wait_time / 60))
-	until kubectl_bin wait psmdb-restore restore-${backup_name} --for=jsonpath='{.status.state}'=${target_state} --timeout=60s 2>/dev/null; do
+	until kubectl_bin wait psmdb-restore restore-${backup_name} --for=jsonpath='{.status.state}'=${target_state} --timeout=60s >/dev/null 2>&1; do
 		echo -n .
 		let retry+=1
 		current_state=$(kubectl_bin get psmdb-restore restore-$backup_name -o jsonpath='{.status.state}')

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -377,8 +377,8 @@ wait_restore() {
 		fi
 		current_state=$(kubectl_bin get psmdb-restore restore-$backup_name -o jsonpath='{.status.state}')
 		if [[ ${ok_if_ready} == 1 && ${current_state} == 'ready' ]]; then
-				echo "OK"
-				break
+			echo "OK"
+			break
 		fi
 		if [[ ${retry} == ${retry_count} || ${current_state} == 'error' ]]; then
 				kubectl_bin logs ${OPERATOR_NS:+-n $OPERATOR_NS} $(get_operator_pod) \

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -239,6 +239,7 @@ wait_backup() {
 				| grep -v 'Getting tasks for pod' \
 				| grep -v 'Getting pods from source' \
 				| tail -100
+			kubectl_bin get psmdb-backup
 			echo "Backup object psmdb-backup/${backup_name} is in ${current_state} state."
 			echo something went wrong with operator or kubernetes cluster
 			exit 1

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -1023,6 +1023,13 @@ delete_crd() {
 	kubectl_bin delete -f "${src_dir}/deploy/$rbac_yaml" --ignore-not-found || true
 }
 
+delete_backups() {
+	desc 'Delete psmdb-backup'
+	if [ $(kubectl_bin get psmdb-backup --no-headers | wc -l) != 0 ]; then
+		kubectl_bin delete psmdb-backup --all
+	fi
+}
+
 destroy() {
 	local namespace="$1"
 	local ignore_logs="${2:-true}"
@@ -1042,6 +1049,8 @@ destroy() {
 	fi
 	#TODO: maybe will be enabled later
 	#diff $test_dir/compare/operator.log $tmp_dir/operator.log
+
+	delete_backups
 
 	delete_crd
 

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -348,35 +348,55 @@ wait_restore() {
 	local ok_if_ready=${6:-0}
 
 	set +o xtrace
+    # We need to run wait till object is created, otherwise wait fails at once
+    echo -n "Waiting for the psmdb-restore/restore-$backup_name object to be created"
+    retry_object=0
+	until [[ ${retry_object} == 60 ]]; do
+        echo -n .
+        if  kubectl_bin get psmdb-restore restore-$backup_name > /dev/null; then
+            echo "OK"
+			break
+		fi
+        let retry_object+=1
+        if [[ ${retry_object} == 60 ]]; then
+            echo "psmdb-restore/restore-$backup_name object was not created."
+            exit 1
+        fi
+		sleep 1
+	done
+
+	echo -n "Waiting psmdb-restore/restore-${backup_name} to reach state \"${target_state}\" "
 	retry=0
-	echo -n "waiting psmdb-restore/restore-${backup_name} to reach ${target_state} state"
-	local current_state=
-	until [[ ${current_state} == ${target_state} ]]; do
-		sleep 0.5
+	retry_count=$((wait_time / 60))
+	until [[ ${retry} == ${retry_count} ]]; do
 		echo -n .
 		let retry+=1
-		current_state=$(kubectl_bin get psmdb-restore restore-$backup_name -o jsonpath='{.status.state}')
-		if [[ ${ok_if_ready} == 1 && ${current_state} == 'ready' ]]; then
+		if kubectl_bin wait psmdb-restore restore-${backup_name} --for=jsonpath='{.status.state}'=${target_state} --timeout=60s 2>/dev/null; then
 			echo "OK"
 			break
 		fi
-		if [[ $retry -ge $wait_time || ${current_state} == 'error' ]]; then
-			kubectl_bin logs ${OPERATOR_NS:+-n $OPERATOR_NS} $(get_operator_pod) \
-				| grep -v 'level=info' \
-				| grep -v 'level=debug' \
-				| grep -v 'Getting tasks for pod' \
-				| grep -v 'Getting pods from source' \
-				| tail -100
-			kubectl_bin get psmdb-restore restore-${backup_name} -o yaml
-			echo "Restore object restore-${backup_name} is in ${current_state} state."
-			echo something went wrong with operator or kubernetes cluster
-			exit 1
+		current_state=$(kubectl_bin get psmdb-restore restore-$backup_name -o jsonpath='{.status.state}')
+		if [[ ${ok_if_ready} == 1 && ${current_state} == 'ready' ]]; then
+				echo "OK"
+				break
+		fi
+		if [[ ${retry} == ${retry_count} || ${current_state} == 'error' ]]; then
+				kubectl_bin logs ${OPERATOR_NS:+-n $OPERATOR_NS} $(get_operator_pod) \
+					| grep -v 'level=info' \
+					| grep -v 'level=debug' \
+					| grep -v 'Getting tasks for pod' \
+					| grep -v 'Getting pods from source' \
+					| tail -100
+				kubectl_bin get psmdb-restore restore-${backup_name} -o yaml
+				echo "Restore object restore-${backup_name} is in ${current_state} state."
+				echo something went wrong with operator or kubernetes cluster
+				exit 1
 		fi
 	done
+
 	echo "OK"
 	set_debug
-
-	if [ $wait_cluster_consistency -eq 1 ]; then
+	if [[ $wait_cluster_consistency -eq 1 ]]; then
 		wait_cluster_consistency "${cluster_name}"
 	fi
 }

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -348,9 +348,9 @@ wait_restore() {
 	local ok_if_ready=${6:-0}
 
 	set +o xtrace
-    # We need to run wait till object is created, otherwise wait fails at once
-    echo -n "Waiting for the psmdb-restore/restore-$backup_name object to be created"
-    retry_object=0
+	# We need to run wait till object is created, otherwise wait fails at once
+	echo -n "Waiting for the psmdb-restore/restore-$backup_name object to be created"
+	retry_object=0
 	until [[ ${retry_object} == 60 ]]; do
         echo -n .
         if  kubectl_bin get psmdb-restore restore-$backup_name > /dev/null; then

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -353,7 +353,7 @@ wait_restore() {
 	retry_object=0
 	until kubectl_bin get psmdb-restore restore-$backup_name >/dev/null; do
 		let retry_object+=1
-		if [[ ${retry_object} == 60 ]]; then
+		if [[ ${retry_object} -ge 60 ]]; then
 			echo "psmdb-restore/restore-$backup_name object was not created."
 			exit 1
 		fi
@@ -371,7 +371,7 @@ wait_restore() {
 			echo "OK"
 			break
 		fi
-		if [[ ${retry} == ${retry_count} || ${current_state} == 'error' ]]; then
+		if [[ ${retry} -ge ${retry_count} || ${current_state} == 'error' ]]; then
 			kubectl_bin logs ${OPERATOR_NS:+-n $OPERATOR_NS} $(get_operator_pod) \
 				| grep -v 'level=info' \
 				| grep -v 'level=debug' \

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -1026,6 +1026,7 @@ delete_crd() {
 delete_backups() {
 	desc 'Delete psmdb-backup'
 	if [ $(kubectl_bin get psmdb-backup --no-headers | wc -l) != 0 ]; then
+		kubectl_bin get psmdb-backup
 		kubectl_bin delete psmdb-backup --all
 	fi
 }

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -381,16 +381,16 @@ wait_restore() {
 			break
 		fi
 		if [[ ${retry} == ${retry_count} || ${current_state} == 'error' ]]; then
-				kubectl_bin logs ${OPERATOR_NS:+-n $OPERATOR_NS} $(get_operator_pod) \
-					| grep -v 'level=info' \
-					| grep -v 'level=debug' \
-					| grep -v 'Getting tasks for pod' \
-					| grep -v 'Getting pods from source' \
-					| tail -100
-				kubectl_bin get psmdb-restore restore-${backup_name} -o yaml
-				echo "Restore object restore-${backup_name} is in ${current_state} state."
-				echo something went wrong with operator or kubernetes cluster
-				exit 1
+			kubectl_bin logs ${OPERATOR_NS:+-n $OPERATOR_NS} $(get_operator_pod) \
+				| grep -v 'level=info' \
+				| grep -v 'level=debug' \
+				| grep -v 'Getting tasks for pod' \
+				| grep -v 'Getting pods from source' \
+				| tail -100
+			kubectl_bin get psmdb-restore restore-${backup_name} -o yaml
+			echo "Restore object restore-${backup_name} is in ${current_state} state."
+			echo something went wrong with operator or kubernetes cluster
+			exit 1
 		fi
 	done
 

--- a/e2e-tests/pitr-physical/run
+++ b/e2e-tests/pitr-physical/run
@@ -78,6 +78,8 @@ main() {
 		sleep 10
 	done
 
+	sleep 10
+
 	check_recovery $backup_name_minio-2 date "${last_chunk}" "-2nd" "$cluster"
 
 	run_backup $backup_name_minio 3 physical

--- a/e2e-tests/rs-shard-migration/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/rs-shard-migration/compare/statefulset_some-name-rs0-oc.yml
@@ -55,7 +55,6 @@ spec:
             - --encryptionKeyFile=/etc/mongodb-encryption/encryption-key
             - --wiredTigerCacheSizeGB=0.25
             - --wiredTigerIndexPrefixCompression=true
-            - --config=/etc/mongodb-config/mongod.conf
             - --quiet
           command:
             - /opt/percona/ps-entry.sh
@@ -131,8 +130,6 @@ spec:
             - mountPath: /etc/mongodb-ssl-internal
               name: ssl-internal
               readOnly: true
-            - mountPath: /etc/mongodb-config
-              name: config
             - mountPath: /opt/percona
               name: bin
             - mountPath: /etc/mongodb-encryption
@@ -141,6 +138,56 @@ spec:
             - mountPath: /etc/users-secret
               name: users-secret-file
           workingDir: /data/db
+        - args:
+            - pbm-agent-entrypoint
+          command:
+            - /opt/percona/pbm-entry.sh
+          env:
+            - name: PBM_AGENT_MONGODB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  key: MONGODB_BACKUP_USER_ESCAPED
+                  name: internal-some-name-users
+                  optional: false
+            - name: PBM_AGENT_MONGODB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: MONGODB_BACKUP_PASSWORD_ESCAPED
+                  name: internal-some-name-users
+                  optional: false
+            - name: PBM_MONGODB_REPLSET
+              value: rs0
+            - name: PBM_MONGODB_PORT
+              value: "27017"
+            - name: PBM_AGENT_SIDECAR
+              value: "true"
+            - name: PBM_AGENT_SIDECAR_SLEEP
+              value: "5"
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: PBM_MONGODB_URI
+              value: mongodb://$(PBM_AGENT_MONGODB_USERNAME):$(PBM_AGENT_MONGODB_PASSWORD)@localhost:$(PBM_MONGODB_PORT)/?tls=true&tlsCertificateKeyFile=/tmp/tls.pem&tlsCAFile=/etc/mongodb-ssl/ca.crt&tlsInsecure=true
+            - name: PBM_AGENT_TLS_ENABLED
+              value: "true"
+          imagePullPolicy: Always
+          name: backup-agent
+          resources: {}
+          securityContext:
+            runAsNonRoot: true
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /etc/mongodb-ssl
+              name: ssl
+              readOnly: true
+            - mountPath: /opt/percona
+              name: bin
+              readOnly: true
+            - mountPath: /data/db
+              name: mongod-data
       dnsPolicy: ClusterFirst
       initContainers:
         - command:
@@ -175,11 +222,6 @@ spec:
             secretName: some-name-mongodb-keyfile
         - emptyDir: {}
           name: bin
-        - configMap:
-            defaultMode: 420
-            name: some-name-rs0-mongod
-            optional: true
-          name: config
         - name: some-name-mongodb-encryption-key
           secret:
             defaultMode: 288


### PR DESCRIPTION
[![K8SPSMDB-1265](https://badgen.net/badge/JIRA/K8SPSMDB-1265/green)](https://jira.percona.com/browse/K8SPSMDB-1265) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
Hi. The following problems should be fixed:
1) From time to time `wait_restore()` does not detect that object has `requested` state and fails, although eventually restore gets ready state.
2) The presence of the backup in minio storage fails in `demand-backup-sharded`. 
3) The backups are not deleted from the storage after tests as a result resync requires a lot of time and tests run long.


**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
1) Use kubectl wait instead of regular loop.
2) Add retry.
3) Delete backups before removing finalizers from objects.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-1265]: https://perconadev.atlassian.net/browse/K8SPSMDB-1265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ