### PR TITLE
K8SPSMDB-1395: Bypass client cache for backup objects

### DIFF
--- a/pkg/controller/perconaservermongodbbackup/perconaservermongodbbackup_controller.go
+++ b/pkg/controller/perconaservermongodbbackup/perconaservermongodbbackup_controller.go
@@ -37,11 +37,6 @@ import (
 	"github.com/percona/percona-server-mongodb-operator/pkg/version"
 )
 
-/**
-* USER ACTION REQUIRED: This is a scaffold file intended for the user to modify with their own Controller
-* business logic.  Delete these comments after modifying this file.*
- */
-
 // Add creates a new PerconaServerMongoDBBackup Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager) error {
@@ -61,6 +56,7 @@ func newReconciler(mgr manager.Manager) (reconcile.Reconciler, error) {
 
 	return &ReconcilePerconaServerMongoDBBackup{
 		client:     mgr.GetClient(),
+		apiReader:  mgr.GetAPIReader(),
 		scheme:     mgr.GetScheme(),
 		newPBMFunc: backup.NewPBM,
 		clientcmd:  cli,
@@ -91,6 +87,7 @@ type ReconcilePerconaServerMongoDBBackup struct {
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver
 	client    client.Client
+	apiReader client.Reader
 	scheme    *runtime.Scheme
 	clientcmd *clientcmd.Client
 
@@ -113,7 +110,14 @@ func (r *ReconcilePerconaServerMongoDBBackup) Reconcile(ctx context.Context, req
 	}
 	// Fetch the PerconaServerMongoDBBackup instance
 	cr := &psmdbv1.PerconaServerMongoDBBackup{}
-	err := r.client.Get(ctx, request.NamespacedName, cr)
+
+	// Here we use k8s APIReader to read the k8s object by making the
+	// direct call to k8s apiserver instead of using k8sClient.
+	// The reason is that k8sClient uses a cache and sometimes k8sClient can
+	// return stale copy of object.
+	// It is okay to make direct call to k8s apiserver because we are only
+	// making single read call for complete reconciler loop.
+	err := r.apiReader.Get(ctx, request.NamespacedName, cr)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
@@ -124,6 +128,8 @@ func (r *ReconcilePerconaServerMongoDBBackup) Reconcile(ctx context.Context, req
 		// Error reading the object - requeue the request.
 		return rr, err
 	}
+
+	log.V(1).Info("Got object from API server", "state", cr.Status.State)
 
 	if (cr.Status.State == psmdbv1.BackupStateReady || cr.Status.State == psmdbv1.BackupStateError) &&
 		cr.ObjectMeta.DeletionTimestamp == nil {


### PR DESCRIPTION
[![K8SPSMDB-1395](https://badgen.net/badge/JIRA/K8SPSMDB-1395/green)](https://jira.percona.com/browse/K8SPSMDB-1395) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
Backup status is used to decide if we should send a backup request to PBM or not but it's highly possible that backup controller receives stale data due to cache.

**Solution:**
 Bypass cache and ensure we're hitting the API server directly.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-1395]: https://perconadev.atlassian.net/browse/K8SPSMDB-1395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ