### PR TITLE
K8SPSMDB-1679 | arm64 support for logcollector container

### DIFF
--- a/build/logcollector/entrypoint.sh
+++ b/build/logcollector/entrypoint.sh
@@ -70,14 +70,12 @@ run_logrotate() {
 		done
 	fi
 
-
 	local logrotate_cmd="logrotate -s \"$logrotate_status_file\" \"$logrotate_conf_file\""
 	for additional_conf in "${logrotate_additional_conf_files[@]}"; do
 		logrotate_cmd="$logrotate_cmd \"$additional_conf\""
 	done
 
 	set -o xtrace
-
 	run_cron "$LOGROTATE_SCHEDULE" "$logrotate_cmd"
 }
 

--- a/build/logcollector/entrypoint.sh
+++ b/build/logcollector/entrypoint.sh
@@ -3,7 +3,7 @@ set -e
 
 export PATH="$PATH:/opt/fluent-bit/bin"
 
-LOGROTATE_SCHEDULE="${LOGROTATE_SCHEDULE:-0 0 0 * * *}"
+LOGROTATE_SCHEDULE="${LOGROTATE_SCHEDULE:-0 0 * * *}"
 
 run_cron() {
 	local schedule="$1"

--- a/build/logcollector/entrypoint.sh
+++ b/build/logcollector/entrypoint.sh
@@ -5,6 +5,18 @@ export PATH="$PATH:/opt/fluent-bit/bin"
 
 LOGROTATE_SCHEDULE="${LOGROTATE_SCHEDULE:-0 0 0 * * *}"
 
+run_cron() {
+	local schedule="$1"
+	local cmd="$2"
+
+	if [ -f /usr/bin/supercronic ]; then
+        printf '%s %s\n' "$schedule" "$cmd" > /tmp/crontab
+        exec supercronic /tmp/crontab
+    else
+        exec go-cron "$schedule" sh -c "$cmd"
+    fi
+}
+
 is_logrotate_config_invalid() {
 	local config_file="$1"
 	if [ -z "$config_file" ] || [ ! -f "$config_file" ]; then
@@ -25,6 +37,14 @@ run_logrotate() {
 	local logrotate_conf_file="/opt/percona/logcollector/logrotate/logrotate.conf"
 	local logrotate_additional_conf_files=()
 	local conf_d_dir="/opt/percona/logcollector/logrotate/conf.d"
+
+	# Ensure logrotate can run with current UID
+	if [[ $EUID != 1001 ]]; then
+		# logrotate requires UID in /etc/passwd
+		sed -e "s^x:1001:^x:$EUID:^" /etc/passwd >/tmp/passwd
+		cat /tmp/passwd >/etc/passwd
+		rm -rf /tmp/passwd
+	fi
 
 	# Check if mongodb.conf exists and validate it
 	if [ -f "$conf_d_dir/mongodb.conf" ]; then
@@ -49,13 +69,7 @@ run_logrotate() {
 			fi
 		done
 	fi
-	# Ensure logrotate can run with current UID
-	if [[ $EUID != 1001 ]]; then
-		# logrotate requires UID in /etc/passwd
-		sed -e "s^x:1001:^x:$EUID:^" /etc/passwd >/tmp/passwd
-		cat /tmp/passwd >/etc/passwd
-		rm -rf /tmp/passwd
-	fi
+
 
 	local logrotate_cmd="logrotate -s \"$logrotate_status_file\" \"$logrotate_conf_file\""
 	for additional_conf in "${logrotate_additional_conf_files[@]}"; do
@@ -63,7 +77,8 @@ run_logrotate() {
 	done
 
 	set -o xtrace
-	exec go-cron "$LOGROTATE_SCHEDULE" sh -c "$logrotate_cmd"
+
+	run_cron "$LOGROTATE_SCHEDULE" "$logrotate_cmd"
 }
 
 run_fluentbit() {

--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -956,4 +956,4 @@ spec:
 #        }
 #      extraConfig:
 #        name: logrotate-config
-#      schedule: "0 0 0 * * *"
+#      schedule: "0 0 * * *"


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
Cannot run logcollector on arm64 nodes

**Cause:**
The current cron dependency `go-cron` does not have an arm compatible build

**Solution:**
https://github.com/percona/percona-docker/pull/1318 already adds a new arm compatible cron executor in the logcollector image, this PR updates the `entrypoint` script to use it

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
