### PR TITLE
K8SPSMDB-1412: More PBM v2.10.0 fixes

### DIFF
--- a/config/crd/bases/psmdb.percona.com_perconaservermongodbs.yaml
+++ b/config/crd/bases/psmdb.percona.com_perconaservermongodbs.yaml
@@ -24826,9 +24826,9 @@ spec:
             type: object
           status:
             properties:
-              backup:
-                type: string
               backupConfigHash:
+                type: string
+              backupImage:
                 type: string
               backupVersion:
                 type: string

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -25621,9 +25621,9 @@ spec:
             type: object
           status:
             properties:
-              backup:
-                type: string
               backupConfigHash:
+                type: string
+              backupImage:
                 type: string
               backupVersion:
                 type: string

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -25621,9 +25621,9 @@ spec:
             type: object
           status:
             properties:
-              backup:
-                type: string
               backupConfigHash:
+                type: string
+              backupImage:
                 type: string
               backupVersion:
                 type: string

--- a/deploy/cw-bundle.yaml
+++ b/deploy/cw-bundle.yaml
@@ -25621,9 +25621,9 @@ spec:
             type: object
           status:
             properties:
-              backup:
-                type: string
               backupConfigHash:
+                type: string
+              backupImage:
                 type: string
               backupVersion:
                 type: string

--- a/e2e-tests/version-service/conf/crd.yaml
+++ b/e2e-tests/version-service/conf/crd.yaml
@@ -25621,9 +25621,9 @@ spec:
             type: object
           status:
             properties:
-              backup:
-                type: string
               backupConfigHash:
+                type: string
+              backupImage:
                 type: string
               backupVersion:
                 type: string

--- a/pkg/apis/psmdb/v1/psmdb_types.go
+++ b/pkg/apis/psmdb/v1/psmdb_types.go
@@ -321,8 +321,8 @@ type PerconaServerMongoDBStatus struct {
 	Replsets           map[string]ReplsetStatus `json:"replsets,omitempty"`
 	Mongos             *MongosStatus            `json:"mongos,omitempty"`
 	ObservedGeneration int64                    `json:"observedGeneration,omitempty"`
-	BackupStatus       AppState                 `json:"backup,omitempty"`
 	BackupVersion      string                   `json:"backupVersion,omitempty"`
+	BackupImage        string                   `json:"backupImage,omitempty"`
 	BackupConfigHash   string                   `json:"backupConfigHash,omitempty"`
 	PMMStatus          AppState                 `json:"pmmStatus,omitempty"`
 	PMMVersion         string                   `json:"pmmVersion,omitempty"`
@@ -1254,6 +1254,20 @@ func (cr *PerconaServerMongoDB) CompareMongoDBVersion(version string) (int, erro
 	}
 
 	return mongoVer.Compare(compare), nil
+}
+
+func (cr *PerconaServerMongoDB) ComparePBMAgentVersion(version string) (int, error) {
+	backupVer, err := v.NewVersion(cr.Status.BackupVersion)
+	if err != nil {
+		return 0, errors.Wrap(err, "parse status.backupVersion")
+	}
+
+	compare, err := v.NewVersion(version)
+	if err != nil {
+		return 0, errors.Wrap(err, "parse version")
+	}
+
+	return backupVer.Compare(compare), nil
 }
 
 const (

--- a/pkg/controller/perconaservermongodb/pbm.go
+++ b/pkg/controller/perconaservermongodb/pbm.go
@@ -40,6 +40,10 @@ func (r *ReconcilePerconaServerMongoDB) reconcilePBM(ctx context.Context, cr *ps
 		return errors.Wrap(err, "resync PBM if needed")
 	}
 
+	if err := r.reconcileBackupVersion(ctx, cr); err != nil {
+		return errors.Wrap(err, "reconcile backup version")
+	}
+
 	return nil
 }
 

--- a/pkg/controller/perconaservermongodb/psmdb_controller.go
+++ b/pkg/controller/perconaservermongodb/psmdb_controller.go
@@ -548,6 +548,7 @@ func (r *ReconcilePerconaServerMongoDB) reconcileReplsets(ctx context.Context, c
 			return "", errors.Wrapf(err, "reconcile replset %s", replset.Name)
 		}
 
+		// TODO: why do we do it for each replset??
 		if err := r.fetchVersionFromMongo(ctx, cr, replset); err != nil {
 			return "", errors.Wrap(err, "update mongo version")
 		}

--- a/pkg/controller/perconaservermongodb/smart.go
+++ b/pkg/controller/perconaservermongodb/smart.go
@@ -23,10 +23,15 @@ import (
 	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb/backup"
 )
 
-func (r *ReconcilePerconaServerMongoDB) smartUpdate(ctx context.Context, cr *api.PerconaServerMongoDB, sfs *appsv1.StatefulSet,
+func (r *ReconcilePerconaServerMongoDB) smartUpdate(
+	ctx context.Context,
+	cr *api.PerconaServerMongoDB,
+	sfs *appsv1.StatefulSet,
 	replset *api.ReplsetSpec,
 ) error {
-	log := logf.FromContext(ctx).WithName("SmartUpdate").WithValues("statefulset", sfs.Name, "replset", replset.Name)
+	log := logf.FromContext(ctx).
+		WithName("SmartUpdate").
+		WithValues("statefulset", sfs.Name, "replset", replset.Name)
 
 	if replset.Size == 0 {
 		return nil

--- a/pkg/controller/perconaservermongodbrestore/validate.go
+++ b/pkg/controller/perconaservermongodbrestore/validate.go
@@ -2,10 +2,12 @@ package perconaservermongodbrestore
 
 import (
 	"context"
+	"strings"
 
 	"github.com/pkg/errors"
 
 	"github.com/percona/percona-backup-mongodb/pbm/defs"
+	"github.com/percona/percona-backup-mongodb/pbm/storage/s3"
 
 	psmdbv1 "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
 	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb/backup"
@@ -43,6 +45,17 @@ func (r *ReconcilePerconaServerMongoDBRestore) validate(ctx context.Context, cr 
 	cfg, err := backup.GetPBMConfig(ctx, r.client, cluster, storage)
 	if err != nil {
 		return errors.Wrap(err, "get pbm config")
+	}
+
+	// we need to explicitly overwrite storage config for s3-compatible gcs
+	// because new GCS config only used by pbm-agent v2.10+
+	// but here we need to use the new config regardless of pbm-agent version
+	if storage.Type == psmdbv1.BackupStorageS3 && strings.Contains(storage.S3.EndpointURL, s3.GCSEndpointURL) {
+		storageConf, err := backup.GetPBMStorageS3CompatibleGCSConfig(ctx, r.client, cluster, storage)
+		if err != nil {
+			return errors.Wrap(err, "get s3-compatible gcs config")
+		}
+		cfg.Storage = storageConf
 	}
 
 	if err := pbmc.ValidateBackup(ctx, &cfg, bcp); err != nil {

--- a/pkg/controller/perconaservermongodbrestore/validate_test.go
+++ b/pkg/controller/perconaservermongodbrestore/validate_test.go
@@ -13,6 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/percona/percona-backup-mongodb/pbm/defs"
+	pbmVersion "github.com/percona/percona-backup-mongodb/pbm/version"
 
 	psmdbv1 "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
 	fakeBackup "github.com/percona/percona-server-mongodb-operator/pkg/psmdb/backup/fake"
@@ -49,6 +50,7 @@ func TestValidate(t *testing.T) {
 			},
 		},
 	}
+	cluster.Status.BackupVersion = pbmVersion.Current().Version
 	bcp := readDefaultBackup(t, backupName, ns)
 	bcp.Status.State = psmdbv1.BackupStateReady
 	bcp.Spec.ClusterName = clusterName
@@ -187,6 +189,7 @@ func TestValidatePiTR(t *testing.T) {
 			},
 		},
 	}
+	cluster.Status.BackupVersion = pbmVersion.Current().Version
 
 	tests := []struct {
 		name        string

--- a/pkg/k8s/utils.go
+++ b/pkg/k8s/utils.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"strings"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 const WatchNamespaceEnvVar = "WATCH_NAMESPACE"
@@ -25,4 +27,17 @@ func GetOperatorNamespace() (string, error) {
 	}
 
 	return strings.TrimSpace(string(nsBytes)), nil
+}
+
+func IsPodReady(pod corev1.Pod) bool {
+	if pod.Status.Phase != corev1.PodRunning || pod.DeletionTimestamp != nil {
+		return false
+	}
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == corev1.ContainersReady && cond.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+
+	return false
 }

--- a/pkg/psmdb/backup/pbm_test.go
+++ b/pkg/psmdb/backup/pbm_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/percona/percona-backup-mongodb/pbm/storage/fs"
 	"github.com/percona/percona-backup-mongodb/pbm/storage/gcs"
 	"github.com/percona/percona-backup-mongodb/pbm/storage/s3"
+	pbmVersion "github.com/percona/percona-backup-mongodb/pbm/version"
 
 	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
 	"github.com/percona/percona-server-mongodb-operator/pkg/version"
@@ -28,6 +29,7 @@ import (
 
 func TestApplyCustomPBMConfig(t *testing.T) {
 	cr := expectedCR(t)
+	cr.Status.BackupVersion = pbmVersion.Current().Version
 
 	storage := cr.Spec.Backup.Storages["test-s3-storage"]
 
@@ -117,6 +119,9 @@ func TestPBMStorageConfig(t *testing.T) {
 		},
 		Spec: api.PerconaServerMongoDBSpec{
 			CRVersion: version.Version(),
+		},
+		Status: api.PerconaServerMongoDBStatus{
+			BackupVersion: pbmVersion.Current().Version,
 		},
 	}
 


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
This PR fixes 3 problems:
1. Backups are failing with pbm-agent v2.10.0 and s3-compatible GCS configuration.
2. Restores are failing with PBM go module v2.11.0 with authorization errors in validation.
3. PBM fails to delete any GCS backups taken by PBM v2.10.0.

**Solution:**
1. New GCS config needs to be used for backups only if pbm-agent version is greater or equal to v2.10.0. For this operator needs to get the pbm-agent version from running container and decide how should it configure PBM and GCS.
2. During restore validation operator needs to use the new GCS config regardless of pbm-agent version.
3. GCS backups taken by PBM <2.10.0 needs to be handled separately and new GCS config needs to be used while deleting backup files, even if backup metadata contains s3-compatible configuration for GCS.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
