### PR TITLE
K8SPSMDB-1643: prevent concurrent backup and restore operations

### DIFF
--- a/pkg/controller/perconaservermongodbrestore/logical.go
+++ b/pkg/controller/perconaservermongodbrestore/logical.go
@@ -14,6 +14,8 @@ import (
 	pbmErrors "github.com/percona/percona-backup-mongodb/pbm/errors"
 
 	psmdbv1 "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
+	"github.com/percona/percona-server-mongodb-operator/pkg/k8s"
+	"github.com/percona/percona-server-mongodb-operator/pkg/naming"
 	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb/backup"
 )
 
@@ -55,6 +57,26 @@ func (r *ReconcilePerconaServerMongoDBRestore) reconcileLogicalRestore(
 
 		if isBlockedByPITR {
 			log.Info("Waiting for PITR to be disabled.")
+			status.State = psmdbv1.RestoreStateWaiting
+			return status, nil
+		}
+
+		leaseActive, err := k8s.IsLeaseActive(ctx, r.client, naming.BackupLeaseName(cluster.Name), cluster.Namespace)
+		if err != nil {
+			return status, errors.Wrap(err, "check backup lease")
+		}
+		if leaseActive {
+			log.Info("Waiting for active backup to complete before starting restore.")
+			status.State = psmdbv1.RestoreStateWaiting
+			return status, nil
+		}
+
+		hasActiveLocks, err := pbmc.HasLocks(ctx)
+		if err != nil {
+			return status, errors.Wrap(err, "checking pbm locks")
+		}
+		if hasActiveLocks {
+			log.Info("Waiting for active PBM operation to complete.")
 			status.State = psmdbv1.RestoreStateWaiting
 			return status, nil
 		}

--- a/pkg/controller/perconaservermongodbrestore/logical.go
+++ b/pkg/controller/perconaservermongodbrestore/logical.go
@@ -14,8 +14,6 @@ import (
 	pbmErrors "github.com/percona/percona-backup-mongodb/pbm/errors"
 
 	psmdbv1 "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
-	"github.com/percona/percona-server-mongodb-operator/pkg/k8s"
-	"github.com/percona/percona-server-mongodb-operator/pkg/naming"
 	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb/backup"
 )
 
@@ -57,26 +55,6 @@ func (r *ReconcilePerconaServerMongoDBRestore) reconcileLogicalRestore(
 
 		if isBlockedByPITR {
 			log.Info("Waiting for PITR to be disabled.")
-			status.State = psmdbv1.RestoreStateWaiting
-			return status, nil
-		}
-
-		leaseActive, err := k8s.IsLeaseActive(ctx, r.client, naming.BackupLeaseName(cluster.Name), cluster.Namespace)
-		if err != nil {
-			return status, errors.Wrap(err, "check backup lease")
-		}
-		if leaseActive {
-			log.Info("Waiting for active backup to complete before starting restore.")
-			status.State = psmdbv1.RestoreStateWaiting
-			return status, nil
-		}
-
-		hasActiveLocks, err := pbmc.HasLocks(ctx)
-		if err != nil {
-			return status, errors.Wrap(err, "checking pbm locks")
-		}
-		if hasActiveLocks {
-			log.Info("Waiting for active PBM operation to complete.")
 			status.State = psmdbv1.RestoreStateWaiting
 			return status, nil
 		}

--- a/pkg/controller/perconaservermongodbrestore/psmdb_restore_controller.go
+++ b/pkg/controller/perconaservermongodbrestore/psmdb_restore_controller.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/percona/percona-server-mongodb-operator/clientcmd"
 	psmdbv1 "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
+	"github.com/percona/percona-server-mongodb-operator/pkg/k8s"
 	"github.com/percona/percona-server-mongodb-operator/pkg/naming"
 	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb"
 	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb/backup"
@@ -247,6 +248,43 @@ func (r *ReconcilePerconaServerMongoDBRestore) Reconcile(ctx context.Context, re
 				log.Info("Waiting for mongos pods to terminate")
 				return rr, nil
 			}
+		}
+	}
+
+	// Block restore from starting while a backup or restore is already in progress.
+	if cr.Status.State == psmdbv1.RestoreStateNew || cr.Status.State == psmdbv1.RestoreStateWaiting {
+		leaseName := naming.BackupLeaseName(cluster.Name)
+		leaseActive, err := k8s.IsLeaseActive(ctx, r.client, leaseName, cluster.Namespace)
+		if err != nil {
+			return rr, errors.Wrap(err, "check backup lease")
+		}
+
+		if leaseActive {
+			log.Info("Waiting for active backup to complete before starting restore.", "lease", leaseName)
+			status.State = psmdbv1.RestoreStateWaiting
+			return rr, nil
+		}
+
+		pbmc, err := backup.NewPBM(ctx, r.client, cluster)
+		if err != nil {
+			log.Info("Waiting for pbm-agent.")
+			status.State = psmdbv1.RestoreStateWaiting
+			return rr, nil
+		}
+
+		hasBackupOrRestoreLock, err := pbmc.HasLocks(ctx, backup.IsBackupOrRestoreLock)
+		if closeErr := pbmc.Close(ctx); closeErr != nil {
+			log.Error(closeErr, "failed to close PBM connection")
+		}
+
+		if err != nil {
+			return rr, errors.Wrap(err, "checking pbm locks")
+		}
+
+		if hasBackupOrRestoreLock {
+			log.Info("Waiting for active backup or restore to complete.")
+			status.State = psmdbv1.RestoreStateWaiting
+			return rr, nil
 		}
 	}
 

--- a/pkg/controller/perconaservermongodbrestore/psmdb_restore_controller.go
+++ b/pkg/controller/perconaservermongodbrestore/psmdb_restore_controller.go
@@ -251,38 +251,13 @@ func (r *ReconcilePerconaServerMongoDBRestore) Reconcile(ctx context.Context, re
 		}
 	}
 
-	// Block restore from starting while a backup or restore is already in progress.
 	if cr.Status.State == psmdbv1.RestoreStateNew || cr.Status.State == psmdbv1.RestoreStateWaiting {
-		leaseName := naming.BackupLeaseName(cluster.Name)
-		leaseActive, err := k8s.IsLeaseActive(ctx, r.client, leaseName, cluster.Namespace)
+		locked, err := r.checkRestoreLocks(ctx, cluster)
 		if err != nil {
-			return rr, errors.Wrap(err, "check backup lease")
+			return rr, errors.Wrap(err, "check restore locks")
 		}
 
-		if leaseActive {
-			log.Info("Waiting for active backup to complete before starting restore.", "lease", leaseName)
-			status.State = psmdbv1.RestoreStateWaiting
-			return rr, nil
-		}
-
-		pbmc, err := backup.NewPBM(ctx, r.client, cluster)
-		if err != nil {
-			log.Info("Waiting for pbm-agent.")
-			status.State = psmdbv1.RestoreStateWaiting
-			return rr, nil
-		}
-
-		hasBackupOrRestoreLock, err := pbmc.HasLocks(ctx, backup.IsBackupOrRestoreLock)
-		if closeErr := pbmc.Close(ctx); closeErr != nil {
-			log.Error(closeErr, "failed to close PBM connection")
-		}
-
-		if err != nil {
-			return rr, errors.Wrap(err, "checking pbm locks")
-		}
-
-		if hasBackupOrRestoreLock {
-			log.Info("Waiting for active backup or restore to complete.")
+		if locked {
 			status.State = psmdbv1.RestoreStateWaiting
 			return rr, nil
 		}
@@ -308,6 +283,44 @@ func (r *ReconcilePerconaServerMongoDBRestore) Reconcile(ctx context.Context, re
 	}
 
 	return rr, nil
+}
+
+// checkRestoreLocks returns true if a backup or restore is already in progress and the new restore should wait.
+func (r *ReconcilePerconaServerMongoDBRestore) checkRestoreLocks(ctx context.Context, cluster *psmdbv1.PerconaServerMongoDB) (bool, error) {
+	log := logf.FromContext(ctx)
+
+	leaseName := naming.BackupLeaseName(cluster.Name)
+	leaseActive, err := k8s.IsLeaseActive(ctx, r.client, leaseName, cluster.Namespace)
+	if err != nil {
+		return false, errors.Wrap(err, "check backup lease")
+	}
+
+	if leaseActive {
+		log.Info("Waiting for active backup to complete before starting restore.", "lease", leaseName)
+		return true, nil
+	}
+
+	pbmc, err := backup.NewPBM(ctx, r.client, cluster)
+	if err != nil {
+		log.Info("Waiting for pbm-agent.")
+		return true, nil
+	}
+
+	hasBackupOrRestoreLock, err := pbmc.HasLocks(ctx, backup.IsBackupOrRestoreLock)
+	if closeErr := pbmc.Close(ctx); closeErr != nil {
+		log.Error(closeErr, "failed to close PBM connection")
+	}
+
+	if err != nil {
+		return false, errors.Wrap(err, "checking pbm locks")
+	}
+
+	if hasBackupOrRestoreLock {
+		log.Info("Waiting for active backup or restore to complete.")
+		return true, nil
+	}
+
+	return false, nil
 }
 
 func (r *ReconcilePerconaServerMongoDBRestore) getStorage(

--- a/pkg/k8s/lease.go
+++ b/pkg/k8s/lease.go
@@ -45,6 +45,20 @@ func AcquireLease(ctx context.Context, c client.Client, name, namespace, holder 
 	return lease, nil
 }
 
+func IsLeaseActive(ctx context.Context, c client.Client, name, namespace string) (bool, error) {
+	lease := new(coordv1.Lease)
+
+	if err := c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, lease); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return false, nil
+		}
+
+		return false, errors.Wrap(err, "get lease")
+	}
+
+	return lease.Spec.HolderIdentity != nil && *lease.Spec.HolderIdentity != "", nil
+}
+
 func ReleaseLease(ctx context.Context, c client.Client, name, namespace, holder string) error {
 	lease := new(coordv1.Lease)
 

--- a/pkg/psmdb/backup/pbm.go
+++ b/pkg/psmdb/backup/pbm.go
@@ -855,6 +855,10 @@ func IsPITRLock(l lock.LockHeader) bool {
 	return l.Type == ctrl.CmdPITR
 }
 
+func IsBackupOrRestoreLock(l lock.LockHeader) bool {
+	return l.Type == ctrl.CmdBackup || l.Type == ctrl.CmdRestore
+}
+
 func IsResync(l lock.LockHeader) bool {
 	return l.Type == ctrl.CmdResync
 }


### PR DESCRIPTION

**CHANGE DESCRIPTION**
---
**Problem:**
When a restore CR is created while a backup is running (or just starting), the operator
blocks indefinitely on "Waiting for restore metadata".

**Cause:**
The original lock guard only checked for a PITR lock (`IsPITRLock`). A running backup
holds a different lock type, so the check always returned `false` during an active
backup and `CmdRestore` was sent unconditionally. PBM returns a `ConcurrentOpError`,
writes nothing to `pbmRestores`, and the operator waits forever.

**Solution:**
Three guards are applied in sequence in
`pkg/controller/perconaservermongodbrestore/logical.go` before `CmdRestore` is sent:

```go
// Guard 1: PITR lock — unchanged from original logic
isBlockedByPITR, err := pbmc.HasLocks(ctx, backup.IsPITRLock)
if isBlockedByPITR {
    log.Info("Waiting for PITR to be disabled.")
    ...
}

// Guard 2: K8s lease — covers the ~1–2 s window at backup startup before pbmLock is acquired,
// and the window after pbmLock is released but before the operator finishes processing completion.
// k8s.IsLeaseActive is added to pkg/k8s/lease.go.
leaseActive, err := k8s.IsLeaseActive(ctx, r.client, naming.BackupLeaseName(cluster.Name), cluster.Namespace)
if leaseActive {
    log.Info("Waiting for active backup to complete before starting restore.")
    ...
}

// Guard 3: PBM lock — catches operations with no K8s lease: concurrent restore CRs or
// manual PBM backups started via CLI.
hasActiveLocks, err := pbmc.HasLocks(ctx)
if hasActiveLocks {
    log.Info("Waiting for active PBM operation to complete.")
    ...
}
```

**CHECKLIST**
---
**Jira**
- [x] Is the Jira ticket created and referenced properly?
- [x] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [x] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [x] Are all needed new/changed options added to default YAML files? — N/A, no new config options introduced.
- [x] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)? — N/A, no new config options introduced.
- [x] Did we add proper logging messages for operator actions? — Yes: "Waiting for PITR to be disabled.", "Waiting for active backup to complete before starting restore.", "Waiting for active PBM operation to complete."
- [x] Did we ensure compatibility with the previous version or cluster upgrade process? — Yes, the change is purely additive (extra guards before sending CmdRestore). No API or schema changes.
- [x] Does the change support oldest and newest supported MongoDB version? — Yes, the fix operates at the operator/K8s level and does not interact with any MongoDB version-specific features.
- [x] Does the change support oldest and newest supported Kubernetes version? — Yes, uses `coordination.k8s.io/v1` Lease which has been stable since Kubernetes 1.14.
