### PR TITLE
K8SPSMDB-1371: Prevent panic if no oplogs are in PBM metadata

### DIFF
--- a/pkg/controller/perconaservermongodbrestore/physical.go
+++ b/pkg/controller/perconaservermongodbrestore/physical.go
@@ -918,6 +918,10 @@ func (r *ReconcilePerconaServerMongoDBRestore) getLatestChunkTS(ctx context.Cont
 		return "", errors.Wrap(err, "unmarshal PBM status output")
 	}
 
+	if len(pbmStatus.Backups.Chunks.Timelines) < 1 {
+		return "", errors.New("no oplog chunks")
+	}
+
 	latest := pbmStatus.Backups.Chunks.Timelines[len(pbmStatus.Backups.Chunks.Timelines)-1].Range.End
 	ts := time.Unix(int64(latest), 0).UTC()
 


### PR DESCRIPTION
[![K8SPSMDB-1371](https://badgen.net/badge/JIRA/K8SPSMDB-1371/green)](https://jira.percona.com/browse/K8SPSMDB-1371) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
Operator panics if user tries to run a physical restore with `pitr.type: latest` and there are no oplogs are in PBM metadata.

**Solution:**
Add a sanity check.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-1371]: https://perconadev.atlassian.net/browse/K8SPSMDB-1371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ