### PR TITLE
K8SPSMDB-1480: Fix vote distribution algorithm

### DIFF
--- a/pkg/psmdb/mongo/mongo_test.go
+++ b/pkg/psmdb/mongo/mongo_test.go
@@ -3,22 +3,71 @@ package mongo_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/percona/percona-server-mongodb-operator/pkg/naming"
 	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb/mongo"
 )
 
 func TestVoting(t *testing.T) {
 	cases := []struct {
-		name     string
-		mset     *mongo.ConfigMembers
-		desiered *mongo.ConfigMembers
+		name      string
+		mset      *mongo.ConfigMembers
+		desired   *mongo.ConfigMembers
+		unsafePSA bool
 	}{
 		{
 			"nothing",
 			&mongo.ConfigMembers{},
 			&mongo.ConfigMembers{},
+			false,
 		},
 		{
-			"3 mongos",
+			"1 member: 1 rs0",
+			&mongo.ConfigMembers{
+				mongo.ConfigMember{
+					Host:     "host0",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+			},
+			&mongo.ConfigMembers{
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+			},
+			false,
+		},
+		{
+			"2 members: 2 rs0",
+			&mongo.ConfigMembers{
+				mongo.ConfigMember{
+					Host:     "host0",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Host:     "host1",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+			},
+			&mongo.ConfigMembers{
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Votes:    0,
+					Priority: 0,
+				},
+			},
+			false,
+		},
+		{
+			"3 members: 3 rs0",
 			&mongo.ConfigMembers{
 				mongo.ConfigMember{
 					Host:     "host0",
@@ -50,34 +99,10 @@ func TestVoting(t *testing.T) {
 					Priority: mongo.DefaultPriority,
 				},
 			},
+			false,
 		},
 		{
-			"2 mongos",
-			&mongo.ConfigMembers{
-				mongo.ConfigMember{
-					Host:     "host0",
-					Votes:    mongo.DefaultVotes,
-					Priority: mongo.DefaultPriority,
-				},
-				mongo.ConfigMember{
-					Host:     "host1",
-					Votes:    mongo.DefaultVotes,
-					Priority: mongo.DefaultPriority,
-				},
-			},
-			&mongo.ConfigMembers{
-				mongo.ConfigMember{
-					Votes:    mongo.DefaultVotes,
-					Priority: mongo.DefaultPriority,
-				},
-				mongo.ConfigMember{
-					Votes:    0,
-					Priority: 0,
-				},
-			},
-		},
-		{
-			"2 mongos + 1 arbiter",
+			"3 members: 2 rs0 + 1 arbiter",
 			&mongo.ConfigMembers{
 				mongo.ConfigMember{
 					Host:     "host0",
@@ -110,9 +135,10 @@ func TestVoting(t *testing.T) {
 					Priority: 0,
 				},
 			},
+			false,
 		},
 		{
-			"2 mongos + 1 first arbiter",
+			"3 members: 1 arbiter + 2 rs0",
 			&mongo.ConfigMembers{
 				mongo.ConfigMember{
 					Host:        "host0",
@@ -145,9 +171,820 @@ func TestVoting(t *testing.T) {
 					Priority: mongo.DefaultPriority,
 				},
 			},
+			false,
 		},
 		{
-			"9 mongos",
+			"3 members (unsafe PSA): 2 rs0 + 1 arbiter",
+			&mongo.ConfigMembers{
+				mongo.ConfigMember{
+					Host:     "host0",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Host:     "host1",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Host:        "host2",
+					Votes:       mongo.DefaultVotes,
+					Priority:    0,
+					ArbiterOnly: true,
+				},
+			},
+			&mongo.ConfigMembers{
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: 0,
+				},
+			},
+			true,
+		},
+		{
+			"4 members: 4 rs0",
+			&mongo.ConfigMembers{
+				mongo.ConfigMember{
+					Host:     "host0",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Host:     "host1",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Host:     "host2",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Host:     "host3",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+			},
+			&mongo.ConfigMembers{
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Votes:    0,
+					Priority: 0,
+				},
+			},
+			false,
+		},
+		{
+			"4 members: 3 rs0 + 1 arbiter",
+			&mongo.ConfigMembers{
+				mongo.ConfigMember{
+					Host:     "host0",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Host:     "host1",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Host:     "host2",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Host:        "host3",
+					Votes:       mongo.DefaultVotes,
+					Priority:    0,
+					ArbiterOnly: true,
+				},
+			},
+			&mongo.ConfigMembers{
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Votes:    0,
+					Priority: 0,
+				},
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: 0,
+				},
+			},
+			false,
+		},
+		{
+			"4 members: 1 rs0 + 3 hidden",
+			&mongo.ConfigMembers{
+				mongo.ConfigMember{
+					Host:     "host0",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Host:     "host1",
+					Votes:    mongo.DefaultVotes,
+					Priority: 0,
+					Hidden:   true,
+					Tags: mongo.ReplsetTags{
+						naming.ComponentHidden: "true",
+					},
+				},
+				mongo.ConfigMember{
+					Host:     "host2",
+					Votes:    mongo.DefaultVotes,
+					Priority: 0,
+					Hidden:   true,
+					Tags: mongo.ReplsetTags{
+						naming.ComponentHidden: "true",
+					},
+				},
+				mongo.ConfigMember{
+					Host:     "host3",
+					Votes:    mongo.DefaultVotes,
+					Priority: 0,
+					Hidden:   true,
+					Tags: mongo.ReplsetTags{
+						naming.ComponentHidden: "true",
+					},
+				},
+			},
+			&mongo.ConfigMembers{
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: 0,
+				},
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: 0,
+				},
+				mongo.ConfigMember{
+					Votes:    0,
+					Priority: 0,
+				},
+			},
+			false,
+		},
+		{
+			"5 members",
+			&mongo.ConfigMembers{
+				mongo.ConfigMember{
+					Host:     "host0",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Host:     "host1",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Host:     "host2",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Host:     "host3",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Host:     "host4",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+			},
+			&mongo.ConfigMembers{
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+			},
+			false,
+		},
+		{
+			"5 members: 3 rs0 + 2 non-voting",
+			&mongo.ConfigMembers{
+				mongo.ConfigMember{
+					Host:     "host0",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Host:     "host1",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Host:     "host2",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Host:     "host3",
+					Votes:    0,
+					Priority: 0,
+					Tags: mongo.ReplsetTags{
+						naming.ComponentNonVoting: "true",
+					},
+				},
+				mongo.ConfigMember{
+					Host:     "host4",
+					Votes:    0,
+					Priority: 0,
+					Tags: mongo.ReplsetTags{
+						naming.ComponentNonVoting: "true",
+					},
+				},
+			},
+			&mongo.ConfigMembers{
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Votes:    0,
+					Priority: 0,
+				},
+				mongo.ConfigMember{
+					Votes:    0,
+					Priority: 0,
+				},
+			},
+			false,
+		},
+		{
+			"6 members: 3 rs0 + 3 hidden",
+			&mongo.ConfigMembers{
+				mongo.ConfigMember{
+					Host:     "host0",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Host:     "host1",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Host:     "host2",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Host:     "host3",
+					Votes:    mongo.DefaultVotes,
+					Priority: 0,
+					Hidden:   true,
+					Tags: mongo.ReplsetTags{
+						naming.ComponentHidden: "true",
+					},
+				},
+				mongo.ConfigMember{
+					Host:     "host4",
+					Votes:    mongo.DefaultVotes,
+					Priority: 0,
+					Hidden:   true,
+					Tags: mongo.ReplsetTags{
+						naming.ComponentHidden: "true",
+					},
+				},
+				mongo.ConfigMember{
+					Host:     "host5",
+					Votes:    mongo.DefaultVotes,
+					Priority: 0,
+					Hidden:   true,
+					Tags: mongo.ReplsetTags{
+						naming.ComponentHidden: "true",
+					},
+				},
+			},
+			&mongo.ConfigMembers{
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: 0,
+				},
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: 0,
+				},
+				mongo.ConfigMember{
+					Votes:    0,
+					Priority: 0,
+				},
+			},
+			false,
+		},
+		{
+			"6 members: 3 rs0 + 1 non-voting + 1 hidden + 1 arbiter",
+			&mongo.ConfigMembers{
+				mongo.ConfigMember{
+					Host:     "host0",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Host:     "host1",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Host:     "host2",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Host:     "host3",
+					Votes:    0,
+					Priority: 0,
+					Tags: mongo.ReplsetTags{
+						naming.ComponentNonVoting: "true",
+					},
+				},
+				mongo.ConfigMember{
+					Host:     "host4",
+					Votes:    mongo.DefaultVotes,
+					Priority: 0,
+					Hidden:   true,
+					Tags: mongo.ReplsetTags{
+						naming.ComponentHidden: "true",
+					},
+				},
+				mongo.ConfigMember{
+					Host:        "host5",
+					Votes:       mongo.DefaultVotes,
+					Priority:    0,
+					ArbiterOnly: true,
+				},
+			},
+			&mongo.ConfigMembers{
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Votes:    0,
+					Priority: 0,
+				},
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: 0,
+				},
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: 0,
+				},
+			},
+			false,
+		},
+		{
+			"6 members: 3 rs0 + 3 external (all voters)",
+			&mongo.ConfigMembers{
+				mongo.ConfigMember{
+					Host:     "host0",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Host:     "host1",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Host:     "host2",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Host:     "host3",
+					Votes:    mongo.DefaultVotes,
+					Priority: 0,
+					Tags:     mongo.ReplsetTags{"external": "true"},
+				},
+				mongo.ConfigMember{
+					Host:     "host4",
+					Votes:    mongo.DefaultVotes,
+					Priority: 0,
+					Tags:     mongo.ReplsetTags{"external": "true"},
+				},
+				mongo.ConfigMember{
+					Host:     "host5",
+					Votes:    mongo.DefaultVotes,
+					Priority: 0,
+					Tags:     mongo.ReplsetTags{"external": "true"},
+				},
+			},
+			&mongo.ConfigMembers{
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Votes:    0,
+					Priority: 0,
+				},
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: 0,
+				},
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: 0,
+				},
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: 0,
+				},
+			},
+			false,
+		},
+		{
+			"6 members: 3 rs0 + 3 external (no voters)",
+			&mongo.ConfigMembers{
+				mongo.ConfigMember{
+					Host:     "host0",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Host:     "host1",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Host:     "host2",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Host:     "host3",
+					Votes:    0,
+					Priority: 0,
+					Tags:     mongo.ReplsetTags{"external": "true"},
+				},
+				mongo.ConfigMember{
+					Host:     "host4",
+					Votes:    0,
+					Priority: 0,
+					Tags:     mongo.ReplsetTags{"external": "true"},
+				},
+				mongo.ConfigMember{
+					Host:     "host5",
+					Votes:    0,
+					Priority: 0,
+					Tags:     mongo.ReplsetTags{"external": "true"},
+				},
+			},
+			&mongo.ConfigMembers{
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Votes:    0,
+					Priority: 0,
+				},
+				mongo.ConfigMember{
+					Votes:    0,
+					Priority: 0,
+				},
+				mongo.ConfigMember{
+					Votes:    0,
+					Priority: 0,
+				},
+			},
+			false,
+		},
+		{
+			"7 members",
+			&mongo.ConfigMembers{
+				mongo.ConfigMember{
+					Host:     "host0",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Host:     "host1",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Host:     "host2",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Host:     "host3",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Host:     "host4",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Host:     "host5",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Host:     "host6",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+			},
+			&mongo.ConfigMembers{
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+			},
+			false,
+		},
+		{
+			"8 members",
+			&mongo.ConfigMembers{
+				mongo.ConfigMember{
+					Host:     "host0",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Host:     "host1",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Host:     "host2",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Host:     "host3",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Host:     "host4",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Host:     "host5",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Host:     "host6",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Host:     "host7",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+			},
+			&mongo.ConfigMembers{
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Votes:    0,
+					Priority: 0,
+				},
+			},
+			false,
+		},
+		{
+			"8 members: 5 rs0 + 3 hidden",
+			&mongo.ConfigMembers{
+				mongo.ConfigMember{
+					Host:     "host0",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Host:     "host1",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Host:     "host2",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Host:     "host3",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Host:     "host4",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Host:     "host5",
+					Votes:    mongo.DefaultVotes,
+					Priority: 0,
+					Hidden:   true,
+					Tags: mongo.ReplsetTags{
+						naming.ComponentHidden: "true",
+					},
+				},
+				mongo.ConfigMember{
+					Host:     "host6",
+					Votes:    mongo.DefaultVotes,
+					Priority: 0,
+					Hidden:   true,
+					Tags: mongo.ReplsetTags{
+						naming.ComponentHidden: "true",
+					},
+				},
+				mongo.ConfigMember{
+					Host:     "host7",
+					Votes:    mongo.DefaultVotes,
+					Priority: 0,
+					Hidden:   true,
+					Tags: mongo.ReplsetTags{
+						naming.ComponentHidden: "true",
+					},
+				},
+			},
+			&mongo.ConfigMembers{
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: 0,
+				},
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: 0,
+				},
+				mongo.ConfigMember{
+					Votes:    0,
+					Priority: 0,
+				},
+			},
+			false,
+		},
+		{
+			"9 members",
 			&mongo.ConfigMembers{
 				mongo.ConfigMember{
 					Host:     "host0",
@@ -233,88 +1070,10 @@ func TestVoting(t *testing.T) {
 					Priority: 0,
 				},
 			},
+			false,
 		},
 		{
-			"8 mongos",
-			&mongo.ConfigMembers{
-				mongo.ConfigMember{
-					Host:     "host0",
-					Votes:    mongo.DefaultVotes,
-					Priority: mongo.DefaultPriority,
-				},
-				mongo.ConfigMember{
-					Host:     "host1",
-					Votes:    mongo.DefaultVotes,
-					Priority: mongo.DefaultPriority,
-				},
-				mongo.ConfigMember{
-					Host:     "host2",
-					Votes:    mongo.DefaultVotes,
-					Priority: mongo.DefaultPriority,
-				},
-				mongo.ConfigMember{
-					Host:     "host3",
-					Votes:    mongo.DefaultVotes,
-					Priority: mongo.DefaultPriority,
-				},
-				mongo.ConfigMember{
-					Host:     "host4",
-					Votes:    mongo.DefaultVotes,
-					Priority: mongo.DefaultPriority,
-				},
-				mongo.ConfigMember{
-					Host:     "host5",
-					Votes:    mongo.DefaultVotes,
-					Priority: mongo.DefaultPriority,
-				},
-				mongo.ConfigMember{
-					Host:     "host6",
-					Votes:    mongo.DefaultVotes,
-					Priority: mongo.DefaultPriority,
-				},
-				mongo.ConfigMember{
-					Host:     "host7",
-					Votes:    mongo.DefaultVotes,
-					Priority: mongo.DefaultPriority,
-				},
-			},
-			&mongo.ConfigMembers{
-				mongo.ConfigMember{
-					Votes:    mongo.DefaultVotes,
-					Priority: mongo.DefaultPriority,
-				},
-				mongo.ConfigMember{
-					Votes:    mongo.DefaultVotes,
-					Priority: mongo.DefaultPriority,
-				},
-				mongo.ConfigMember{
-					Votes:    mongo.DefaultVotes,
-					Priority: mongo.DefaultPriority,
-				},
-				mongo.ConfigMember{
-					Votes:    mongo.DefaultVotes,
-					Priority: mongo.DefaultPriority,
-				},
-				mongo.ConfigMember{
-					Votes:    mongo.DefaultVotes,
-					Priority: mongo.DefaultPriority,
-				},
-				mongo.ConfigMember{
-					Votes:    mongo.DefaultVotes,
-					Priority: mongo.DefaultPriority,
-				},
-				mongo.ConfigMember{
-					Votes:    mongo.DefaultVotes,
-					Priority: mongo.DefaultPriority,
-				},
-				mongo.ConfigMember{
-					Votes:    0,
-					Priority: 0,
-				},
-			},
-		},
-		{
-			"8 mongos + 1 arbiter",
+			"9 members: 8 rs0 + 1 arbiter",
 			&mongo.ConfigMembers{
 				mongo.ConfigMember{
 					Host:     "host0",
@@ -389,21 +1148,23 @@ func TestVoting(t *testing.T) {
 					Priority: mongo.DefaultPriority,
 				},
 				mongo.ConfigMember{
-					Votes:    mongo.DefaultVotes,
-					Priority: mongo.DefaultPriority,
+					Votes:    0,
+					Priority: 0,
 				},
 				mongo.ConfigMember{
 					Votes:    0,
 					Priority: 0,
 				},
 				mongo.ConfigMember{
-					Votes:    mongo.DefaultVotes,
-					Priority: 0,
+					Votes:       mongo.DefaultVotes,
+					Priority:    0,
+					ArbiterOnly: true,
 				},
 			},
+			false,
 		},
 		{
-			"3 mongos + 1 arbiter",
+			"10 members: 5 rs0 + 3 hidden + 2 non-voting",
 			&mongo.ConfigMembers{
 				mongo.ConfigMember{
 					Host:     "host0",
@@ -421,10 +1182,57 @@ func TestVoting(t *testing.T) {
 					Priority: mongo.DefaultPriority,
 				},
 				mongo.ConfigMember{
-					Host:        "host3",
-					Votes:       mongo.DefaultVotes,
-					Priority:    0,
-					ArbiterOnly: true,
+					Host:     "host3",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Host:     "host4",
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Host:     "host5",
+					Votes:    mongo.DefaultVotes,
+					Priority: 0,
+					Hidden:   true,
+					Tags: mongo.ReplsetTags{
+						naming.ComponentHidden: "true",
+					},
+				},
+				mongo.ConfigMember{
+					Host:     "host6",
+					Votes:    mongo.DefaultVotes,
+					Priority: 0,
+					Hidden:   true,
+					Tags: mongo.ReplsetTags{
+						naming.ComponentHidden: "true",
+					},
+				},
+				mongo.ConfigMember{
+					Host:     "host7",
+					Votes:    mongo.DefaultVotes,
+					Priority: 0,
+					Hidden:   true,
+					Tags: mongo.ReplsetTags{
+						naming.ComponentHidden: "true",
+					},
+				},
+				mongo.ConfigMember{
+					Host:     "host8",
+					Votes:    0,
+					Priority: 0,
+					Tags: mongo.ReplsetTags{
+						naming.ComponentNonVoting: "true",
+					},
+				},
+				mongo.ConfigMember{
+					Host:     "host9",
+					Votes:    0,
+					Priority: 0,
+					Tags: mongo.ReplsetTags{
+						naming.ComponentNonVoting: "true",
+					},
 				},
 			},
 			&mongo.ConfigMembers{
@@ -437,29 +1245,61 @@ func TestVoting(t *testing.T) {
 					Priority: mongo.DefaultPriority,
 				},
 				mongo.ConfigMember{
-					Votes:    0,
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
+					Priority: mongo.DefaultPriority,
+				},
+				mongo.ConfigMember{
+					Votes:    mongo.DefaultVotes,
 					Priority: 0,
 				},
 				mongo.ConfigMember{
 					Votes:    mongo.DefaultVotes,
 					Priority: 0,
 				},
+				mongo.ConfigMember{
+					Votes:    0,
+					Priority: 0,
+				},
+				mongo.ConfigMember{
+					Votes:    0,
+					Priority: 0,
+				},
+				mongo.ConfigMember{
+					Votes:    0,
+					Priority: 0,
+				},
 			},
+			false,
 		},
 	}
 
 	for _, c := range cases {
-		c.mset.SetVotes(*c.mset, false)
-		if len(*c.mset) != len(*c.desiered) {
-			t.Errorf("%s: missmatched members size", c.name)
-			continue
-		}
+		t.Run(c.name, func(t *testing.T) {
+			c.mset.SetVotes(*c.mset, c.unsafePSA)
+			require.Len(t, *c.mset, len(*c.desired))
 
-		for i, member := range *c.mset {
-			d := []mongo.ConfigMember(*c.desiered)
-			if member.Votes != d[i].Votes || member.Priority != d[i].Priority {
-				t.Errorf("%s: member (%s) want %v, have %v", c.name, member.Host, d[i], member)
+			votes := 0
+			for i, member := range *c.mset {
+				d := []mongo.ConfigMember(*c.desired)
+
+				votes += member.Votes
+
+				assert.Equalf(t, d[i].Votes, member.Votes, "member (%s) votes are wrong", member.Host)
+				assert.Equalf(t, d[i].Priority, member.Priority, "member (%s) priority is wrong", member.Host)
 			}
-		}
+
+			assert.Falsef(t, votes > mongo.MaxVotingMembers, "there should be max (%d) votes in replset", mongo.MaxVotingMembers)
+			if votes != 0 {
+				assert.Falsef(t, votes%2 == 0, "total votes (%d) should be an odd number", votes)
+			}
+		})
 	}
 }


### PR DESCRIPTION
[![K8SPSMDB-1480](https://badgen.net/badge/JIRA/K8SPSMDB-1480/green)](https://jira.percona.com/browse/K8SPSMDB-1480) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=percona&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

**CHANGE DESCRIPTION**
---

This PR improves our vote distribution algorithm to ensure operator adheres the max voting members limit.

There were multiple problems in the previous implementation. For example:
- When adding hidden members MaxVotingMembers rule was ignored.
- If MaxVotingMembers limit is exceeded when adding an arbiter, operator blindly removed votes from the last member without checking if that member had votes in the first place.
- If total votes end up as an even number, operator, again, blindly removed votes from the last member without checking if that member had votes in the first place.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?

[K8SPSMDB-1480]: https://perconadev.atlassian.net/browse/K8SPSMDB-1480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ