### PR TITLE
K8SPSMDB-1427 generate .pem files in sleep forever mode

### DIFF
--- a/build/ps-entry.sh
+++ b/build/ps-entry.sh
@@ -245,11 +245,26 @@ _dbPath() {
 	echo "$dbPath"
 }
 
+# generate_pem_files concatenates the TLS key and cert into the .pem files
+generate_pem_files() {
+	MONGO_SSL_DIR=${MONGO_SSL_DIR:-/etc/mongodb-ssl}
+	if [ -f "${MONGO_SSL_DIR}/tls.key" ] && [ -f "${MONGO_SSL_DIR}/tls.crt" ]; then
+		cat "${MONGO_SSL_DIR}/tls.key" "${MONGO_SSL_DIR}/tls.crt" >/tmp/tls.pem
+	fi
+	MONGO_SSL_INTERNAL_DIR=${MONGO_SSL_INTERNAL_DIR:-/etc/mongodb-ssl-internal}
+	if [ -f "${MONGO_SSL_INTERNAL_DIR}/tls.key" ] && [ -f "${MONGO_SSL_INTERNAL_DIR}/tls.crt" ]; then
+		cat "${MONGO_SSL_INTERNAL_DIR}/tls.key" "${MONGO_SSL_INTERNAL_DIR}/tls.crt" >/tmp/tls-internal.pem
+	fi
+}
+
 is_manual_recovery() {
 	recovery_file='/data/db/sleep-forever'
 	if [ -f "${recovery_file}" ]; then
 		echo "The $recovery_file file is detected, node is going to infinity loop"
 		echo "If you want to exit from infinity loop you need to remove $recovery_file file"
+		# Generate the .pem files so a user who execs into the container during
+		# sleep-forever mode can start mongod manually without recreating them.
+		generate_pem_files
 		while [ -f "${recovery_file}" ]; do
 			sleep 1
 		done
@@ -440,16 +455,17 @@ if [[ $originalArgOne == mongo* ]]; then
 		if [ -f "${MONGO_SSL_DIR}/ca.crt" ]; then
 			CA="${MONGO_SSL_DIR}/ca.crt"
 		fi
+
+		generate_pem_files
+
+		MONGO_SSL_INTERNAL_DIR=${MONGO_SSL_INTERNAL_DIR:-/etc/mongodb-ssl-internal}
 		if [ -f "${MONGO_SSL_DIR}/tls.key" ] && [ -f "${MONGO_SSL_DIR}/tls.crt" ]; then
-			cat "${MONGO_SSL_DIR}/tls.key" "${MONGO_SSL_DIR}/tls.crt" >/tmp/tls.pem
 			_mongod_hack_ensure_arg_val --sslPEMKeyFile /tmp/tls.pem "${mongodHackedArgs[@]}"
 			if [ -f "${CA}" ]; then
 				_mongod_hack_ensure_arg_val --sslCAFile "${CA}" "${mongodHackedArgs[@]}"
 			fi
 		fi
-		MONGO_SSL_INTERNAL_DIR=${MONGO_SSL_INTERNAL_DIR:-/etc/mongodb-ssl-internal}
 		if [ -f "${MONGO_SSL_INTERNAL_DIR}/tls.key" ] && [ -f "${MONGO_SSL_INTERNAL_DIR}/tls.crt" ]; then
-			cat "${MONGO_SSL_INTERNAL_DIR}/tls.key" "${MONGO_SSL_INTERNAL_DIR}/tls.crt" >/tmp/tls-internal.pem
 			_mongod_hack_ensure_arg_val --sslClusterFile /tmp/tls-internal.pem "${mongodHackedArgs[@]}"
 			if [ -f "${MONGO_SSL_INTERNAL_DIR}/ca.crt" ]; then
 				_mongod_hack_ensure_arg_val --sslClusterCAFile "${MONGO_SSL_INTERNAL_DIR}/ca.crt" "${mongodHackedArgs[@]}"


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
In sleep-forever mode, ps-entry.sh entered the wait loop before generating the TLS .pem files, so /tmp was empty and users had to recreate them by hand before starting mongod.

Move the .pem assembly into a generate_pem_files() helper and call it before the wait loop. Normal startup reuses the same helper — no behavior change.

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
