### PR TITLE
K8SPSMDB-1297 add data dir to proc

### DIFF
--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-cfg-oc.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-cfg-oc.yml
@@ -277,6 +277,9 @@ spec:
             - mountPath: /etc/mongodb-ssl
               name: ssl
               readOnly: true
+            - mountPath: /data/db
+              name: mongod-data
+              readOnly: true
       dnsPolicy: ClusterFirst
       initContainers:
         - command:

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-cfg.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-cfg.yml
@@ -278,6 +278,9 @@ spec:
             - mountPath: /etc/mongodb-ssl
               name: ssl
               readOnly: true
+            - mountPath: /data/db
+              name: mongod-data
+              readOnly: true
       dnsPolicy: ClusterFirst
       initContainers:
         - command:

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-mongos-oc.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-mongos-oc.yml
@@ -278,6 +278,9 @@ spec:
             - mountPath: /etc/mongodb-ssl
               name: ssl
               readOnly: true
+            - mountPath: /data/db
+              name: mongod-data
+              readOnly: true
       dnsPolicy: ClusterFirst
       initContainers:
         - command:

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-mongos.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-mongos.yml
@@ -279,6 +279,9 @@ spec:
             - mountPath: /etc/mongodb-ssl
               name: ssl
               readOnly: true
+            - mountPath: /data/db
+              name: mongod-data
+              readOnly: true
       dnsPolicy: ClusterFirst
       initContainers:
         - command:

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0-oc.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0-oc.yml
@@ -265,6 +265,9 @@ spec:
             - mountPath: /etc/mongodb-ssl
               name: ssl
               readOnly: true
+            - mountPath: /data/db
+              name: mongod-data
+              readOnly: true
       dnsPolicy: ClusterFirst
       initContainers:
         - command:

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0.yml
@@ -266,6 +266,9 @@ spec:
             - mountPath: /etc/mongodb-ssl
               name: ssl
               readOnly: true
+            - mountPath: /data/db
+              name: mongod-data
+              readOnly: true
       dnsPolicy: ClusterFirst
       initContainers:
         - command:

--- a/pkg/psmdb/const.go
+++ b/pkg/psmdb/const.go
@@ -16,7 +16,7 @@ const (
 
 	// MongodDataVolClaimName is a PVC Claim name
 	MongodDataVolClaimName = "mongod-data"
-	// MongodContainerDataDir is a mondo data path in container
+	// MongodContainerDataDir is a mongo data path in container
 	MongodContainerDataDir = "/data/db"
 
 	BinVolumeName = "bin"

--- a/pkg/psmdb/init.go
+++ b/pkg/psmdb/init.go
@@ -18,7 +18,7 @@ func EntrypointInitContainer(cr *api.PerconaServerMongoDB, name, image string, p
 		VolumeMounts: []corev1.VolumeMount{
 			{
 				Name:      MongodDataVolClaimName,
-				MountPath: "/data/db",
+				MountPath: MongodContainerDataDir,
 			},
 		},
 		Image:           image,

--- a/pkg/psmdb/statefulset.go
+++ b/pkg/psmdb/statefulset.go
@@ -437,7 +437,7 @@ func backupAgentContainer(ctx context.Context, cr *api.PerconaServerMongoDB, rep
 
 		c.VolumeMounts = append(c.VolumeMounts, []corev1.VolumeMount{
 			{
-				Name:      "mongod-data",
+				Name:      MongodDataVolClaimName,
 				MountPath: MongodContainerDataDir,
 				ReadOnly:  false,
 			},


### PR DESCRIPTION
[![K8SPSMDB-1297](https://badgen.net/badge/JIRA/K8SPSMDB-1297/green)](https://jira.percona.com/browse/K8SPSMDB-1297) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
datadir mountpoint is not access by node_exporter because it is not exposed in the /proc 

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
 Expose the datadir to the sidecar so the node_exporter can gather the metrics.
<img width="1201" alt="Screenshot 2025-05-15 at 14 08 59" src="https://github.com/user-attachments/assets/bdaedf1c-bc18-4936-a684-c274d5104a86" />


**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-1297]: https://perconadev.atlassian.net/browse/K8SPSMDB-1297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ