### PR TITLE
K8SPSMDB-1154: disable encryption by default for inMemory

### DIFF
--- a/pkg/apis/psmdb/v1/psmdb_defaults.go
+++ b/pkg/apis/psmdb/v1/psmdb_defaults.go
@@ -727,6 +727,16 @@ func (rs *ReplsetSpec) SetDefaults(platform version.Platform, cr *PerconaServerM
 		}
 	}
 
+	if rs.Storage.Engine == StorageEngineInMemory {
+		encryptionEnabled, err := rs.Configuration.IsEncryptionEnabled()
+		if err != nil {
+			return errors.Wrap(err, "failed to parse replset configuration")
+		}
+		if encryptionEnabled != nil && *encryptionEnabled {
+			return errors.New("inMemory storage engine doesn't support encryption")
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/psmdb/statefulset.go
+++ b/pkg/psmdb/statefulset.go
@@ -584,7 +584,11 @@ func isEncryptionEnabled(cr *api.PerconaServerMongoDB, replset *api.ReplsetSpec)
 	if err != nil {
 		return false, errors.Wrap(err, "failed to parse replset configuration")
 	}
+
 	if enabled == nil {
+		if replset.Storage.Engine == api.StorageEngineInMemory {
+			return false, nil // disabled for inMemory engine by default
+		}
 		return true, nil // true by default
 	}
 	return *enabled, nil


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/K8SPSMDB-1154

**CHANGE DESCRIPTION**
---
**Problem:**
*Short explanation of the problem.*

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
