### PR TITLE
K8SPSMDB-297 change logcollector to logCollector in cr

### DIFF
--- a/config/crd/bases/psmdb.percona.com_perconaservermongodbs.yaml
+++ b/config/crd/bases/psmdb.percona.com_perconaservermongodbs.yaml
@@ -534,7 +534,7 @@ spec:
                 type: object
               initImage:
                 type: string
-              logcollector:
+              logCollector:
                 properties:
                   configuration:
                     type: string

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -1253,7 +1253,7 @@ spec:
                 type: object
               initImage:
                 type: string
-              logcollector:
+              logCollector:
                 properties:
                   configuration:
                     type: string

--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -804,7 +804,7 @@ spec:
 #        storageName: s3-us-west
 #        compressionType: gzip
 #        compressionLevel: 6
-  logcollector:
+  logCollector:
     enabled: true
     image: perconalab/fluentbit:main-logcollector
 #    configuration: |

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -1253,7 +1253,7 @@ spec:
                 type: object
               initImage:
                 type: string
-              logcollector:
+              logCollector:
                 properties:
                   configuration:
                     type: string

--- a/deploy/cw-bundle.yaml
+++ b/deploy/cw-bundle.yaml
@@ -1253,7 +1253,7 @@ spec:
                 type: object
               initImage:
                 type: string
-              logcollector:
+              logCollector:
                 properties:
                   configuration:
                     type: string

--- a/e2e-tests/init-deploy/conf/another-name-rs0.yml
+++ b/e2e-tests/init-deploy/conf/another-name-rs0.yml
@@ -68,6 +68,6 @@ spec:
     size: 3
   secrets:
     users: some-users
-  logcollector:
+  logCollector:
     enabled: true
     image: perconalab/fluentbit:main-logcollector

--- a/e2e-tests/version-service/conf/crd.yaml
+++ b/e2e-tests/version-service/conf/crd.yaml
@@ -1253,7 +1253,7 @@ spec:
                 type: object
               initImage:
                 type: string
-              logcollector:
+              logCollector:
                 properties:
                   configuration:
                     type: string

--- a/pkg/apis/psmdb/v1/psmdb_types.go
+++ b/pkg/apis/psmdb/v1/psmdb_types.go
@@ -97,7 +97,7 @@ type PerconaServerMongoDBSpec struct {
 	Users                        []User                               `json:"users,omitempty"`
 	Roles                        []Role                               `json:"roles,omitempty"`
 	VolumeExpansionEnabled       bool                                 `json:"enableVolumeExpansion,omitempty"`
-	LogCollector                 *LogCollectorSpec                    `json:"logcollector,omitempty"`
+	LogCollector                 *LogCollectorSpec                    `json:"logCollector,omitempty"`
 }
 
 type UserRole struct {


### PR DESCRIPTION
[![K8SPSMDB-297](https://badgen.net/badge/JIRA/K8SPSMDB-297/green)](https://jira.percona.com/browse/K8SPSMDB-297) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**
While preparing the helm chart for this feature, noticed that the option in the cr in not camel case. We have this issue in the pxc operator, but we don't need to keep it like that for psmdb.

Followup to this pr: https://github.com/percona/percona-server-mongodb-operator/pull/1936

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-297]: https://perconadev.atlassian.net/browse/K8SPSMDB-297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ