### PR TITLE
 K8SPSMDB-1378: Prevent parallel backups

### DIFF
--- a/e2e-tests/demand-backup-incremental-sharded/run
+++ b/e2e-tests/demand-backup-incremental-sharded/run
@@ -127,8 +127,16 @@ if [ -z "$SKIP_BACKUPS_TO_AWS_GCP_AZURE" ]; then
 	run_backup azure-blob ${backup_name_azure}
 
 	wait_backup "${backup_name_aws}"
+	check_backup_in_storage ${backup_name_aws} s3 rs0
+	check_backup_in_storage ${backup_name_aws} s3 cfg
+
 	wait_backup "${backup_name_gcp}"
+	check_backup_in_storage ${backup_name_gcp} gcs rs0
+	check_backup_in_storage ${backup_name_gcp} gcs cfg
+
 	wait_backup "${backup_name_azure}"
+	check_backup_in_storage ${backup_name_azure} azure rs0
+	check_backup_in_storage ${backup_name_azure} azure cfg
 fi
 
 backup_name_minio="backup-minio-sharded"

--- a/e2e-tests/demand-backup-incremental/run
+++ b/e2e-tests/demand-backup-incremental/run
@@ -111,8 +111,13 @@ if [ -z "$SKIP_BACKUPS_TO_AWS_GCP_AZURE" ]; then
 	run_backup azure-blob ${backup_name_azure}
 
 	wait_backup "${backup_name_aws}"
+	check_backup_in_storage ${backup_name_aws} s3 rs0
+
 	wait_backup "${backup_name_gcp}"
+	check_backup_in_storage ${backup_name_gcp} gcs rs0
+
 	wait_backup "${backup_name_azure}"
+	check_backup_in_storage ${backup_name_azure} azure rs0
 fi
 
 backup_name_minio="backup-minio"

--- a/e2e-tests/demand-backup-physical-sharded/run
+++ b/e2e-tests/demand-backup-physical-sharded/run
@@ -112,8 +112,16 @@ if [ -z "$SKIP_BACKUPS_TO_AWS_GCP_AZURE" ]; then
 	run_backup azure-blob ${backup_name_azure}
 
 	wait_backup "${backup_name_aws}"
+	check_backup_in_storage ${backup_name_aws} s3 rs0
+	check_backup_in_storage ${backup_name_aws} s3 cfg
+
 	wait_backup "${backup_name_gcp}"
+	check_backup_in_storage ${backup_name_gcp} gcs rs0
+	check_backup_in_storage ${backup_name_gcp} gcs cfg
+
 	wait_backup "${backup_name_azure}"
+	check_backup_in_storage ${backup_name_azure} azure rs0
+	check_backup_in_storage ${backup_name_azure} azure cfg
 fi
 wait_backup "${backup_name_minio}"
 

--- a/e2e-tests/demand-backup-physical/run
+++ b/e2e-tests/demand-backup-physical/run
@@ -98,8 +98,13 @@ if [ -z "$SKIP_BACKUPS_TO_AWS_GCP_AZURE" ]; then
 	run_backup azure-blob ${backup_name_azure}
 
 	wait_backup "${backup_name_aws}"
+	check_backup_in_storage ${backup_name_aws} s3 rs0
+
 	wait_backup "${backup_name_gcp}"
+	check_backup_in_storage ${backup_name_gcp} gcs rs0
+
 	wait_backup "${backup_name_azure}"
+	check_backup_in_storage ${backup_name_azure} azure rs0
 fi
 wait_backup "${backup_name_minio}"
 

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -17,6 +17,7 @@ IMAGE_PMM_CLIENT=${IMAGE_PMM_CLIENT:-"perconalab/pmm-client:dev-latest"}
 IMAGE_PMM_SERVER=${IMAGE_PMM_SERVER:-"perconalab/pmm-server:dev-latest"}
 CERT_MANAGER_VER="1.16.3"
 UPDATE_COMPARE_FILES=${UPDATE_COMPARE_FILES:-0}
+DELETE_CRD_ON_START=${DELETE_CRD_ON_START:-1}
 tmp_dir=$(mktemp -d)
 sed=$(which gsed || which sed)
 date=$(which gdate || which date)
@@ -1331,8 +1332,10 @@ check_backup_deletion() {
 create_infra() {
 	local ns="$1"
 
-	delete_crd
-	check_crd_for_deletion "${GIT_BRANCH}"
+	if [[ ${DELETE_CRD_ON_START} == 1 ]]; then
+		delete_crd
+		check_crd_for_deletion "${GIT_BRANCH}"
+	fi
 	if [ -n "$OPERATOR_NS" ]; then
 		create_namespace $OPERATOR_NS
 		deploy_operator
@@ -1866,4 +1869,32 @@ wait_for_oplogs() {
 		log "Waiting for last oplog chunk ($(format_date ${last_chunk})) to be greater than last write ($(format_date ${backup_last_write}))"
 		sleep 10
 	done
+}
+
+check_backup_in_storage() {
+	local backup=$1
+	local storage_type=$2
+	local replset=$3
+	local file=${4:-"filelist.pbm"}
+
+	local endpoint
+	case ${storage_type} in
+		s3)
+			endpoint="s3.amazonaws.com"
+			;;
+		gcs)
+			endpoint="storage.googleapis.com"
+			;;
+		azure)
+			endpoint="engk8soperators.blob.core.windows.net"
+			;;
+		*)
+			echo "unsupported storage type: ${storage_type}"
+			exit 1
+	esac
+
+	backup_dest=$(get_backup_dest "$backup")
+	local url="https://${endpoint}/${backup_dest}/${replset}/${file}"
+	log "checking if ${url} exists"
+	curl --fail --head "${url}"
 }

--- a/pkg/apis/psmdb/v1/perconaservermongodbbackup_types.go
+++ b/pkg/apis/psmdb/v1/perconaservermongodbbackup_types.go
@@ -11,6 +11,7 @@ import (
 
 // PerconaServerMongoDBBackupSpec defines the desired state of PerconaServerMongoDBBackup
 type PerconaServerMongoDBBackupSpec struct {
+	// Deprecated: Use ClusterName instead
 	PSMDBCluster     string                   `json:"psmdbCluster,omitempty"` // TODO: Remove after v1.15
 	ClusterName      string                   `json:"clusterName,omitempty"`
 	StorageName      string                   `json:"storageName,omitempty"`

--- a/pkg/k8s/lease.go
+++ b/pkg/k8s/lease.go
@@ -1,0 +1,68 @@
+package k8s
+
+import (
+	"context"
+	"time"
+
+	"github.com/pkg/errors"
+	coordv1 "k8s.io/api/coordination/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	ErrNotTheHolder = errors.New("not the holder")
+)
+
+func AcquireLease(ctx context.Context, c client.Client, name, namespace, holder string) (*coordv1.Lease, error) {
+	lease := new(coordv1.Lease)
+
+	if err := c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, lease); err != nil {
+		if !k8serrors.IsNotFound(err) {
+			return lease, errors.Wrap(err, "get lease")
+		}
+
+		lease := &coordv1.Lease{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Spec: coordv1.LeaseSpec{
+				AcquireTime:    &metav1.MicroTime{Time: time.Now()},
+				HolderIdentity: &holder,
+			},
+		}
+
+		if err := c.Create(ctx, lease); err != nil {
+			return lease, errors.Wrap(err, "create lease")
+		}
+
+		return lease, nil
+	}
+
+	return lease, nil
+}
+
+func ReleaseLease(ctx context.Context, c client.Client, name, namespace, holder string) error {
+	lease := new(coordv1.Lease)
+
+	if err := c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, lease); err != nil {
+		return errors.Wrap(err, "get lease")
+	}
+
+	if lease.Spec.HolderIdentity == nil {
+		// TODO: What to do?
+	}
+
+	if lease.Spec.HolderIdentity != nil && *lease.Spec.HolderIdentity != holder {
+		return ErrNotTheHolder
+	}
+
+	if err := c.Delete(ctx, lease); err != nil {
+		return errors.Wrap(err, "delete lease")
+	}
+
+	return nil
+}

--- a/pkg/k8s/lease.go
+++ b/pkg/k8s/lease.go
@@ -52,10 +52,7 @@ func ReleaseLease(ctx context.Context, c client.Client, name, namespace, holder 
 		return errors.Wrap(err, "get lease")
 	}
 
-	if lease.Spec.HolderIdentity == nil {
-		// TODO: What to do?
-	}
-
+	// HolderIdentity can be nil, we allow deleting the lease if that's the case
 	if lease.Spec.HolderIdentity != nil && *lease.Spec.HolderIdentity != holder {
 		return ErrNotTheHolder
 	}

--- a/pkg/k8s/lease_test.go
+++ b/pkg/k8s/lease_test.go
@@ -1,0 +1,74 @@
+package k8s_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	coordv1 "k8s.io/api/coordination/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake" // nolint
+
+	"github.com/percona/percona-server-mongodb-operator/pkg/k8s"
+)
+
+var _ = Describe("Lease", func() {
+	It("should be create a lease", func() {
+		cl := fake.NewFakeClient()
+
+		ctx := context.Background()
+
+		name := "backup-lock"
+		namespace := "test"
+		holder := "backup1-a96b4d1c-c0ea-424a-b13c-2e1f351c6e61"
+
+		lease, err := k8s.AcquireLease(ctx, cl, name, namespace, holder)
+		Expect(err).ToNot(HaveOccurred())
+
+		freshLease := new(coordv1.Lease)
+		nn := types.NamespacedName{
+			Name:      name,
+			Namespace: namespace,
+		}
+		err = cl.Get(ctx, nn, freshLease)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(freshLease.Spec.AcquireTime).NotTo(BeNil())
+		Expect(freshLease.Spec.HolderIdentity, lease.Spec.HolderIdentity)
+	})
+
+	It("should be delete a lease", func() {
+		ctx := context.Background()
+
+		name := "backup-lock"
+		namespace := "test"
+		holder := "backup1-a96b4d1c-c0ea-424a-b13c-2e1f351c6e61"
+
+		lease := &coordv1.Lease{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Spec: coordv1.LeaseSpec{
+				AcquireTime:    &metav1.MicroTime{Time: time.Now()},
+				HolderIdentity: &holder,
+			},
+		}
+
+		cl := fake.NewFakeClient(lease)
+
+		err := k8s.ReleaseLease(ctx, cl, name, namespace, holder)
+		Expect(err).ToNot(HaveOccurred())
+
+		freshLease := new(coordv1.Lease)
+		nn := types.NamespacedName{
+			Name:      name,
+			Namespace: namespace,
+		}
+		err = cl.Get(ctx, nn, freshLease)
+		Expect(err).To(HaveOccurred())
+		Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+	})
+})

--- a/pkg/naming/backup.go
+++ b/pkg/naming/backup.go
@@ -1,0 +1,15 @@
+package naming
+
+import (
+	"fmt"
+
+	psmdbv1 "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
+)
+
+func BackupLeaseName(clusterName string) string {
+	return "psmdb-" + clusterName + "-backup-lock"
+}
+
+func BackupHolderId(cr *psmdbv1.PerconaServerMongoDBBackup) string {
+	return fmt.Sprintf("%s-%s", cr.Name, cr.UID)
+}

--- a/pkg/naming/naming.go
+++ b/pkg/naming/naming.go
@@ -6,13 +6,17 @@ import (
 	psmdbv1 "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
 )
 
-const perconaPrefix = "percona.com/"
+const (
+	perconaPrefix  = "percona.com/"
+	internalPrefix = "internal." + perconaPrefix
+)
 
 const (
 	FinalizerDeleteBackup           = perconaPrefix + "delete-backup"
 	FinalizerDeletePITR             = perconaPrefix + "delete-pitr-chunks"
 	FinalizerDeletePVC              = perconaPrefix + "delete-psmdb-pvc"
 	FinalizerDeletePSMDBPodsInOrder = perconaPrefix + "delete-psmdb-pods-in-order"
+	FinalizerReleaseLock            = internalPrefix + "release-lock"
 )
 
 const (

--- a/pkg/psmdb/backup/backup.go
+++ b/pkg/psmdb/backup/backup.go
@@ -41,31 +41,8 @@ func HasActiveJobs(ctx context.Context, newPBMFunc NewPBMFunc, cl client.Client,
 	l := log.FromContext(ctx)
 	l.V(1).Info("Checking for active jobs", "currentJob", current)
 
-	bcps := &api.PerconaServerMongoDBBackupList{}
-	err := cl.List(ctx,
-		bcps,
-		&client.ListOptions{
-			Namespace: cluster.Namespace,
-		},
-	)
-	if err != nil {
-		return false, errors.Wrap(err, "get backup list")
-	}
-	for _, b := range bcps.Items {
-		if b.Name == current.Name && current.Type == TypeBackup {
-			continue
-		}
-		if b.Spec.GetClusterName() == cluster.Name &&
-			b.Status.State != api.BackupStateReady &&
-			b.Status.State != api.BackupStateError &&
-			b.Status.State != api.BackupStateWaiting {
-			l.Info("Waiting for backup to complete", "backup", b.Name, "status", b.Status.State)
-			return true, nil
-		}
-	}
-
 	rstrs := &api.PerconaServerMongoDBRestoreList{}
-	err = cl.List(ctx,
+	err := cl.List(ctx,
 		rstrs,
 		&client.ListOptions{
 			Namespace: cluster.Namespace,


### PR DESCRIPTION
[![K8SPSMDB-1378](https://badgen.net/badge/JIRA/K8SPSMDB-1378/green)](https://jira.percona.com/browse/K8SPSMDB-1378) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
With these changes, psmdb-backup controller will create a lease object for a running backup and no other backup will be able to start until this lease is released (deleted). Lock is released when backup succeeds or fails.

We introduce a new finalizer called `internal.percona.com/release-lock` for PerconaServerMongoDBBackup objects. Operator will automatically add this finalizer to each new backup object if it doesn't exist. This finalizer will release the lock if user deletes a running backup object.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-1378]: https://perconadev.atlassian.net/browse/K8SPSMDB-1378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ