### PR TITLE
CLOUD-727: pin envtest version for unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ IMAGE ?= $(IMAGE_TAG_BASE):$(VERSION)
 DEPLOYDIR = ./deploy
 
 ENVTEST_K8S_VERSION = 1.31
+ENVTEST_VERSION ?= release-0.23
 
 all: build
 
@@ -94,7 +95,7 @@ kustomize: ## Download kustomize locally if necessary.
 
 ENVTEST = $(shell pwd)/bin/setup-envtest
 envtest: ## Download envtest-setup locally if necessary.
-	$(call go-get-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)
+	$(call go-get-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@$(ENVTEST_VERSION))
 
 SWAGGER = $(shell pwd)/bin/swagger
 swagger: ## Download swagger locally if necessary.


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
```
go fmt ./...
go vet ./...
go: downloading github.com/onsi/ginkgo/v2 v2.28.1
go: downloading github.com/onsi/gomega v1.39.1
go: downloading gotest.tools v2.2.0+incompatible
go: downloading github.com/Masterminds/semver/v3 v3.4.0
go: creating new go.mod: module tmp
Downloading sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
go: downloading sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20260331165415-bce0ec74ad73
go: downloading sigs.k8s.io/controller-runtime v0.23.3
go: sigs.k8s.io/controller-runtime/tools/setup-envtest@latest: sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20260331165415-bce0ec74ad73 requires go >= 1.26.0 (running go 1.25.8; GOTOOLCHAIN=local)
make: *** [Makefile:105: envtest] Error 1
Error: Process completed with exit code 2.
```

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
