### PR TITLE
K8SPSMDB-1339 make pitr date validation more restrictive

### DIFF
--- a/config/crd/bases/psmdb.percona.com_perconaservermongodbrestores.yaml
+++ b/config/crd/bases/psmdb.percona.com_perconaservermongodbrestores.yaml
@@ -192,9 +192,10 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-validations:
-                - message: Time should be in format YYYY-MM-DD HH:MM:SS
-                  rule: self.type != 'date' || (has(self.date) && self.date.matches('^[0-9]{4}-[0-9]{2}-[0-9]{2}
-                    [0-9]{2}:[0-9]{2}:[0-9]{2}$'))
+                - message: 'Time should be in format YYYY-MM-DD HH:MM:SS with valid
+                    ranges (MM: 01-12, DD: 01-31, HH: 00-23, MM/SS: 00-59)'
+                  rule: self.type != 'date' || (has(self.date) && self.date.matches('^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])
+                    ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$'))
                 - message: Date should not be used when 'latest' type is used
                   rule: self.type != 'latest' || !has(self.date)
               replset:

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -427,9 +427,10 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-validations:
-                - message: Time should be in format YYYY-MM-DD HH:MM:SS
-                  rule: self.type != 'date' || (has(self.date) && self.date.matches('^[0-9]{4}-[0-9]{2}-[0-9]{2}
-                    [0-9]{2}:[0-9]{2}:[0-9]{2}$'))
+                - message: 'Time should be in format YYYY-MM-DD HH:MM:SS with valid
+                    ranges (MM: 01-12, DD: 01-31, HH: 00-23, MM/SS: 00-59)'
+                  rule: self.type != 'date' || (has(self.date) && self.date.matches('^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])
+                    ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$'))
                 - message: Date should not be used when 'latest' type is used
                   rule: self.type != 'latest' || !has(self.date)
               replset:

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -427,9 +427,10 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-validations:
-                - message: Time should be in format YYYY-MM-DD HH:MM:SS
-                  rule: self.type != 'date' || (has(self.date) && self.date.matches('^[0-9]{4}-[0-9]{2}-[0-9]{2}
-                    [0-9]{2}:[0-9]{2}:[0-9]{2}$'))
+                - message: 'Time should be in format YYYY-MM-DD HH:MM:SS with valid
+                    ranges (MM: 01-12, DD: 01-31, HH: 00-23, MM/SS: 00-59)'
+                  rule: self.type != 'date' || (has(self.date) && self.date.matches('^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])
+                    ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$'))
                 - message: Date should not be used when 'latest' type is used
                   rule: self.type != 'latest' || !has(self.date)
               replset:

--- a/deploy/cw-bundle.yaml
+++ b/deploy/cw-bundle.yaml
@@ -427,9 +427,10 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-validations:
-                - message: Time should be in format YYYY-MM-DD HH:MM:SS
-                  rule: self.type != 'date' || (has(self.date) && self.date.matches('^[0-9]{4}-[0-9]{2}-[0-9]{2}
-                    [0-9]{2}:[0-9]{2}:[0-9]{2}$'))
+                - message: 'Time should be in format YYYY-MM-DD HH:MM:SS with valid
+                    ranges (MM: 01-12, DD: 01-31, HH: 00-23, MM/SS: 00-59)'
+                  rule: self.type != 'date' || (has(self.date) && self.date.matches('^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])
+                    ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$'))
                 - message: Date should not be used when 'latest' type is used
                   rule: self.type != 'latest' || !has(self.date)
               replset:

--- a/e2e-tests/version-service/conf/crd.yaml
+++ b/e2e-tests/version-service/conf/crd.yaml
@@ -427,9 +427,10 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-validations:
-                - message: Time should be in format YYYY-MM-DD HH:MM:SS
-                  rule: self.type != 'date' || (has(self.date) && self.date.matches('^[0-9]{4}-[0-9]{2}-[0-9]{2}
-                    [0-9]{2}:[0-9]{2}:[0-9]{2}$'))
+                - message: 'Time should be in format YYYY-MM-DD HH:MM:SS with valid
+                    ranges (MM: 01-12, DD: 01-31, HH: 00-23, MM/SS: 00-59)'
+                  rule: self.type != 'date' || (has(self.date) && self.date.matches('^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])
+                    ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$'))
                 - message: Date should not be used when 'latest' type is used
                   rule: self.type != 'latest' || !has(self.date)
               replset:

--- a/pkg/apis/psmdb/v1/perconaservermongodbrestore_types.go
+++ b/pkg/apis/psmdb/v1/perconaservermongodbrestore_types.go
@@ -177,7 +177,7 @@ func (t *PITRestoreDate) MarshalJSON() ([]byte, error) {
 	return json.Marshal(t.Time.Format("2006-01-02 15:04:05"))
 }
 
-// +kubebuilder:validation:XValidation:rule="self.type != 'date' || (has(self.date) && self.date.matches('^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}$'))",message="Time should be in format YYYY-MM-DD HH:MM:SS"
+// +kubebuilder:validation:XValidation:rule="self.type != 'date' || (has(self.date) && self.date.matches('^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$'))",message="Time should be in format YYYY-MM-DD HH:MM:SS with valid ranges (MM: 01-12, DD: 01-31, HH: 00-23, MM/SS: 00-59)"
 // +kubebuilder:validation:XValidation:rule="self.type != 'latest' || !has(self.date)",message="Date should not be used when 'latest' type is used"
 type PITRestoreSpec struct {
 	Type PITRestoreType  `json:"type,omitempty"`

--- a/pkg/controller/perconaservermongodbrestore/psmdb_restore_controller_test.go
+++ b/pkg/controller/perconaservermongodbrestore/psmdb_restore_controller_test.go
@@ -75,7 +75,13 @@ var _ = Describe("PerconaServerMongoDB", Ordered, func() {
 			Expect(unstructured.SetNestedField(obj.Object, "2020-01-01", "spec", "pitr", "date")).To(Succeed())
 
 			err = k8sClient.Create(ctx, obj)
-			Expect(err.Error()).To(Equal(`PerconaServerMongoDBRestore.psmdb.percona.com "date-validation" is invalid: spec.pitr: Invalid value: "object": Time should be in format YYYY-MM-DD HH:MM:SS`))
+			Expect(err.Error()).To(Equal(`PerconaServerMongoDBRestore.psmdb.percona.com "date-validation" is invalid: spec.pitr: Invalid value: "object": Time should be in format YYYY-MM-DD HH:MM:SS with valid ranges (MM: 01-12, DD: 01-31, HH: 00-23, MM/SS: 00-59)`))
+
+			obj = &unstructured.Unstructured{Object: m}
+			Expect(unstructured.SetNestedField(obj.Object, "1992-13-32 25:63:64", "spec", "pitr", "date")).To(Succeed())
+
+			err = k8sClient.Create(ctx, obj)
+			Expect(err.Error()).To(Equal(`PerconaServerMongoDBRestore.psmdb.percona.com "date-validation" is invalid: spec.pitr: Invalid value: "object": Time should be in format YYYY-MM-DD HH:MM:SS with valid ranges (MM: 01-12, DD: 01-31, HH: 00-23, MM/SS: 00-59)`))
 		})
 		It("Should create restore", func() {
 			Expect(unstructured.SetNestedField(obj.Object, "2020-01-01 10:10:10", "spec", "pitr", "date")).To(Succeed())


### PR DESCRIPTION
[![K8SPSMDB-1339](https://badgen.net/badge/JIRA/K8SPSMDB-1339/green)](https://jira.percona.com/browse/K8SPSMDB-1339) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---
**Problem:**

The existing validation for the pitr date does allow datetimes that are not possible. With this PR we are making the validation more restrictive so that it is following this format: `(MM: 01-12, DD: 01-31, HH: 00-23, MM/SS: 00-59)`

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-1339]: https://perconadev.atlassian.net/browse/K8SPSMDB-1339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ