### PR TITLE
K8SPSMDB-1292 Trim spaces from count in check_backup_count function for e2e tests

### DIFF
--- a/e2e-tests/scheduled-backup/run
+++ b/e2e-tests/scheduled-backup/run
@@ -23,6 +23,7 @@ check_backup_count() {
 	local expected=$2
 
 	local count=$(kubectl_bin get psmdb-backup -l percona.com/backup-ancestor=${ancestor} | grep ready | wc -l)
+	count="${count//[[:space:]]/}"
 
 	if [[ ${count} != ${expected} ]]; then
 		echo "${ancestor}: Expected ${expected} backups but found ${count}."


### PR DESCRIPTION
[![K8SPSMDB-1292](https://badgen.net/badge/JIRA/K8SPSMDB-1292/green)](https://jira.percona.com/browse/K8SPSMDB-1292) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
Noticed that locally, when running tests that are utilizing the function `check_backup_count `, we have errors like the following:


![Screenshot 2025-05-15 at 12 28 53 PM](https://github.com/user-attachments/assets/296f7843-ea69-43d0-9704-22a9343216a0)

This causes the assertion to fail because the 2 strings are not matching.


**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**

strip all the heading and trailing spaces from the count string.

Test:
```
count="      1    "
count="${count//[[:space:]]/}"
echo "$count"  # expected output is: 1
```
**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-1292]: https://perconadev.atlassian.net/browse/K8SPSMDB-1292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ