### PR TITLE
K8SPSMDB-1268 && K8SPSMDB-1297 add data dir for pmm3

### DIFF
--- a/e2e-tests/monitoring-pmm3/compare/statefulset_monitoring-pmm3-cfg-oc.yml
+++ b/e2e-tests/monitoring-pmm3/compare/statefulset_monitoring-pmm3-cfg-oc.yml
@@ -264,6 +264,9 @@ spec:
             - mountPath: /etc/mongodb-ssl
               name: ssl
               readOnly: true
+            - mountPath: /data/db
+              name: mongod-data
+              readOnly: true
       dnsPolicy: ClusterFirst
       initContainers:
         - command:

--- a/e2e-tests/monitoring-pmm3/compare/statefulset_monitoring-pmm3-cfg.yml
+++ b/e2e-tests/monitoring-pmm3/compare/statefulset_monitoring-pmm3-cfg.yml
@@ -265,6 +265,9 @@ spec:
             - mountPath: /etc/mongodb-ssl
               name: ssl
               readOnly: true
+            - mountPath: /data/db
+              name: mongod-data
+              readOnly: true
       dnsPolicy: ClusterFirst
       initContainers:
         - command:

--- a/e2e-tests/monitoring-pmm3/compare/statefulset_monitoring-pmm3-mongos-oc.yml
+++ b/e2e-tests/monitoring-pmm3/compare/statefulset_monitoring-pmm3-mongos-oc.yml
@@ -265,6 +265,9 @@ spec:
             - mountPath: /etc/mongodb-ssl
               name: ssl
               readOnly: true
+            - mountPath: /data/db
+              name: mongod-data
+              readOnly: true
       dnsPolicy: ClusterFirst
       initContainers:
         - command:

--- a/e2e-tests/monitoring-pmm3/compare/statefulset_monitoring-pmm3-mongos.yml
+++ b/e2e-tests/monitoring-pmm3/compare/statefulset_monitoring-pmm3-mongos.yml
@@ -266,6 +266,9 @@ spec:
             - mountPath: /etc/mongodb-ssl
               name: ssl
               readOnly: true
+            - mountPath: /data/db
+              name: mongod-data
+              readOnly: true
       dnsPolicy: ClusterFirst
       initContainers:
         - command:

--- a/e2e-tests/monitoring-pmm3/compare/statefulset_monitoring-pmm3-rs0-oc.yml
+++ b/e2e-tests/monitoring-pmm3/compare/statefulset_monitoring-pmm3-rs0-oc.yml
@@ -252,6 +252,9 @@ spec:
             - mountPath: /etc/mongodb-ssl
               name: ssl
               readOnly: true
+            - mountPath: /data/db
+              name: mongod-data
+              readOnly: true
       dnsPolicy: ClusterFirst
       initContainers:
         - command:

--- a/e2e-tests/monitoring-pmm3/compare/statefulset_monitoring-pmm3-rs0.yml
+++ b/e2e-tests/monitoring-pmm3/compare/statefulset_monitoring-pmm3-rs0.yml
@@ -253,6 +253,9 @@ spec:
             - mountPath: /etc/mongodb-ssl
               name: ssl
               readOnly: true
+            - mountPath: /data/db
+              name: mongod-data
+              readOnly: true
       dnsPolicy: ClusterFirst
       initContainers:
         - command:

--- a/pkg/psmdb/pmm/pmm.go
+++ b/pkg/psmdb/pmm/pmm.go
@@ -521,6 +521,11 @@ func containerForPMM3(cr *api.PerconaServerMongoDB, secret *corev1.Secret, dbPor
 				MountPath: psmdbconfig.SSLDir,
 				ReadOnly:  true,
 			},
+			{
+				Name:      psmdbconfig.MongodDataVolClaimName,
+				MountPath: psmdbconfig.MongodContainerDataDir,
+				ReadOnly:  true,
+			},
 		},
 	}
 

--- a/pkg/psmdb/pmm/pmm_test.go
+++ b/pkg/psmdb/pmm/pmm_test.go
@@ -167,6 +167,11 @@ pmm-admin annotate --service-name=$(PMM_AGENT_SETUP_NODE_NAME) 'Service restarte
 				MountPath: psmdbconfig.SSLDir,
 				ReadOnly:  true,
 			},
+			{
+				Name:      "mongod-data",
+				MountPath: psmdbconfig.MongodContainerDataDir,
+				ReadOnly:  true,
+			},
 		},
 		SecurityContext: &corev1.SecurityContext{
 			RunAsNonRoot: &boolTrue,


### PR DESCRIPTION
[![K8SPSMDB-1268](https://badgen.net/badge/JIRA/K8SPSMDB-1268/green)](https://jira.percona.com/browse/K8SPSMDB-1268) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
Introducing this work: https://github.com/percona/percona-server-mongodb-operator/pull/1924, but for PMM3, which is introduced on the PR by the branch that is the base for this current PR.

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-1268]: https://perconadev.atlassian.net/browse/K8SPSMDB-1268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ