### PR TITLE
K8SPSMDB-1476 fix service LoadBalancer Finalizer error

### DIFF
--- a/pkg/util/apply.go
+++ b/pkg/util/apply.go
@@ -67,6 +67,7 @@ func Apply(ctx context.Context, cl client.Client, obj client.Object) (ApplyStatu
 		switch object := obj.(type) {
 		case *corev1.Service:
 			object.Spec.ClusterIP = oldObject.(*corev1.Service).Spec.ClusterIP
+			object.Finalizers = oldObject.GetFinalizers()
 		}
 
 		return ApplyStatusUpdated, cl.Update(ctx, obj)


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
When a MongoDB ReplicaSet is exposed via a LoadBalancer service on GKE, the cloud load balancer controller adds finalizers to the service after creation (service.kubernetes.io/load-balancer-cleanup, gke.networking.io/l4-ilb-v1). On every reconcile, the operator updates the service with an object built from the CR — which has no finalizers. Kubernetes strips them, GKE immediately re-adds them and fires UnexpectedlyRemovedFinalizer warning events.
 ```
kg events
LAST SEEN   TYPE      REASON                         OBJECT                          MESSAGE
83s         Normal    EnsuringLoadBalancer           service/my-cluster-name-rs0-0   Ensuring load balancer
86s         Warning   UnexpectedlyRemovedFinalizer   service/my-cluster-name-rs0-0   Finalizer gke.networking.io/l4-ilb-v1 was unexpectedly removed from the service.
86s         Warning   UnexpectedlyRemovedFinalizer   service/my-cluster-name-rs0-0   Finalizer service.kubernetes.io/load-balancer-cleanup was unexpectedly removed from the service.
78s         Normal    EnsuredLoadBalancer            service/my-cluster-name-rs0-0   Ensured load balancer
```

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
Preserve finalizers from the existing service before calling Update.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
