### PR TITLE
Bump Kubernetes version to 1.33 on Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ void createCluster(String CLUSTER_SUFFIX) {
                     --preemptible \
                     --zone=${region} \
                     --machine-type='n1-standard-4' \
-                    --cluster-version='1.32' \
+                    --cluster-version='1.33' \
                     --num-nodes=3 \
                     --labels='delete-cluster-after-hours=6' \
                     --disk-size=30 \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -300,7 +300,7 @@ void prepareNode() {
         sudo tee /etc/yum.repos.d/google-cloud-sdk.repo << EOF
 [google-cloud-cli]
 name=Google Cloud CLI
-baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el7-x86_64
+baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el9-x86_64
 enabled=1
 gpgcheck=1
 repo_gpgcheck=0

--- a/e2e-tests/multi-cluster-service/run
+++ b/e2e-tests/multi-cluster-service/run
@@ -69,10 +69,36 @@ wait_service_export() {
 }
 
 desc "Register Kubernetes cluster"
-k8s_cluster_name=$(kubectl -n default run --quiet curl --rm --restart=Never -it --image=appropriate/curl -- -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/attributes/cluster-name)
-k8s_cluster_region=$(kubectl -n default run --quiet curl --rm --restart=Never -it --image=appropriate/curl -- -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/attributes/cluster-location)
+
+cat <<EOF | kubectl -n default apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: curl
+  namespace: default
+spec:
+  terminationGracePeriodSeconds: 1
+  containers:
+    - name: curl
+      image: appropriate/curl
+      imagePullPolicy: Always
+      command: ["sh"]
+      args:
+      - -c
+      - "sleep 100500"
+EOF
+
+kubectl -n default wait --for=condition=Ready pod/curl
+log "pod/curl is ready"
+
+k8s_cluster_name=$(kubectl exec -n default -it curl -- curl -s -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/attributes/cluster-name)
+k8s_cluster_region=$(kubectl exec -n default -it curl -- curl -s -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/attributes/cluster-location)
+log "gke-cluster=${k8s_cluster_region}/${k8s_cluster_name}"
 
 gcloud container hub memberships register ${k8s_cluster_name} --gke-cluster ${k8s_cluster_region}/${k8s_cluster_name} --enable-workload-identity
+log "GKE cluster ${k8s_cluster_region}/${k8s_cluster_name} is registered to the hub"
+
+kubectl -n default delete pod curl
 
 wait_mcs_api
 


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
1.32 is gone.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
