### PR TITLE
K8SPSMDB-1641: prioritize internal TLS certificates for healthcheck probes (#2310)

### DIFF
--- a/e2e-tests/arbiter/compare/statefulset_arbiter-clusterip-rs0-arbiter-oc.yml
+++ b/e2e-tests/arbiter/compare/statefulset_arbiter-clusterip-rs0-arbiter-oc.yml
@@ -90,9 +90,9 @@ spec:
             - --ssl
             - --sslInsecure
             - --sslCAFile
-            - /etc/mongodb-ssl/ca.crt
+            - /etc/mongodb-ssl-internal/ca.crt
             - --sslPEMKeyFile
-            - /tmp/tls.pem
+            - /tmp/tls-internal.pem
             - --startupDelaySeconds
             - "7200"
           failureThreshold: 4
@@ -116,9 +116,9 @@ spec:
               - --ssl
               - --sslInsecure
               - --sslCAFile
-              - /etc/mongodb-ssl/ca.crt
+              - /etc/mongodb-ssl-internal/ca.crt
               - --sslPEMKeyFile
-              - /tmp/tls.pem
+              - /tmp/tls-internal.pem
           failureThreshold: 8
           initialDelaySeconds: 10
           periodSeconds: 3

--- a/e2e-tests/arbiter/compare/statefulset_arbiter-clusterip-rs0-arbiter.yml
+++ b/e2e-tests/arbiter/compare/statefulset_arbiter-clusterip-rs0-arbiter.yml
@@ -110,9 +110,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/arbiter/compare/statefulset_arbiter-rs0-arbiter-oc.yml
+++ b/e2e-tests/arbiter/compare/statefulset_arbiter-rs0-arbiter-oc.yml
@@ -91,9 +91,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -117,9 +117,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/arbiter/compare/statefulset_arbiter-rs0-arbiter.yml
+++ b/e2e-tests/arbiter/compare/statefulset_arbiter-rs0-arbiter.yml
@@ -91,9 +91,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -117,9 +117,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/custom-tls/compare/statefulset_some-name-cfg-oc.yml
+++ b/e2e-tests/custom-tls/compare/statefulset_some-name-cfg-oc.yml
@@ -91,9 +91,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -117,9 +117,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/custom-tls/compare/statefulset_some-name-cfg-oc.yml
+++ b/e2e-tests/custom-tls/compare/statefulset_some-name-cfg-oc.yml
@@ -91,9 +91,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl-internal/ca.crt
+                - /etc/mongodb-ssl/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls-internal.pem
+                - /tmp/tls.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -117,9 +117,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl-internal/ca.crt
+                - /etc/mongodb-ssl/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls-internal.pem
+                - /tmp/tls.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/custom-tls/compare/statefulset_some-name-cfg.yml
+++ b/e2e-tests/custom-tls/compare/statefulset_some-name-cfg.yml
@@ -91,9 +91,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -117,9 +117,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/custom-tls/compare/statefulset_some-name-cfg.yml
+++ b/e2e-tests/custom-tls/compare/statefulset_some-name-cfg.yml
@@ -91,9 +91,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl-internal/ca.crt
+                - /etc/mongodb-ssl/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls-internal.pem
+                - /tmp/tls.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -117,9 +117,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl-internal/ca.crt
+                - /etc/mongodb-ssl/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls-internal.pem
+                - /tmp/tls.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/custom-tls/compare/statefulset_some-name-mongos-oc.yml
+++ b/e2e-tests/custom-tls/compare/statefulset_some-name-mongos-oc.yml
@@ -82,9 +82,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "10"
             failureThreshold: 4
@@ -108,9 +108,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 1

--- a/e2e-tests/custom-tls/compare/statefulset_some-name-mongos-oc.yml
+++ b/e2e-tests/custom-tls/compare/statefulset_some-name-mongos-oc.yml
@@ -82,9 +82,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl-internal/ca.crt
+                - /etc/mongodb-ssl/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls-internal.pem
+                - /tmp/tls.pem
                 - --startupDelaySeconds
                 - "10"
             failureThreshold: 4
@@ -108,9 +108,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl-internal/ca.crt
+                - /etc/mongodb-ssl/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls-internal.pem
+                - /tmp/tls.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 1

--- a/e2e-tests/custom-tls/compare/statefulset_some-name-mongos.yml
+++ b/e2e-tests/custom-tls/compare/statefulset_some-name-mongos.yml
@@ -82,9 +82,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "10"
             failureThreshold: 4
@@ -108,9 +108,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 1

--- a/e2e-tests/custom-tls/compare/statefulset_some-name-mongos.yml
+++ b/e2e-tests/custom-tls/compare/statefulset_some-name-mongos.yml
@@ -82,9 +82,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl-internal/ca.crt
+                - /etc/mongodb-ssl/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls-internal.pem
+                - /tmp/tls.pem
                 - --startupDelaySeconds
                 - "10"
             failureThreshold: 4
@@ -108,9 +108,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl-internal/ca.crt
+                - /etc/mongodb-ssl/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls-internal.pem
+                - /tmp/tls.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 1

--- a/e2e-tests/custom-tls/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/custom-tls/compare/statefulset_some-name-rs0-oc.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/custom-tls/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/custom-tls/compare/statefulset_some-name-rs0-oc.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl-internal/ca.crt
+                - /etc/mongodb-ssl/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls-internal.pem
+                - /tmp/tls.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl-internal/ca.crt
+                - /etc/mongodb-ssl/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls-internal.pem
+                - /tmp/tls.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/custom-tls/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/custom-tls/compare/statefulset_some-name-rs0.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/custom-tls/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/custom-tls/compare/statefulset_some-name-rs0.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl-internal/ca.crt
+                - /etc/mongodb-ssl/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls-internal.pem
+                - /tmp/tls.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl-internal/ca.crt
+                - /etc/mongodb-ssl/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls-internal.pem
+                - /tmp/tls.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/custom-users-roles-sharded/compare/statefulset_some-name-cfg-4-oc.yml
+++ b/e2e-tests/custom-users-roles-sharded/compare/statefulset_some-name-cfg-4-oc.yml
@@ -91,9 +91,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -117,9 +117,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/custom-users-roles-sharded/compare/statefulset_some-name-cfg-oc.yml
+++ b/e2e-tests/custom-users-roles-sharded/compare/statefulset_some-name-cfg-oc.yml
@@ -91,9 +91,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -117,9 +117,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/custom-users-roles-sharded/compare/statefulset_some-name-cfg.yml
+++ b/e2e-tests/custom-users-roles-sharded/compare/statefulset_some-name-cfg.yml
@@ -91,9 +91,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -117,9 +117,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/custom-users-roles-sharded/compare/statefulset_some-name-mongos-4-oc.yml
+++ b/e2e-tests/custom-users-roles-sharded/compare/statefulset_some-name-mongos-4-oc.yml
@@ -83,9 +83,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "10"
             failureThreshold: 4
@@ -109,9 +109,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 1

--- a/e2e-tests/custom-users-roles-sharded/compare/statefulset_some-name-mongos-oc.yml
+++ b/e2e-tests/custom-users-roles-sharded/compare/statefulset_some-name-mongos-oc.yml
@@ -83,9 +83,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "10"
             failureThreshold: 4
@@ -109,9 +109,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 1

--- a/e2e-tests/custom-users-roles-sharded/compare/statefulset_some-name-mongos.yml
+++ b/e2e-tests/custom-users-roles-sharded/compare/statefulset_some-name-mongos.yml
@@ -83,9 +83,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "10"
             failureThreshold: 4
@@ -109,9 +109,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 1

--- a/e2e-tests/custom-users-roles-sharded/compare/statefulset_some-name-rs0-4-oc.yml
+++ b/e2e-tests/custom-users-roles-sharded/compare/statefulset_some-name-rs0-4-oc.yml
@@ -81,9 +81,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -107,9 +107,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/custom-users-roles-sharded/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/custom-users-roles-sharded/compare/statefulset_some-name-rs0-oc.yml
@@ -81,9 +81,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -107,9 +107,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/custom-users-roles-sharded/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/custom-users-roles-sharded/compare/statefulset_some-name-rs0.yml
@@ -81,9 +81,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -107,9 +107,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/data-at-rest-encryption/compare/statefulset_some-name-cfg-oc.yml
+++ b/e2e-tests/data-at-rest-encryption/compare/statefulset_some-name-cfg-oc.yml
@@ -78,9 +78,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -104,9 +104,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/data-at-rest-encryption/compare/statefulset_some-name-cfg.yml
+++ b/e2e-tests/data-at-rest-encryption/compare/statefulset_some-name-cfg.yml
@@ -78,9 +78,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -104,9 +104,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/data-at-rest-encryption/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/data-at-rest-encryption/compare/statefulset_some-name-rs0-oc.yml
@@ -79,9 +79,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -105,9 +105,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/data-at-rest-encryption/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/data-at-rest-encryption/compare/statefulset_some-name-rs0.yml
@@ -79,9 +79,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -105,9 +105,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/default-cr/compare/statefulset_minimal-cluster-cfg-oc.yml
+++ b/e2e-tests/default-cr/compare/statefulset_minimal-cluster-cfg-oc.yml
@@ -91,9 +91,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -117,9 +117,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/default-cr/compare/statefulset_minimal-cluster-cfg.yml
+++ b/e2e-tests/default-cr/compare/statefulset_minimal-cluster-cfg.yml
@@ -91,9 +91,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -117,9 +117,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/default-cr/compare/statefulset_minimal-cluster-rs0-oc.yml
+++ b/e2e-tests/default-cr/compare/statefulset_minimal-cluster-rs0-oc.yml
@@ -91,9 +91,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -117,9 +117,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/default-cr/compare/statefulset_minimal-cluster-rs0.yml
+++ b/e2e-tests/default-cr/compare/statefulset_minimal-cluster-rs0.yml
@@ -91,9 +91,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -117,9 +117,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/default-cr/compare/statefulset_my-cluster-name-cfg-oc.yml
+++ b/e2e-tests/default-cr/compare/statefulset_my-cluster-name-cfg-oc.yml
@@ -82,9 +82,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -108,9 +108,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/default-cr/compare/statefulset_my-cluster-name-cfg.yml
+++ b/e2e-tests/default-cr/compare/statefulset_my-cluster-name-cfg.yml
@@ -82,9 +82,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -108,9 +108,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/default-cr/compare/statefulset_my-cluster-name-rs0-oc.yml
+++ b/e2e-tests/default-cr/compare/statefulset_my-cluster-name-rs0-oc.yml
@@ -82,9 +82,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -108,9 +108,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/default-cr/compare/statefulset_my-cluster-name-rs0.yml
+++ b/e2e-tests/default-cr/compare/statefulset_my-cluster-name-rs0.yml
@@ -82,9 +82,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -108,9 +108,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-eks-credentials-irsa/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/demand-backup-eks-credentials-irsa/compare/statefulset_some-name-rs0.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-eks-credentials/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/demand-backup-eks-credentials/compare/statefulset_some-name-rs0.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-fs/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/demand-backup-fs/compare/statefulset_some-name-rs0.yml
@@ -91,9 +91,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -117,9 +117,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-incremental-aws/compare/statefulset_some-name-rs0_restore-oc.yml
+++ b/e2e-tests/demand-backup-incremental-aws/compare/statefulset_some-name-rs0_restore-oc.yml
@@ -108,9 +108,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -134,9 +134,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-incremental-aws/compare/statefulset_some-name-rs0_restore.yml
+++ b/e2e-tests/demand-backup-incremental-aws/compare/statefulset_some-name-rs0_restore.yml
@@ -108,9 +108,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -134,9 +134,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-incremental-azure/compare/statefulset_some-name-rs0_restore-oc.yml
+++ b/e2e-tests/demand-backup-incremental-azure/compare/statefulset_some-name-rs0_restore-oc.yml
@@ -108,9 +108,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -134,9 +134,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-incremental-azure/compare/statefulset_some-name-rs0_restore.yml
+++ b/e2e-tests/demand-backup-incremental-azure/compare/statefulset_some-name-rs0_restore.yml
@@ -108,9 +108,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -134,9 +134,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-incremental-gcp-native/compare/statefulset_some-name-rs0_restore-oc.yml
+++ b/e2e-tests/demand-backup-incremental-gcp-native/compare/statefulset_some-name-rs0_restore-oc.yml
@@ -108,9 +108,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -134,9 +134,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-incremental-gcp-native/compare/statefulset_some-name-rs0_restore.yml
+++ b/e2e-tests/demand-backup-incremental-gcp-native/compare/statefulset_some-name-rs0_restore.yml
@@ -108,9 +108,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -134,9 +134,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-incremental-gcp-s3/compare/statefulset_some-name-rs0_restore-oc.yml
+++ b/e2e-tests/demand-backup-incremental-gcp-s3/compare/statefulset_some-name-rs0_restore-oc.yml
@@ -108,9 +108,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -134,9 +134,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-incremental-gcp-s3/compare/statefulset_some-name-rs0_restore.yml
+++ b/e2e-tests/demand-backup-incremental-gcp-s3/compare/statefulset_some-name-rs0_restore.yml
@@ -108,9 +108,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -134,9 +134,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-incremental-minio/compare/statefulset_some-name-rs0_restore-arbiter-nv-oc.yml
+++ b/e2e-tests/demand-backup-incremental-minio/compare/statefulset_some-name-rs0_restore-arbiter-nv-oc.yml
@@ -108,9 +108,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -134,9 +134,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-incremental-minio/compare/statefulset_some-name-rs0_restore-arbiter-nv.yml
+++ b/e2e-tests/demand-backup-incremental-minio/compare/statefulset_some-name-rs0_restore-arbiter-nv.yml
@@ -108,9 +108,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -134,9 +134,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-incremental-minio/compare/statefulset_some-name-rs0_restore-oc.yml
+++ b/e2e-tests/demand-backup-incremental-minio/compare/statefulset_some-name-rs0_restore-oc.yml
@@ -108,9 +108,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -134,9 +134,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-incremental-minio/compare/statefulset_some-name-rs0_restore.yml
+++ b/e2e-tests/demand-backup-incremental-minio/compare/statefulset_some-name-rs0_restore.yml
@@ -108,9 +108,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -134,9 +134,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-incremental-sharded-aws/compare/statefulset_some-name-rs0_restore_sharded-oc.yml
+++ b/e2e-tests/demand-backup-incremental-sharded-aws/compare/statefulset_some-name-rs0_restore_sharded-oc.yml
@@ -109,9 +109,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -135,9 +135,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-incremental-sharded-aws/compare/statefulset_some-name-rs0_restore_sharded.yml
+++ b/e2e-tests/demand-backup-incremental-sharded-aws/compare/statefulset_some-name-rs0_restore_sharded.yml
@@ -109,9 +109,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -135,9 +135,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-incremental-sharded-azure/compare/statefulset_some-name-rs0_restore_sharded-oc.yml
+++ b/e2e-tests/demand-backup-incremental-sharded-azure/compare/statefulset_some-name-rs0_restore_sharded-oc.yml
@@ -109,9 +109,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -135,9 +135,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-incremental-sharded-azure/compare/statefulset_some-name-rs0_restore_sharded.yml
+++ b/e2e-tests/demand-backup-incremental-sharded-azure/compare/statefulset_some-name-rs0_restore_sharded.yml
@@ -109,9 +109,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -135,9 +135,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-incremental-sharded-gcp-native/compare/statefulset_some-name-rs0_restore_sharded-oc.yml
+++ b/e2e-tests/demand-backup-incremental-sharded-gcp-native/compare/statefulset_some-name-rs0_restore_sharded-oc.yml
@@ -109,9 +109,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -135,9 +135,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-incremental-sharded-gcp-native/compare/statefulset_some-name-rs0_restore_sharded.yml
+++ b/e2e-tests/demand-backup-incremental-sharded-gcp-native/compare/statefulset_some-name-rs0_restore_sharded.yml
@@ -109,9 +109,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -135,9 +135,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-incremental-sharded-gcp-s3/compare/statefulset_some-name-rs0_restore_sharded-oc.yml
+++ b/e2e-tests/demand-backup-incremental-sharded-gcp-s3/compare/statefulset_some-name-rs0_restore_sharded-oc.yml
@@ -109,9 +109,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -135,9 +135,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-incremental-sharded-gcp-s3/compare/statefulset_some-name-rs0_restore_sharded.yml
+++ b/e2e-tests/demand-backup-incremental-sharded-gcp-s3/compare/statefulset_some-name-rs0_restore_sharded.yml
@@ -109,9 +109,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -135,9 +135,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-incremental-sharded-minio/compare/statefulset_some-name-rs0_restore_sharded-oc.yml
+++ b/e2e-tests/demand-backup-incremental-sharded-minio/compare/statefulset_some-name-rs0_restore_sharded-oc.yml
@@ -109,9 +109,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -135,9 +135,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-incremental-sharded-minio/compare/statefulset_some-name-rs0_restore_sharded.yml
+++ b/e2e-tests/demand-backup-incremental-sharded-minio/compare/statefulset_some-name-rs0_restore_sharded.yml
@@ -109,9 +109,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -135,9 +135,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-logical-minio-native-tls/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/demand-backup-logical-minio-native-tls/compare/statefulset_some-name-rs0-oc.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-logical-minio-native-tls/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/demand-backup-logical-minio-native-tls/compare/statefulset_some-name-rs0.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-physical-aws/compare/statefulset_some-name-rs0_restore-oc.yml
+++ b/e2e-tests/demand-backup-physical-aws/compare/statefulset_some-name-rs0_restore-oc.yml
@@ -108,9 +108,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -134,9 +134,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-physical-aws/compare/statefulset_some-name-rs0_restore.yml
+++ b/e2e-tests/demand-backup-physical-aws/compare/statefulset_some-name-rs0_restore.yml
@@ -108,9 +108,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -134,9 +134,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-physical-azure/compare/statefulset_some-name-rs0_restore-oc.yml
+++ b/e2e-tests/demand-backup-physical-azure/compare/statefulset_some-name-rs0_restore-oc.yml
@@ -108,9 +108,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -134,9 +134,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-physical-azure/compare/statefulset_some-name-rs0_restore.yml
+++ b/e2e-tests/demand-backup-physical-azure/compare/statefulset_some-name-rs0_restore.yml
@@ -108,9 +108,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -134,9 +134,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-physical-gcp-native/compare/statefulset_some-name-rs0_restore-oc.yml
+++ b/e2e-tests/demand-backup-physical-gcp-native/compare/statefulset_some-name-rs0_restore-oc.yml
@@ -108,9 +108,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -134,9 +134,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-physical-gcp-native/compare/statefulset_some-name-rs0_restore.yml
+++ b/e2e-tests/demand-backup-physical-gcp-native/compare/statefulset_some-name-rs0_restore.yml
@@ -108,9 +108,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -134,9 +134,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-physical-gcp-s3/compare/statefulset_some-name-rs0_restore-oc.yml
+++ b/e2e-tests/demand-backup-physical-gcp-s3/compare/statefulset_some-name-rs0_restore-oc.yml
@@ -108,9 +108,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -134,9 +134,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-physical-gcp-s3/compare/statefulset_some-name-rs0_restore.yml
+++ b/e2e-tests/demand-backup-physical-gcp-s3/compare/statefulset_some-name-rs0_restore.yml
@@ -108,9 +108,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -134,9 +134,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-physical-minio-native-tls/compare/statefulset_some-name-rs0_restore-oc.yml
+++ b/e2e-tests/demand-backup-physical-minio-native-tls/compare/statefulset_some-name-rs0_restore-oc.yml
@@ -110,9 +110,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -136,9 +136,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-physical-minio-native-tls/compare/statefulset_some-name-rs0_restore.yml
+++ b/e2e-tests/demand-backup-physical-minio-native-tls/compare/statefulset_some-name-rs0_restore.yml
@@ -110,9 +110,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -136,9 +136,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-physical-minio-native/compare/statefulset_some-name-rs0_restore-arbiter-nv-oc.yml
+++ b/e2e-tests/demand-backup-physical-minio-native/compare/statefulset_some-name-rs0_restore-arbiter-nv-oc.yml
@@ -108,9 +108,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -134,9 +134,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-physical-minio-native/compare/statefulset_some-name-rs0_restore-arbiter-nv.yml
+++ b/e2e-tests/demand-backup-physical-minio-native/compare/statefulset_some-name-rs0_restore-arbiter-nv.yml
@@ -108,9 +108,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -134,9 +134,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-physical-minio-native/compare/statefulset_some-name-rs0_restore-oc.yml
+++ b/e2e-tests/demand-backup-physical-minio-native/compare/statefulset_some-name-rs0_restore-oc.yml
@@ -108,9 +108,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -134,9 +134,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-physical-minio-native/compare/statefulset_some-name-rs0_restore.yml
+++ b/e2e-tests/demand-backup-physical-minio-native/compare/statefulset_some-name-rs0_restore.yml
@@ -108,9 +108,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -134,9 +134,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-physical-minio/compare/statefulset_some-name-rs0_restore-arbiter-nv-oc.yml
+++ b/e2e-tests/demand-backup-physical-minio/compare/statefulset_some-name-rs0_restore-arbiter-nv-oc.yml
@@ -108,9 +108,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -134,9 +134,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-physical-minio/compare/statefulset_some-name-rs0_restore-arbiter-nv.yml
+++ b/e2e-tests/demand-backup-physical-minio/compare/statefulset_some-name-rs0_restore-arbiter-nv.yml
@@ -108,9 +108,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -134,9 +134,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-physical-minio/compare/statefulset_some-name-rs0_restore-oc.yml
+++ b/e2e-tests/demand-backup-physical-minio/compare/statefulset_some-name-rs0_restore-oc.yml
@@ -108,9 +108,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -134,9 +134,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-physical-minio/compare/statefulset_some-name-rs0_restore.yml
+++ b/e2e-tests/demand-backup-physical-minio/compare/statefulset_some-name-rs0_restore.yml
@@ -108,9 +108,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -134,9 +134,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-physical-sharded-aws/compare/statefulset_some-name-rs0_restore_sharded-oc.yml
+++ b/e2e-tests/demand-backup-physical-sharded-aws/compare/statefulset_some-name-rs0_restore_sharded-oc.yml
@@ -109,9 +109,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -135,9 +135,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-physical-sharded-aws/compare/statefulset_some-name-rs0_restore_sharded.yml
+++ b/e2e-tests/demand-backup-physical-sharded-aws/compare/statefulset_some-name-rs0_restore_sharded.yml
@@ -109,9 +109,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -135,9 +135,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-physical-sharded-azure/compare/statefulset_some-name-rs0_restore_sharded-oc.yml
+++ b/e2e-tests/demand-backup-physical-sharded-azure/compare/statefulset_some-name-rs0_restore_sharded-oc.yml
@@ -109,9 +109,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -135,9 +135,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-physical-sharded-azure/compare/statefulset_some-name-rs0_restore_sharded.yml
+++ b/e2e-tests/demand-backup-physical-sharded-azure/compare/statefulset_some-name-rs0_restore_sharded.yml
@@ -109,9 +109,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -135,9 +135,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-physical-sharded-gcp-native/compare/statefulset_some-name-rs0_restore_sharded-oc.yml
+++ b/e2e-tests/demand-backup-physical-sharded-gcp-native/compare/statefulset_some-name-rs0_restore_sharded-oc.yml
@@ -109,9 +109,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -135,9 +135,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-physical-sharded-gcp-native/compare/statefulset_some-name-rs0_restore_sharded.yml
+++ b/e2e-tests/demand-backup-physical-sharded-gcp-native/compare/statefulset_some-name-rs0_restore_sharded.yml
@@ -109,9 +109,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -135,9 +135,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-physical-sharded-minio-native/compare/statefulset_some-name-rs0_restore_sharded-oc.yml
+++ b/e2e-tests/demand-backup-physical-sharded-minio-native/compare/statefulset_some-name-rs0_restore_sharded-oc.yml
@@ -109,9 +109,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -135,9 +135,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-physical-sharded-minio-native/compare/statefulset_some-name-rs0_restore_sharded.yml
+++ b/e2e-tests/demand-backup-physical-sharded-minio-native/compare/statefulset_some-name-rs0_restore_sharded.yml
@@ -109,9 +109,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -135,9 +135,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-physical-sharded-minio/compare/statefulset_some-name-rs0_restore_sharded-oc.yml
+++ b/e2e-tests/demand-backup-physical-sharded-minio/compare/statefulset_some-name-rs0_restore_sharded-oc.yml
@@ -109,9 +109,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -135,9 +135,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-physical-sharded-minio/compare/statefulset_some-name-rs0_restore_sharded.yml
+++ b/e2e-tests/demand-backup-physical-sharded-minio/compare/statefulset_some-name-rs0_restore_sharded.yml
@@ -109,9 +109,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -135,9 +135,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-physical-sharded-parallel/compare/statefulset_some-name-rs0_restore_sharded-oc.yml
+++ b/e2e-tests/demand-backup-physical-sharded-parallel/compare/statefulset_some-name-rs0_restore_sharded-oc.yml
@@ -105,9 +105,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -131,9 +131,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-physical-sharded-parallel/compare/statefulset_some-name-rs0_restore_sharded.yml
+++ b/e2e-tests/demand-backup-physical-sharded-parallel/compare/statefulset_some-name-rs0_restore_sharded.yml
@@ -109,9 +109,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -135,9 +135,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-cfg-4-oc.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-cfg-4-oc.yml
@@ -92,9 +92,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -118,9 +118,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-cfg-oc.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-cfg-oc.yml
@@ -92,9 +92,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -118,9 +118,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-cfg.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-cfg.yml
@@ -92,9 +92,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -118,9 +118,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-mongos-4-oc.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-mongos-4-oc.yml
@@ -83,9 +83,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "10"
             failureThreshold: 4
@@ -109,9 +109,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 1

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-mongos-oc.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-mongos-oc.yml
@@ -83,9 +83,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "10"
             failureThreshold: 4
@@ -109,9 +109,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 1

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-mongos-secret-oc.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-mongos-secret-oc.yml
@@ -83,9 +83,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "10"
             failureThreshold: 4
@@ -109,9 +109,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 1

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-mongos-secret.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-mongos-secret.yml
@@ -83,9 +83,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "10"
             failureThreshold: 4
@@ -109,9 +109,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 1

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-mongos.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-mongos.yml
@@ -83,9 +83,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "10"
             failureThreshold: 4
@@ -109,9 +109,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 1

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs0-4-oc.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs0-4-oc.yml
@@ -81,9 +81,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -107,9 +107,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs0-oc.yml
@@ -81,9 +81,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -107,9 +107,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs0.yml
@@ -81,9 +81,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -107,9 +107,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs1-oc.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs1-oc.yml
@@ -81,9 +81,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -107,9 +107,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs1.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs1.yml
@@ -81,9 +81,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -107,9 +107,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs2-oc.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs2-oc.yml
@@ -81,9 +81,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -107,9 +107,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs2.yml
+++ b/e2e-tests/demand-backup-sharded/compare/statefulset_some-name-rs2.yml
@@ -81,9 +81,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -107,9 +107,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/demand-backup/compare/statefulset_some-name-rs0-oc.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/demand-backup/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/demand-backup/compare/statefulset_some-name-rs0.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/expose-sharded/compare/statefulset_some-name-cfg-4-oc.yml
+++ b/e2e-tests/expose-sharded/compare/statefulset_some-name-cfg-4-oc.yml
@@ -91,9 +91,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -117,9 +117,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/expose-sharded/compare/statefulset_some-name-cfg-oc.yml
+++ b/e2e-tests/expose-sharded/compare/statefulset_some-name-cfg-oc.yml
@@ -91,9 +91,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -117,9 +117,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/expose-sharded/compare/statefulset_some-name-cfg.yml
+++ b/e2e-tests/expose-sharded/compare/statefulset_some-name-cfg.yml
@@ -91,9 +91,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -117,9 +117,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/expose-sharded/compare/statefulset_some-name-mongos-4-oc.yml
+++ b/e2e-tests/expose-sharded/compare/statefulset_some-name-mongos-4-oc.yml
@@ -83,9 +83,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "10"
             failureThreshold: 4
@@ -109,9 +109,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 1

--- a/e2e-tests/expose-sharded/compare/statefulset_some-name-mongos-oc.yml
+++ b/e2e-tests/expose-sharded/compare/statefulset_some-name-mongos-oc.yml
@@ -83,9 +83,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "10"
             failureThreshold: 4
@@ -109,9 +109,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 1

--- a/e2e-tests/expose-sharded/compare/statefulset_some-name-mongos.yml
+++ b/e2e-tests/expose-sharded/compare/statefulset_some-name-mongos.yml
@@ -83,9 +83,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "10"
             failureThreshold: 4
@@ -109,9 +109,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 1

--- a/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0-4-oc.yml
+++ b/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0-4-oc.yml
@@ -81,9 +81,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -107,9 +107,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0-oc.yml
@@ -81,9 +81,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -107,9 +107,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0-sharding-disabled-oc.yml
+++ b/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0-sharding-disabled-oc.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0-sharding-disabled.yml
+++ b/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0-sharding-disabled.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0-sharding-enabled-oc.yml
+++ b/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0-sharding-enabled-oc.yml
@@ -81,9 +81,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -107,9 +107,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0-sharding-enabled.yml
+++ b/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0-sharding-enabled.yml
@@ -81,9 +81,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -107,9 +107,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/expose-sharded/compare/statefulset_some-name-rs0.yml
@@ -81,9 +81,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -107,9 +107,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/init-deploy/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/init-deploy/compare/statefulset_some-name-rs0-oc.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/init-deploy/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/init-deploy/compare/statefulset_some-name-rs0.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/limits/compare/statefulset_no-limits-rs0-increased-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-rs0-increased-oc.yml
@@ -91,9 +91,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -117,9 +117,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/limits/compare/statefulset_no-limits-rs0-increased.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-rs0-increased.yml
@@ -91,9 +91,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -117,9 +117,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/limits/compare/statefulset_no-limits-rs0-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-rs0-oc.yml
@@ -91,9 +91,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -117,9 +117,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/limits/compare/statefulset_no-limits-rs0.yml
+++ b/e2e-tests/limits/compare/statefulset_no-limits-rs0.yml
@@ -91,9 +91,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -117,9 +117,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/limits/compare/statefulset_no-requests-no-limits-rs0-increased-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-no-limits-rs0-increased-oc.yml
@@ -91,9 +91,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -117,9 +117,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/limits/compare/statefulset_no-requests-no-limits-rs0-increased.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-no-limits-rs0-increased.yml
@@ -91,9 +91,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -117,9 +117,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/limits/compare/statefulset_no-requests-no-limits-rs0-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-no-limits-rs0-oc.yml
@@ -91,9 +91,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -117,9 +117,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/limits/compare/statefulset_no-requests-no-limits-rs0.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-no-limits-rs0.yml
@@ -91,9 +91,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -117,9 +117,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/limits/compare/statefulset_no-requests-rs0-increased-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-rs0-increased-oc.yml
@@ -92,9 +92,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -118,9 +118,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/limits/compare/statefulset_no-requests-rs0-increased.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-rs0-increased.yml
@@ -92,9 +92,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -118,9 +118,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/limits/compare/statefulset_no-requests-rs0-oc.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-rs0-oc.yml
@@ -92,9 +92,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -118,9 +118,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/limits/compare/statefulset_no-requests-rs0.yml
+++ b/e2e-tests/limits/compare/statefulset_no-requests-rs0.yml
@@ -92,9 +92,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -118,9 +118,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/liveness/compare/statefulset_liveness-rs0-changed-oc.yml
+++ b/e2e-tests/liveness/compare/statefulset_liveness-rs0-changed-oc.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7202"
             failureThreshold: 6

--- a/e2e-tests/liveness/compare/statefulset_liveness-rs0-changed.yml
+++ b/e2e-tests/liveness/compare/statefulset_liveness-rs0-changed.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7202"
             failureThreshold: 6

--- a/e2e-tests/liveness/compare/statefulset_liveness-rs0-oc.yml
+++ b/e2e-tests/liveness/compare/statefulset_liveness-rs0-oc.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7201"
             failureThreshold: 5

--- a/e2e-tests/liveness/compare/statefulset_liveness-rs0.yml
+++ b/e2e-tests/liveness/compare/statefulset_liveness-rs0.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7201"
             failureThreshold: 5

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-cfg-oc.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-cfg-oc.yml
@@ -92,9 +92,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -118,9 +118,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-cfg.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-cfg.yml
@@ -92,9 +92,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -118,9 +118,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-mongos-oc.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-mongos-oc.yml
@@ -83,9 +83,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "10"
             failureThreshold: 4
@@ -109,9 +109,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 1

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-mongos.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-mongos.yml
@@ -83,9 +83,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "10"
             failureThreshold: 4
@@ -109,9 +109,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 1

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0-no-pmm-oc.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0-no-pmm-oc.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0-no-pmm.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0-no-pmm.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0-oc.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0-oc.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0.yml
+++ b/e2e-tests/monitoring-2-0/compare/statefulset_monitoring-rs0.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/monitoring-pmm3/compare/statefulset_monitoring-pmm3-cfg-oc.yml
+++ b/e2e-tests/monitoring-pmm3/compare/statefulset_monitoring-pmm3-cfg-oc.yml
@@ -92,9 +92,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -118,9 +118,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/monitoring-pmm3/compare/statefulset_monitoring-pmm3-cfg.yml
+++ b/e2e-tests/monitoring-pmm3/compare/statefulset_monitoring-pmm3-cfg.yml
@@ -92,9 +92,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -118,9 +118,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/monitoring-pmm3/compare/statefulset_monitoring-pmm3-mongos-oc.yml
+++ b/e2e-tests/monitoring-pmm3/compare/statefulset_monitoring-pmm3-mongos-oc.yml
@@ -83,9 +83,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "10"
             failureThreshold: 4
@@ -109,9 +109,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 1

--- a/e2e-tests/monitoring-pmm3/compare/statefulset_monitoring-pmm3-mongos.yml
+++ b/e2e-tests/monitoring-pmm3/compare/statefulset_monitoring-pmm3-mongos.yml
@@ -83,9 +83,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "10"
             failureThreshold: 4
@@ -109,9 +109,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 1

--- a/e2e-tests/monitoring-pmm3/compare/statefulset_monitoring-pmm3-rs0-no-pmm-oc.yml
+++ b/e2e-tests/monitoring-pmm3/compare/statefulset_monitoring-pmm3-rs0-no-pmm-oc.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/monitoring-pmm3/compare/statefulset_monitoring-pmm3-rs0-no-pmm.yml
+++ b/e2e-tests/monitoring-pmm3/compare/statefulset_monitoring-pmm3-rs0-no-pmm.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/monitoring-pmm3/compare/statefulset_monitoring-pmm3-rs0-oc.yml
+++ b/e2e-tests/monitoring-pmm3/compare/statefulset_monitoring-pmm3-rs0-oc.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/monitoring-pmm3/compare/statefulset_monitoring-pmm3-rs0.yml
+++ b/e2e-tests/monitoring-pmm3/compare/statefulset_monitoring-pmm3-rs0.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/non-voting-and-hidden/compare/statefulset_nonvoting-rs0-nv.yml
+++ b/e2e-tests/non-voting-and-hidden/compare/statefulset_nonvoting-rs0-nv.yml
@@ -91,9 +91,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7201"
             failureThreshold: 3
@@ -117,9 +117,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/non-voting-and-hidden/compare/statefulset_some-name-rs0-hidden-oc.yml
+++ b/e2e-tests/non-voting-and-hidden/compare/statefulset_some-name-rs0-hidden-oc.yml
@@ -91,9 +91,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -117,9 +117,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/non-voting-and-hidden/compare/statefulset_some-name-rs0-hidden.yml
+++ b/e2e-tests/non-voting-and-hidden/compare/statefulset_some-name-rs0-hidden.yml
@@ -91,9 +91,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -117,9 +117,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/non-voting-and-hidden/compare/statefulset_some-name-rs0-nv-oc.yml
+++ b/e2e-tests/non-voting-and-hidden/compare/statefulset_some-name-rs0-nv-oc.yml
@@ -91,9 +91,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7201"
             failureThreshold: 3
@@ -117,9 +117,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/non-voting-and-hidden/compare/statefulset_some-name-rs0-nv.yml
+++ b/e2e-tests/non-voting-and-hidden/compare/statefulset_some-name-rs0-nv.yml
@@ -91,9 +91,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7201"
             failureThreshold: 3
@@ -117,9 +117,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/non-voting-and-hidden/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/non-voting-and-hidden/compare/statefulset_some-name-rs0-oc.yml
@@ -91,9 +91,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -117,9 +117,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/non-voting-and-hidden/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/non-voting-and-hidden/compare/statefulset_some-name-rs0.yml
@@ -91,9 +91,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -117,9 +117,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/one-pod/compare/statefulset_one-pod-rs0-oc.yml
+++ b/e2e-tests/one-pod/compare/statefulset_one-pod-rs0-oc.yml
@@ -89,9 +89,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -115,9 +115,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/one-pod/compare/statefulset_one-pod-rs0-secret-oc.yml
+++ b/e2e-tests/one-pod/compare/statefulset_one-pod-rs0-secret-oc.yml
@@ -89,9 +89,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -115,9 +115,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/one-pod/compare/statefulset_one-pod-rs0-secret.yml
+++ b/e2e-tests/one-pod/compare/statefulset_one-pod-rs0-secret.yml
@@ -89,9 +89,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -115,9 +115,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/one-pod/compare/statefulset_one-pod-rs0.yml
+++ b/e2e-tests/one-pod/compare/statefulset_one-pod-rs0.yml
@@ -89,9 +89,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -115,9 +115,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/pitr-physical-backup-source/compare/statefulset_some-name-cfg-4-oc.yml
+++ b/e2e-tests/pitr-physical-backup-source/compare/statefulset_some-name-cfg-4-oc.yml
@@ -90,9 +90,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -116,9 +116,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/pitr-physical-backup-source/compare/statefulset_some-name-cfg-oc.yml
+++ b/e2e-tests/pitr-physical-backup-source/compare/statefulset_some-name-cfg-oc.yml
@@ -90,9 +90,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -116,9 +116,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/pitr-physical-backup-source/compare/statefulset_some-name-cfg.yml
+++ b/e2e-tests/pitr-physical-backup-source/compare/statefulset_some-name-cfg.yml
@@ -90,9 +90,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -116,9 +116,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/pitr-physical-backup-source/compare/statefulset_some-name-mongos.yml
+++ b/e2e-tests/pitr-physical-backup-source/compare/statefulset_some-name-mongos.yml
@@ -82,9 +82,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "10"
             failureThreshold: 4
@@ -108,9 +108,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 1

--- a/e2e-tests/pitr-physical-backup-source/compare/statefulset_some-name-rs0-4-oc.yml
+++ b/e2e-tests/pitr-physical-backup-source/compare/statefulset_some-name-rs0-4-oc.yml
@@ -81,9 +81,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -107,9 +107,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/pitr-physical-backup-source/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/pitr-physical-backup-source/compare/statefulset_some-name-rs0-oc.yml
@@ -81,9 +81,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -107,9 +107,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/pitr-physical-backup-source/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/pitr-physical-backup-source/compare/statefulset_some-name-rs0.yml
@@ -81,9 +81,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -107,9 +107,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/pitr-physical-backup-source/compare/statefulset_some-name-rs1-4-oc.yml
+++ b/e2e-tests/pitr-physical-backup-source/compare/statefulset_some-name-rs1-4-oc.yml
@@ -81,9 +81,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -107,9 +107,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/pitr-physical-backup-source/compare/statefulset_some-name-rs1-oc.yml
+++ b/e2e-tests/pitr-physical-backup-source/compare/statefulset_some-name-rs1-oc.yml
@@ -81,9 +81,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -107,9 +107,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/pitr-physical-backup-source/compare/statefulset_some-name-rs1.yml
+++ b/e2e-tests/pitr-physical-backup-source/compare/statefulset_some-name-rs1.yml
@@ -81,9 +81,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -107,9 +107,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/pitr-physical-backup-source/compare/statefulset_some-name-rs2-4-oc.yml
+++ b/e2e-tests/pitr-physical-backup-source/compare/statefulset_some-name-rs2-4-oc.yml
@@ -81,9 +81,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -107,9 +107,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/pitr-physical-backup-source/compare/statefulset_some-name-rs2-oc.yml
+++ b/e2e-tests/pitr-physical-backup-source/compare/statefulset_some-name-rs2-oc.yml
@@ -81,9 +81,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -107,9 +107,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/pitr-physical-backup-source/compare/statefulset_some-name-rs2.yml
+++ b/e2e-tests/pitr-physical-backup-source/compare/statefulset_some-name-rs2.yml
@@ -81,9 +81,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -107,9 +107,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/pitr-physical/compare/statefulset_some-name-cfg-4-oc.yml
+++ b/e2e-tests/pitr-physical/compare/statefulset_some-name-cfg-4-oc.yml
@@ -90,9 +90,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -116,9 +116,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/pitr-physical/compare/statefulset_some-name-cfg-oc.yml
+++ b/e2e-tests/pitr-physical/compare/statefulset_some-name-cfg-oc.yml
@@ -90,9 +90,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -116,9 +116,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/pitr-physical/compare/statefulset_some-name-cfg.yml
+++ b/e2e-tests/pitr-physical/compare/statefulset_some-name-cfg.yml
@@ -90,9 +90,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -116,9 +116,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/pitr-physical/compare/statefulset_some-name-mongos.yml
+++ b/e2e-tests/pitr-physical/compare/statefulset_some-name-mongos.yml
@@ -82,9 +82,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "10"
             failureThreshold: 4
@@ -108,9 +108,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 1

--- a/e2e-tests/pitr-physical/compare/statefulset_some-name-rs0-4-oc.yml
+++ b/e2e-tests/pitr-physical/compare/statefulset_some-name-rs0-4-oc.yml
@@ -81,9 +81,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -107,9 +107,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/pitr-physical/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/pitr-physical/compare/statefulset_some-name-rs0-oc.yml
@@ -81,9 +81,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -107,9 +107,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/pitr-physical/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/pitr-physical/compare/statefulset_some-name-rs0.yml
@@ -81,9 +81,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -107,9 +107,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/pitr-physical/compare/statefulset_some-name-rs1-4-oc.yml
+++ b/e2e-tests/pitr-physical/compare/statefulset_some-name-rs1-4-oc.yml
@@ -81,9 +81,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -107,9 +107,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/pitr-physical/compare/statefulset_some-name-rs1-oc.yml
+++ b/e2e-tests/pitr-physical/compare/statefulset_some-name-rs1-oc.yml
@@ -81,9 +81,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -107,9 +107,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/pitr-physical/compare/statefulset_some-name-rs1.yml
+++ b/e2e-tests/pitr-physical/compare/statefulset_some-name-rs1.yml
@@ -81,9 +81,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -107,9 +107,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/pitr-physical/compare/statefulset_some-name-rs2-4-oc.yml
+++ b/e2e-tests/pitr-physical/compare/statefulset_some-name-rs2-4-oc.yml
@@ -81,9 +81,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -107,9 +107,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/pitr-physical/compare/statefulset_some-name-rs2-oc.yml
+++ b/e2e-tests/pitr-physical/compare/statefulset_some-name-rs2-oc.yml
@@ -81,9 +81,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -107,9 +107,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/pitr-physical/compare/statefulset_some-name-rs2.yml
+++ b/e2e-tests/pitr-physical/compare/statefulset_some-name-rs2.yml
@@ -81,9 +81,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -107,9 +107,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/pitr-sharded/compare/statefulset_some-name-cfg-4-oc.yml
+++ b/e2e-tests/pitr-sharded/compare/statefulset_some-name-cfg-4-oc.yml
@@ -91,9 +91,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -117,9 +117,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/pitr-sharded/compare/statefulset_some-name-cfg-oc.yml
+++ b/e2e-tests/pitr-sharded/compare/statefulset_some-name-cfg-oc.yml
@@ -91,9 +91,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -117,9 +117,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/pitr-sharded/compare/statefulset_some-name-cfg.yml
+++ b/e2e-tests/pitr-sharded/compare/statefulset_some-name-cfg.yml
@@ -91,9 +91,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -117,9 +117,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/pitr-sharded/compare/statefulset_some-name-mongos-oc.yml
+++ b/e2e-tests/pitr-sharded/compare/statefulset_some-name-mongos-oc.yml
@@ -82,9 +82,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "10"
             failureThreshold: 4
@@ -108,9 +108,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 1

--- a/e2e-tests/pitr-sharded/compare/statefulset_some-name-mongos.yml
+++ b/e2e-tests/pitr-sharded/compare/statefulset_some-name-mongos.yml
@@ -82,9 +82,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "10"
             failureThreshold: 4
@@ -108,9 +108,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 1

--- a/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs0-4-oc.yml
+++ b/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs0-4-oc.yml
@@ -81,9 +81,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -107,9 +107,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs0-oc.yml
@@ -81,9 +81,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -107,9 +107,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs0.yml
@@ -81,9 +81,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -107,9 +107,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs1-4-oc.yml
+++ b/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs1-4-oc.yml
@@ -81,9 +81,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -107,9 +107,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs1-oc.yml
+++ b/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs1-oc.yml
@@ -81,9 +81,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -107,9 +107,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs1.yml
+++ b/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs1.yml
@@ -81,9 +81,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -107,9 +107,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs2-4-oc.yml
+++ b/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs2-4-oc.yml
@@ -81,9 +81,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -107,9 +107,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs2-oc.yml
+++ b/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs2-oc.yml
@@ -81,9 +81,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -107,9 +107,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs2.yml
+++ b/e2e-tests/pitr-sharded/compare/statefulset_some-name-rs2.yml
@@ -81,9 +81,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -107,9 +107,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/pitr/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/pitr/compare/statefulset_some-name-rs0-oc.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/pitr/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/pitr/compare/statefulset_some-name-rs0.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/pvc-auto-resize/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/pvc-auto-resize/compare/statefulset_some-name-rs0-oc.yml
@@ -79,9 +79,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -105,9 +105,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/pvc-auto-resize/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/pvc-auto-resize/compare/statefulset_some-name-rs0.yml
@@ -79,9 +79,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -105,9 +105,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/pvc-resize/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/pvc-resize/compare/statefulset_some-name-rs0-oc.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/pvc-resize/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/pvc-resize/compare/statefulset_some-name-rs0.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/rs-shard-migration/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/rs-shard-migration/compare/statefulset_some-name-rs0-oc.yml
@@ -79,9 +79,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -105,9 +105,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/rs-shard-migration/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/rs-shard-migration/compare/statefulset_some-name-rs0.yml
@@ -79,9 +79,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -105,9 +105,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/scheduled-backup/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/scheduled-backup/compare/statefulset_some-name-rs0-oc.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/scheduled-backup/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/scheduled-backup/compare/statefulset_some-name-rs0.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/security-context/compare/statefulset_sec-context-rs0-changed.yml
+++ b/e2e-tests/security-context/compare/statefulset_sec-context-rs0-changed.yml
@@ -81,9 +81,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -107,9 +107,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/security-context/compare/statefulset_sec-context-rs0.yml
+++ b/e2e-tests/security-context/compare/statefulset_sec-context-rs0.yml
@@ -81,9 +81,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -107,9 +107,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/service-per-pod/compare/statefulset_cluster-ip-rs0-oc.yml
+++ b/e2e-tests/service-per-pod/compare/statefulset_cluster-ip-rs0-oc.yml
@@ -79,9 +79,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -105,9 +105,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/service-per-pod/compare/statefulset_cluster-ip-rs0.yml
+++ b/e2e-tests/service-per-pod/compare/statefulset_cluster-ip-rs0.yml
@@ -79,9 +79,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -105,9 +105,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/service-per-pod/compare/statefulset_local-balancer-rs0-oc.yml
+++ b/e2e-tests/service-per-pod/compare/statefulset_local-balancer-rs0-oc.yml
@@ -79,9 +79,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -105,9 +105,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/service-per-pod/compare/statefulset_local-balancer-rs0.yml
+++ b/e2e-tests/service-per-pod/compare/statefulset_local-balancer-rs0.yml
@@ -79,9 +79,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -105,9 +105,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/service-per-pod/compare/statefulset_node-port-rs0-oc.yml
+++ b/e2e-tests/service-per-pod/compare/statefulset_node-port-rs0-oc.yml
@@ -79,9 +79,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -105,9 +105,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/service-per-pod/compare/statefulset_node-port-rs0.yml
+++ b/e2e-tests/service-per-pod/compare/statefulset_node-port-rs0.yml
@@ -79,9 +79,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -105,9 +105,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/serviceless-external-nodes/compare/statefulset_mydb-rs0-oc.yml
+++ b/e2e-tests/serviceless-external-nodes/compare/statefulset_mydb-rs0-oc.yml
@@ -81,9 +81,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -107,9 +107,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/serviceless-external-nodes/compare/statefulset_mydb-rs0.yml
+++ b/e2e-tests/serviceless-external-nodes/compare/statefulset_mydb-rs0.yml
@@ -81,9 +81,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -107,9 +107,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/smart-update/compare/statefulset_smart-update-rs0-arbiter-oc.yml
+++ b/e2e-tests/smart-update/compare/statefulset_smart-update-rs0-arbiter-oc.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/smart-update/compare/statefulset_smart-update-rs0-arbiter.yml
+++ b/e2e-tests/smart-update/compare/statefulset_smart-update-rs0-arbiter.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/smart-update/compare/statefulset_smart-update-rs0-oc.yml
+++ b/e2e-tests/smart-update/compare/statefulset_smart-update-rs0-oc.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/smart-update/compare/statefulset_smart-update-rs0.yml
+++ b/e2e-tests/smart-update/compare/statefulset_smart-update-rs0.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/storage/compare/statefulset_emptydir-rs0-oc.yml
+++ b/e2e-tests/storage/compare/statefulset_emptydir-rs0-oc.yml
@@ -91,9 +91,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -117,9 +117,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/storage/compare/statefulset_emptydir-rs0.yml
+++ b/e2e-tests/storage/compare/statefulset_emptydir-rs0.yml
@@ -91,9 +91,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -117,9 +117,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/storage/compare/statefulset_hostpath-rs0-oc.yml
+++ b/e2e-tests/storage/compare/statefulset_hostpath-rs0-oc.yml
@@ -79,9 +79,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -105,9 +105,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/storage/compare/statefulset_hostpath-rs0.yml
+++ b/e2e-tests/storage/compare/statefulset_hostpath-rs0.yml
@@ -91,9 +91,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -117,9 +117,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/tls-issue-cert-manager/compare/statefulset_some-name-cfg-oc.yml
+++ b/e2e-tests/tls-issue-cert-manager/compare/statefulset_some-name-cfg-oc.yml
@@ -91,9 +91,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -117,9 +117,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/tls-issue-cert-manager/compare/statefulset_some-name-cfg.yml
+++ b/e2e-tests/tls-issue-cert-manager/compare/statefulset_some-name-cfg.yml
@@ -91,9 +91,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -117,9 +117,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/tls-issue-cert-manager/compare/statefulset_some-name-mongos-oc.yml
+++ b/e2e-tests/tls-issue-cert-manager/compare/statefulset_some-name-mongos-oc.yml
@@ -82,9 +82,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "10"
             failureThreshold: 4
@@ -108,9 +108,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 1

--- a/e2e-tests/tls-issue-cert-manager/compare/statefulset_some-name-mongos.yml
+++ b/e2e-tests/tls-issue-cert-manager/compare/statefulset_some-name-mongos.yml
@@ -82,9 +82,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "10"
             failureThreshold: 4
@@ -108,9 +108,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 1

--- a/e2e-tests/tls-issue-cert-manager/compare/statefulset_some-name-rs0-oc.yml
+++ b/e2e-tests/tls-issue-cert-manager/compare/statefulset_some-name-rs0-oc.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/tls-issue-cert-manager/compare/statefulset_some-name-rs0.yml
+++ b/e2e-tests/tls-issue-cert-manager/compare/statefulset_some-name-rs0.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/unsafe-psa/compare/statefulset_unsafe-psa-rs0-oc.yml
+++ b/e2e-tests/unsafe-psa/compare/statefulset_unsafe-psa-rs0-oc.yml
@@ -91,9 +91,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -117,9 +117,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/unsafe-psa/compare/statefulset_unsafe-psa-rs0.yml
+++ b/e2e-tests/unsafe-psa/compare/statefulset_unsafe-psa-rs0.yml
@@ -91,9 +91,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -117,9 +117,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1201-oc.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1201-oc.yml
@@ -92,9 +92,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1201-oc.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1201-oc.yml
@@ -92,9 +92,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl-internal/ca.crt
+                - /etc/mongodb-ssl/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls-internal.pem
+                - /tmp/tls.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1201.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1201.yml
@@ -92,9 +92,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1201.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1201.yml
@@ -92,9 +92,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl-internal/ca.crt
+                - /etc/mongodb-ssl/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls-internal.pem
+                - /tmp/tls.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1212-oc.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1212-oc.yml
@@ -92,9 +92,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1212-oc.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1212-oc.yml
@@ -92,9 +92,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl-internal/ca.crt
+                - /etc/mongodb-ssl/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls-internal.pem
+                - /tmp/tls.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1212.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1212.yml
@@ -92,9 +92,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1212.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1212.yml
@@ -92,9 +92,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl-internal/ca.crt
+                - /etc/mongodb-ssl/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls-internal.pem
+                - /tmp/tls.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1220-oc.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1220-oc.yml
@@ -92,9 +92,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -118,9 +118,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1220-oc.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1220-oc.yml
@@ -92,9 +92,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl-internal/ca.crt
+                - /etc/mongodb-ssl/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls-internal.pem
+                - /tmp/tls.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -118,9 +118,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl-internal/ca.crt
+                - /etc/mongodb-ssl/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls-internal.pem
+                - /tmp/tls.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1220.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1220.yml
@@ -92,9 +92,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -118,9 +118,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1220.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1220.yml
@@ -92,9 +92,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl-internal/ca.crt
+                - /etc/mongodb-ssl/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls-internal.pem
+                - /tmp/tls.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -118,9 +118,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl-internal/ca.crt
+                - /etc/mongodb-ssl/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls-internal.pem
+                - /tmp/tls.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1230-oc.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1230-oc.yml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations: {}
-  generation: 8
+  generation: 7
   labels:
     app.kubernetes.io/component: cfg
     app.kubernetes.io/instance: some-name

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1230-oc.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1230-oc.yml
@@ -92,9 +92,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -118,9 +118,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1230.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1230.yml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations: {}
-  generation: 8
+  generation: 7
   labels:
     app.kubernetes.io/component: cfg
     app.kubernetes.io/instance: some-name

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1230.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1230.yml
@@ -92,9 +92,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -118,9 +118,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 3
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1230.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-cfg-1230.yml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations: {}
-  generation: 7
+  generation: 9
   labels:
     app.kubernetes.io/component: cfg
     app.kubernetes.io/instance: some-name

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1201-oc.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1201-oc.yml
@@ -93,9 +93,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl-internal/ca.crt
+                - /etc/mongodb-ssl/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls-internal.pem
+                - /tmp/tls.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1201-oc.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1201-oc.yml
@@ -93,9 +93,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1201.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1201.yml
@@ -93,9 +93,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl-internal/ca.crt
+                - /etc/mongodb-ssl/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls-internal.pem
+                - /tmp/tls.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1201.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1201.yml
@@ -93,9 +93,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1212-oc.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1212-oc.yml
@@ -93,9 +93,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl-internal/ca.crt
+                - /etc/mongodb-ssl/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls-internal.pem
+                - /tmp/tls.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1212-oc.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1212-oc.yml
@@ -93,9 +93,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1212.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1212.yml
@@ -93,9 +93,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl-internal/ca.crt
+                - /etc/mongodb-ssl/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls-internal.pem
+                - /tmp/tls.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1212.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1212.yml
@@ -93,9 +93,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1220-oc.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1220-oc.yml
@@ -93,9 +93,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -119,9 +119,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1220-oc.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1220-oc.yml
@@ -93,9 +93,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl-internal/ca.crt
+                - /etc/mongodb-ssl/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls-internal.pem
+                - /tmp/tls.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -119,9 +119,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl-internal/ca.crt
+                - /etc/mongodb-ssl/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls-internal.pem
+                - /tmp/tls.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1220.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1220.yml
@@ -93,9 +93,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -119,9 +119,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1220.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1220.yml
@@ -93,9 +93,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl-internal/ca.crt
+                - /etc/mongodb-ssl/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls-internal.pem
+                - /tmp/tls.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -119,9 +119,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl-internal/ca.crt
+                - /etc/mongodb-ssl/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls-internal.pem
+                - /tmp/tls.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1230-oc.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1230-oc.yml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations: {}
-  generation: 8
+  generation: 7
   labels:
     app.kubernetes.io/component: mongod
     app.kubernetes.io/instance: some-name

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1230-oc.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1230-oc.yml
@@ -93,9 +93,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -119,9 +119,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1230.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1230.yml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations: {}
-  generation: 8
+  generation: 7
   labels:
     app.kubernetes.io/component: mongod
     app.kubernetes.io/instance: some-name

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1230.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1230.yml
@@ -93,9 +93,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -119,9 +119,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1230.yml
+++ b/e2e-tests/upgrade-consistency-sharded-tls/compare/statefulset_some-name-rs0-1230.yml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations: {}
-  generation: 7
+  generation: 9
   labels:
     app.kubernetes.io/component: mongod
     app.kubernetes.io/instance: some-name

--- a/e2e-tests/upgrade-consistency-sharded-tls/run
+++ b/e2e-tests/upgrade-consistency-sharded-tls/run
@@ -9,114 +9,114 @@ set_debug
 CLUSTER='some-name'
 
 wait_cluster() {
-	wait_for_running ${CLUSTER}-rs0 3
-	wait_for_running ${CLUSTER}-cfg 3
-	wait_for_running ${CLUSTER}-mongos 3
-	wait_cluster_consistency ${CLUSTER}
+    wait_for_running ${CLUSTER}-rs0 3
+    wait_for_running ${CLUSTER}-cfg 3
+    wait_for_running ${CLUSTER}-mongos 3
+    wait_cluster_consistency ${CLUSTER}
 }
 
 main() {
-	create_infra "$namespace"
-	deploy_cert_manager
+    create_infra "$namespace"
+    deploy_cert_manager
 
-	desc 'create secrets and start client'
-	kubectl_bin apply -f "$conf_dir/secrets.yml"
-	kubectl_bin apply -f "$conf_dir/client_with_tls.yml"
-	deploy_cmctl
+    desc 'create secrets and start client'
+    kubectl_bin apply -f "$conf_dir/secrets.yml"
+    kubectl_bin apply -f "$conf_dir/client_with_tls.yml"
+    deploy_cmctl
 
-	desc "create first PSMDB cluster 1.21.2 $CLUSTER"
-	apply_cluster "$test_dir/conf/${CLUSTER}.yml"
+    desc "create first PSMDB cluster 1.21.2 $CLUSTER"
+    apply_cluster "$test_dir/conf/${CLUSTER}.yml"
 
-	desc 'check if Pod started'
-	wait_cluster
+    desc 'check if Pod started'
+    wait_cluster
 
-	compare_generation "1" "statefulset" "${CLUSTER}-rs0"
-	compare_generation "1" "statefulset" "${CLUSTER}-cfg"
+    compare_generation "1" "statefulset" "${CLUSTER}-rs0"
+    compare_generation "1" "statefulset" "${CLUSTER}-cfg"
 
-	# Wait for at least one reconciliation
-	sleep 20
-	desc 'check if Pod started'
-	wait_cluster
+    # Wait for at least one reconciliation
+    sleep 20
+    desc 'check if Pod started'
+    wait_cluster
 
-	renew_certificate "some-name-ssl"
-	sleep 20
-	wait_cluster
-	compare_generation "2" "statefulset" "${CLUSTER}-rs0"
-	compare_generation "2" "statefulset" "${CLUSTER}-cfg"
+    renew_certificate "some-name-ssl"
+    sleep 20
+    wait_cluster
+    compare_generation "2" "statefulset" "${CLUSTER}-rs0"
+    compare_generation "2" "statefulset" "${CLUSTER}-cfg"
 
-	renew_certificate "some-name-ssl-internal"
-	sleep 20
-	wait_cluster
-	compare_generation "3" "statefulset" "${CLUSTER}-rs0"
-	compare_generation "3" "statefulset" "${CLUSTER}-cfg"
+    renew_certificate "some-name-ssl-internal"
+    sleep 20
+    wait_cluster
+    compare_generation "3" "statefulset" "${CLUSTER}-rs0"
+    compare_generation "3" "statefulset" "${CLUSTER}-cfg"
 
-	desc 'check if service and statefulset created with expected config'
-	compare_kubectl service/${CLUSTER}-rs0 "-1212"
-	compare_kubectl service/${CLUSTER}-cfg "-1212"
-	compare_kubectl statefulset/${CLUSTER}-rs0 "-1212"
-	compare_kubectl statefulset/${CLUSTER}-cfg "-1212"
+    desc 'check if service and statefulset created with expected config'
+    compare_kubectl service/${CLUSTER}-rs0 "-1212"
+    compare_kubectl service/${CLUSTER}-cfg "-1212"
+    compare_kubectl statefulset/${CLUSTER}-rs0 "-1212"
+    compare_kubectl statefulset/${CLUSTER}-cfg "-1212"
 
-	desc 'test 1.22.0'
-	kubectl_bin patch psmdb "${CLUSTER}" --type=merge --patch '{
+    desc 'test 1.22.0'
+    kubectl_bin patch psmdb "${CLUSTER}" --type=merge --patch '{
         "spec": {"crVersion":"1.22.0"}
     }'
-	# Wait for at least one reconciliation
-	sleep 20
-	desc 'check if Pod started'
-	wait_cluster
-	compare_generation "4" "statefulset" "${CLUSTER}-rs0"
-	compare_generation "4" "statefulset" "${CLUSTER}-cfg"
+    # Wait for at least one reconciliation
+    sleep 20
+    desc 'check if Pod started'
+    wait_cluster
+    compare_generation "4" "statefulset" "${CLUSTER}-rs0"
+    compare_generation "4" "statefulset" "${CLUSTER}-cfg"
 
-	renew_certificate "some-name-ssl"
-	sleep 20
-	wait_cluster
-	compare_generation "5" "statefulset" "${CLUSTER}-rs0"
-	compare_generation "5" "statefulset" "${CLUSTER}-cfg"
+    renew_certificate "some-name-ssl"
+    sleep 20
+    wait_cluster
+    compare_generation "5" "statefulset" "${CLUSTER}-rs0"
+    compare_generation "5" "statefulset" "${CLUSTER}-cfg"
 
-	renew_certificate "some-name-ssl-internal"
-	sleep 20
-	wait_cluster
-	compare_generation "6" "statefulset" "${CLUSTER}-rs0"
-	compare_generation "6" "statefulset" "${CLUSTER}-cfg"
+    renew_certificate "some-name-ssl-internal"
+    sleep 20
+    wait_cluster
+    compare_generation "6" "statefulset" "${CLUSTER}-rs0"
+    compare_generation "6" "statefulset" "${CLUSTER}-cfg"
 
-	desc 'check if service and statefulset created with expected config'
-	compare_kubectl service/${CLUSTER}-rs0 "-1220"
-	compare_kubectl service/${CLUSTER}-cfg "-1220"
-	compare_kubectl statefulset/${CLUSTER}-rs0 "-1220"
-	compare_kubectl statefulset/${CLUSTER}-cfg "-1220"
+    desc 'check if service and statefulset created with expected config'
+    compare_kubectl service/${CLUSTER}-rs0 "-1220"
+    compare_kubectl service/${CLUSTER}-cfg "-1220"
+    compare_kubectl statefulset/${CLUSTER}-rs0 "-1220"
+    compare_kubectl statefulset/${CLUSTER}-cfg "-1220"
 
-	desc 'test 1.23.0'
-	kubectl_bin patch psmdb "${CLUSTER}" --type=merge --patch '{
+    desc 'test 1.23.0'
+    kubectl_bin patch psmdb "${CLUSTER}" --type=merge --patch '{
         "spec": {"crVersion":"1.23.0"}
     }'
-	# Wait for at least one reconciliation
-	sleep 20
-	desc 'check if Pod started'
-	wait_cluster
-	compare_generation "6" "statefulset" "${CLUSTER}-rs0"
-	compare_generation "6" "statefulset" "${CLUSTER}-cfg"
+    # Wait for at least one reconciliation
+    sleep 20
+    desc 'check if Pod started'
+    wait_cluster
+    compare_generation "7" "statefulset" "${CLUSTER}-rs0"
+    compare_generation "7" "statefulset" "${CLUSTER}-cfg"
 
-	renew_certificate "some-name-ssl"
-	sleep 20
-	wait_cluster
-	compare_generation "7" "statefulset" "${CLUSTER}-rs0"
-	compare_generation "7" "statefulset" "${CLUSTER}-cfg"
+    renew_certificate "some-name-ssl"
+    sleep 20
+    wait_cluster
+    compare_generation "8" "statefulset" "${CLUSTER}-rs0"
+    compare_generation "8" "statefulset" "${CLUSTER}-cfg"
 
-	renew_certificate "some-name-ssl-internal"
-	sleep 20
-	wait_cluster
-	compare_generation "8" "statefulset" "${CLUSTER}-rs0"
-	compare_generation "8" "statefulset" "${CLUSTER}-cfg"
+    renew_certificate "some-name-ssl-internal"
+    sleep 20
+    wait_cluster
+    compare_generation "9" "statefulset" "${CLUSTER}-rs0"
+    compare_generation "9" "statefulset" "${CLUSTER}-cfg"
 
-	desc 'check if service and statefulset created with expected config'
-	compare_kubectl service/${CLUSTER}-rs0 "-1230"
-	compare_kubectl service/${CLUSTER}-cfg "-1230"
-	compare_kubectl statefulset/${CLUSTER}-rs0 "-1230"
-	compare_kubectl statefulset/${CLUSTER}-cfg "-1230"
+    desc 'check if service and statefulset created with expected config'
+    compare_kubectl service/${CLUSTER}-rs0 "-1230"
+    compare_kubectl service/${CLUSTER}-cfg "-1230"
+    compare_kubectl statefulset/${CLUSTER}-rs0 "-1230"
+    compare_kubectl statefulset/${CLUSTER}-cfg "-1230"
 
-	destroy "$namespace"
+    destroy "$namespace"
 
-	desc 'test passed'
+    desc 'test passed'
 }
 
 main

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1201-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1201-oc.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1201-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1201-oc.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl-internal/ca.crt
+                - /etc/mongodb-ssl/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls-internal.pem
+                - /tmp/tls.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1201.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1201.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1201.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1201.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl-internal/ca.crt
+                - /etc/mongodb-ssl/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls-internal.pem
+                - /tmp/tls.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1212-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1212-oc.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1212-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1212-oc.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl-internal/ca.crt
+                - /etc/mongodb-ssl/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls-internal.pem
+                - /tmp/tls.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1212.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1212.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1212.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1212.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl-internal/ca.crt
+                - /etc/mongodb-ssl/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls-internal.pem
+                - /tmp/tls.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1220-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1220-oc.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1220-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1220-oc.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl-internal/ca.crt
+                - /etc/mongodb-ssl/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls-internal.pem
+                - /tmp/tls.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl-internal/ca.crt
+                - /etc/mongodb-ssl/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls-internal.pem
+                - /tmp/tls.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1220.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1220.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1220.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1220.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl-internal/ca.crt
+                - /etc/mongodb-ssl/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls-internal.pem
+                - /tmp/tls.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl-internal/ca.crt
+                - /etc/mongodb-ssl/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls-internal.pem
+                - /tmp/tls.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1230-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1230-oc.yml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations: {}
-  generation: 2
+  generation: 3
   labels:
     app.kubernetes.io/component: mongod
     app.kubernetes.io/instance: some-name

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1230-oc.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1230-oc.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1230.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1230.yml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   annotations: {}
-  generation: 2
+  generation: 3
   labels:
     app.kubernetes.io/component: mongod
     app.kubernetes.io/instance: some-name

--- a/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1230.yml
+++ b/e2e-tests/upgrade-consistency/compare/statefulset_some-name-rs0-1230.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/version-service/compare/statefulset_minimal-cluster-rs0.yml
+++ b/e2e-tests/version-service/compare/statefulset_minimal-cluster-rs0.yml
@@ -90,9 +90,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4

--- a/e2e-tests/version-service/compare/statefulset_version-service-exact-rs0-oc.yml
+++ b/e2e-tests/version-service/compare/statefulset_version-service-exact-rs0-oc.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/version-service/compare/statefulset_version-service-exact-rs0.yml
+++ b/e2e-tests/version-service/compare/statefulset_version-service-exact-rs0.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/version-service/compare/statefulset_version-service-latest-rs0-oc.yml
+++ b/e2e-tests/version-service/compare/statefulset_version-service-latest-rs0-oc.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/version-service/compare/statefulset_version-service-latest-rs0.yml
+++ b/e2e-tests/version-service/compare/statefulset_version-service-latest-rs0.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/version-service/compare/statefulset_version-service-major-rs0-oc.yml
+++ b/e2e-tests/version-service/compare/statefulset_version-service-major-rs0-oc.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/version-service/compare/statefulset_version-service-major-rs0.yml
+++ b/e2e-tests/version-service/compare/statefulset_version-service-major-rs0.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/version-service/compare/statefulset_version-service-recommended-rs0-oc.yml
+++ b/e2e-tests/version-service/compare/statefulset_version-service-recommended-rs0-oc.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/version-service/compare/statefulset_version-service-recommended-rs0.yml
+++ b/e2e-tests/version-service/compare/statefulset_version-service-recommended-rs0.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 4
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 8
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/version-service/compare/statefulset_version-service-unreachable-rs0-oc.yml
+++ b/e2e-tests/version-service/compare/statefulset_version-service-unreachable-rs0-oc.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 3
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 5
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/e2e-tests/version-service/compare/statefulset_version-service-unreachable-rs0.yml
+++ b/e2e-tests/version-service/compare/statefulset_version-service-unreachable-rs0.yml
@@ -80,9 +80,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
                 - --startupDelaySeconds
                 - "7200"
             failureThreshold: 3
@@ -106,9 +106,9 @@ spec:
                 - --ssl
                 - --sslInsecure
                 - --sslCAFile
-                - /etc/mongodb-ssl/ca.crt
+                - /etc/mongodb-ssl-internal/ca.crt
                 - --sslPEMKeyFile
-                - /tmp/tls.pem
+                - /tmp/tls-internal.pem
             failureThreshold: 5
             initialDelaySeconds: 10
             periodSeconds: 3

--- a/pkg/apis/psmdb/v1/psmdb_defaults.go
+++ b/pkg/apis/psmdb/v1/psmdb_defaults.go
@@ -251,7 +251,7 @@ func (cr *PerconaServerMongoDB) CheckNSetDefaults(ctx context.Context, platform 
 			if cr.TLSEnabled() {
 				var tlsArgs []string
 				// Prioritize internal certificates if configured
-				if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets.SSLInternal != "" && cr.Spec.Secrets.SSLInternal != cr.Spec.Secrets.SSL {
+				if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets != nil && cr.Spec.Secrets.SSLInternal != "" && cr.Spec.Secrets.SSLInternal != cr.Spec.Secrets.SSL {
 					tlsArgs = []string{
 						"--ssl", "--sslInsecure",
 						"--sslCAFile", "/etc/mongodb-ssl-internal/ca.crt",
@@ -309,7 +309,7 @@ func (cr *PerconaServerMongoDB) CheckNSetDefaults(ctx context.Context, platform 
 			if cr.TLSEnabled() {
 				var tlsArgs []string
 				// Prioritize internal certificates if configured
-				if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets.SSLInternal != "" && cr.Spec.Secrets.SSLInternal != cr.Spec.Secrets.SSL {
+				if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets != nil && cr.Spec.Secrets.SSLInternal != "" && cr.Spec.Secrets.SSLInternal != cr.Spec.Secrets.SSL {
 					tlsArgs = []string{
 						"--ssl", "--sslInsecure",
 						"--sslCAFile", "/etc/mongodb-ssl-internal/ca.crt",
@@ -487,7 +487,7 @@ func (cr *PerconaServerMongoDB) CheckNSetDefaults(ctx context.Context, platform 
 			if cr.TLSEnabled() {
 				var tlsArgs []string
 				// Prioritize internal certificates if configured
-				if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets.SSLInternal != "" && cr.Spec.Secrets.SSLInternal != cr.Spec.Secrets.SSL {
+				if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets != nil && cr.Spec.Secrets.SSLInternal != "" && cr.Spec.Secrets.SSLInternal != cr.Spec.Secrets.SSL {
 					tlsArgs = []string{
 						"--ssl", "--sslInsecure",
 						"--sslCAFile", "/etc/mongodb-ssl-internal/ca.crt",
@@ -544,7 +544,7 @@ func (cr *PerconaServerMongoDB) CheckNSetDefaults(ctx context.Context, platform 
 			if cr.TLSEnabled() && cr.CompareVersion("1.22.0") >= 0 {
 				var tlsArgs []string
 				// Prioritize internal certificates if configured
-				if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets.SSLInternal != "" && cr.Spec.Secrets.SSLInternal != cr.Spec.Secrets.SSL {
+				if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets != nil && cr.Spec.Secrets.SSLInternal != "" && cr.Spec.Secrets.SSLInternal != cr.Spec.Secrets.SSL {
 					tlsArgs = []string{
 						"--ssl", "--sslInsecure",
 						"--sslCAFile", "/etc/mongodb-ssl-internal/ca.crt",
@@ -928,7 +928,7 @@ func (nv *NonVotingSpec) SetDefaults(cr *PerconaServerMongoDB, rs *ReplsetSpec) 
 		if cr.TLSEnabled() {
 			var tlsArgs []string
 			// Prioritize internal certificates if configured
-			if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets.SSLInternal != "" && cr.Spec.Secrets.SSLInternal != cr.Spec.Secrets.SSL {
+			if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets != nil && cr.Spec.Secrets.SSLInternal != "" && cr.Spec.Secrets.SSLInternal != cr.Spec.Secrets.SSL {
 				tlsArgs = []string{
 					"--ssl", "--sslInsecure",
 					"--sslCAFile", "/etc/mongodb-ssl-internal/ca.crt",
@@ -971,7 +971,7 @@ func (nv *NonVotingSpec) SetDefaults(cr *PerconaServerMongoDB, rs *ReplsetSpec) 
 		if cr.TLSEnabled() && cr.CompareVersion("1.22.0") >= 0 {
 			var tlsArgs []string
 			// Prioritize internal certificates if configured
-			if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets.SSLInternal != "" && cr.Spec.Secrets.SSLInternal != cr.Spec.Secrets.SSL {
+			if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets != nil && cr.Spec.Secrets.SSLInternal != "" && cr.Spec.Secrets.SSLInternal != cr.Spec.Secrets.SSL {
 				tlsArgs = []string{
 					"--ssl", "--sslInsecure",
 					"--sslCAFile", "/etc/mongodb-ssl-internal/ca.crt",
@@ -1060,7 +1060,7 @@ func (h *HiddenSpec) setLivenessProbe(cr *PerconaServerMongoDB, rs *ReplsetSpec)
 		if cr.TLSEnabled() {
 			var tlsArgs []string
 			// Prioritize internal certificates if configured
-			if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets.SSLInternal != "" && cr.Spec.Secrets.SSLInternal != cr.Spec.Secrets.SSL {
+			if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets != nil && cr.Spec.Secrets.SSLInternal != "" && cr.Spec.Secrets.SSLInternal != cr.Spec.Secrets.SSL {
 				tlsArgs = []string{
 					"--ssl", "--sslInsecure",
 					"--sslCAFile", "/etc/mongodb-ssl-internal/ca.crt",
@@ -1102,7 +1102,7 @@ func (h *HiddenSpec) setReadinessProbe(cr *PerconaServerMongoDB, rs *ReplsetSpec
 		if cr.TLSEnabled() && cr.CompareVersion("1.22.0") >= 0 {
 			var tlsArgs []string
 			// Prioritize internal certificates if configured
-			if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets.SSLInternal != "" && cr.Spec.Secrets.SSLInternal != cr.Spec.Secrets.SSL {
+			if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets != nil && cr.Spec.Secrets.SSLInternal != "" && cr.Spec.Secrets.SSLInternal != cr.Spec.Secrets.SSL {
 				tlsArgs = []string{
 					"--ssl", "--sslInsecure",
 					"--sslCAFile", "/etc/mongodb-ssl-internal/ca.crt",

--- a/pkg/apis/psmdb/v1/psmdb_defaults.go
+++ b/pkg/apis/psmdb/v1/psmdb_defaults.go
@@ -251,7 +251,7 @@ func (cr *PerconaServerMongoDB) CheckNSetDefaults(ctx context.Context, platform 
 			if cr.TLSEnabled() {
 				var tlsArgs []string
 				// Prioritize internal certificates if configured
-				if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets.SSLInternal != "" {
+				if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets.SSLInternal != "" && cr.Spec.Secrets.SSLInternal != cr.Spec.Secrets.SSL {
 					tlsArgs = []string{
 						"--ssl", "--sslInsecure",
 						"--sslCAFile", "/etc/mongodb-ssl-internal/ca.crt",
@@ -309,7 +309,7 @@ func (cr *PerconaServerMongoDB) CheckNSetDefaults(ctx context.Context, platform 
 			if cr.TLSEnabled() && cr.CompareVersion("1.22.0") >= 0 {
 				var tlsArgs []string
 				// Prioritize internal certificates if configured
-				if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets.SSLInternal != "" {
+				if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets.SSLInternal != "" && cr.Spec.Secrets.SSLInternal != cr.Spec.Secrets.SSL {
 					tlsArgs = []string{
 						"--ssl", "--sslInsecure",
 						"--sslCAFile", "/etc/mongodb-ssl-internal/ca.crt",
@@ -487,7 +487,7 @@ func (cr *PerconaServerMongoDB) CheckNSetDefaults(ctx context.Context, platform 
 			if cr.TLSEnabled() {
 				var tlsArgs []string
 				// Prioritize internal certificates if configured
-				if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets.SSLInternal != "" {
+				if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets.SSLInternal != "" && cr.Spec.Secrets.SSLInternal != cr.Spec.Secrets.SSL {
 					tlsArgs = []string{
 						"--ssl", "--sslInsecure",
 						"--sslCAFile", "/etc/mongodb-ssl-internal/ca.crt",
@@ -544,7 +544,7 @@ func (cr *PerconaServerMongoDB) CheckNSetDefaults(ctx context.Context, platform 
 			if cr.TLSEnabled() && cr.CompareVersion("1.22.0") >= 0 {
 				var tlsArgs []string
 				// Prioritize internal certificates if configured
-				if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets.SSLInternal != "" {
+				if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets.SSLInternal != "" && cr.Spec.Secrets.SSLInternal != cr.Spec.Secrets.SSL {
 					tlsArgs = []string{
 						"--ssl", "--sslInsecure",
 						"--sslCAFile", "/etc/mongodb-ssl-internal/ca.crt",
@@ -929,7 +929,7 @@ func (nv *NonVotingSpec) SetDefaults(cr *PerconaServerMongoDB, rs *ReplsetSpec) 
 		if cr.TLSEnabled() {
 			var tlsArgs []string
 			// Prioritize internal certificates if configured
-			if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets.SSLInternal != "" {
+			if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets.SSLInternal != "" && cr.Spec.Secrets.SSLInternal != cr.Spec.Secrets.SSL {
 				tlsArgs = []string{
 					"--ssl", "--sslInsecure",
 					"--sslCAFile", "/etc/mongodb-ssl-internal/ca.crt",
@@ -972,7 +972,7 @@ func (nv *NonVotingSpec) SetDefaults(cr *PerconaServerMongoDB, rs *ReplsetSpec) 
 		if cr.TLSEnabled() && cr.CompareVersion("1.22.0") >= 0 {
 			var tlsArgs []string
 			// Prioritize internal certificates if configured
-			if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets.SSLInternal != "" {
+			if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets.SSLInternal != "" && cr.Spec.Secrets.SSLInternal != cr.Spec.Secrets.SSL {
 				tlsArgs = []string{
 					"--ssl", "--sslInsecure",
 					"--sslCAFile", "/etc/mongodb-ssl-internal/ca.crt",
@@ -1061,7 +1061,7 @@ func (h *HiddenSpec) setLivenessProbe(cr *PerconaServerMongoDB, rs *ReplsetSpec)
 		if cr.TLSEnabled() {
 			var tlsArgs []string
 			// Prioritize internal certificates if configured
-			if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets.SSLInternal != "" {
+			if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets.SSLInternal != "" && cr.Spec.Secrets.SSLInternal != cr.Spec.Secrets.SSL {
 				tlsArgs = []string{
 					"--ssl", "--sslInsecure",
 					"--sslCAFile", "/etc/mongodb-ssl-internal/ca.crt",
@@ -1103,7 +1103,7 @@ func (h *HiddenSpec) setReadinessProbe(cr *PerconaServerMongoDB, rs *ReplsetSpec
 		if cr.TLSEnabled() && cr.CompareVersion("1.22.0") >= 0 {
 			var tlsArgs []string
 			// Prioritize internal certificates if configured
-			if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets.SSLInternal != "" {
+			if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets.SSLInternal != "" && cr.Spec.Secrets.SSLInternal != cr.Spec.Secrets.SSL {
 				tlsArgs = []string{
 					"--ssl", "--sslInsecure",
 					"--sslCAFile", "/etc/mongodb-ssl-internal/ca.crt",

--- a/pkg/apis/psmdb/v1/psmdb_defaults.go
+++ b/pkg/apis/psmdb/v1/psmdb_defaults.go
@@ -251,8 +251,8 @@ func (cr *PerconaServerMongoDB) CheckNSetDefaults(ctx context.Context, platform 
 			if cr.TLSEnabled() {
 				cr.Spec.Sharding.Mongos.LivenessProbe.Exec.Command = append(cr.Spec.Sharding.Mongos.LivenessProbe.Exec.Command,
 					"--ssl", "--sslInsecure",
-					"--sslCAFile", "/etc/mongodb-ssl/ca.crt",
-					"--sslPEMKeyFile", "/tmp/tls.pem")
+					"--sslCAFile", "/etc/mongodb-ssl-internal/ca.crt",
+					"--sslPEMKeyFile", "/tmp/tls-internal.pem")
 			}
 
 			if cr.CompareVersion("1.11.0") >= 0 && !cr.Spec.Sharding.Mongos.LivenessProbe.CommandHas(startupDelaySecondsFlag) {
@@ -295,8 +295,8 @@ func (cr *PerconaServerMongoDB) CheckNSetDefaults(ctx context.Context, platform 
 			if cr.TLSEnabled() {
 				cr.Spec.Sharding.Mongos.ReadinessProbe.Exec.Command = append(cr.Spec.Sharding.Mongos.ReadinessProbe.Exec.Command,
 					"--ssl", "--sslInsecure",
-					"--sslCAFile", "/etc/mongodb-ssl/ca.crt",
-					"--sslPEMKeyFile", "/tmp/tls.pem")
+					"--sslCAFile", "/etc/mongodb-ssl-internal/ca.crt",
+					"--sslPEMKeyFile", "/tmp/tls-internal.pem")
 			}
 
 			if cr.CompareVersion("1.14.0") >= 0 {
@@ -459,8 +459,8 @@ func (cr *PerconaServerMongoDB) CheckNSetDefaults(ctx context.Context, platform 
 			if cr.TLSEnabled() {
 				replset.LivenessProbe.Probe.Exec.Command = append(replset.LivenessProbe.Probe.Exec.Command,
 					"--ssl", "--sslInsecure",
-					"--sslCAFile", "/etc/mongodb-ssl/ca.crt",
-					"--sslPEMKeyFile", "/tmp/tls.pem")
+					"--sslCAFile", "/etc/mongodb-ssl-internal/ca.crt",
+					"--sslPEMKeyFile", "/tmp/tls-internal.pem")
 			}
 
 			if cr.CompareVersion("1.4.0") >= 0 && !replset.LivenessProbe.CommandHas(startupDelaySecondsFlag) {
@@ -502,8 +502,8 @@ func (cr *PerconaServerMongoDB) CheckNSetDefaults(ctx context.Context, platform 
 			if cr.TLSEnabled() && cr.CompareVersion("1.22.0") >= 0 {
 				replset.ReadinessProbe.Exec.Command = append(replset.ReadinessProbe.Exec.Command,
 					"--ssl", "--sslInsecure",
-					"--sslCAFile", "/etc/mongodb-ssl/ca.crt",
-					"--sslPEMKeyFile", "/tmp/tls.pem")
+					"--sslCAFile", "/etc/mongodb-ssl-internal/ca.crt",
+					"--sslPEMKeyFile", "/tmp/tls-internal.pem")
 			}
 
 			if cr.CompareVersion("1.15.0") < 0 {
@@ -873,7 +873,7 @@ func (nv *NonVotingSpec) SetDefaults(cr *PerconaServerMongoDB, rs *ReplsetSpec) 
 		if cr.TLSEnabled() {
 			nv.LivenessProbe.Probe.ProbeHandler.Exec.Command = append(
 				nv.LivenessProbe.Probe.ProbeHandler.Exec.Command,
-				"--ssl", "--sslInsecure", "--sslCAFile", "/etc/mongodb-ssl/ca.crt", "--sslPEMKeyFile", "/tmp/tls.pem",
+				"--ssl", "--sslInsecure", "--sslCAFile", "/etc/mongodb-ssl-internal/ca.crt", "--sslPEMKeyFile", "/tmp/tls-internal.pem",
 			)
 		}
 
@@ -902,8 +902,8 @@ func (nv *NonVotingSpec) SetDefaults(cr *PerconaServerMongoDB, rs *ReplsetSpec) 
 		if cr.TLSEnabled() && cr.CompareVersion("1.22.0") >= 0 {
 			nv.ReadinessProbe.Exec.Command = append(nv.ReadinessProbe.Exec.Command,
 				"--ssl", "--sslInsecure",
-				"--sslCAFile", "/etc/mongodb-ssl/ca.crt",
-				"--sslPEMKeyFile", "/tmp/tls.pem")
+				"--sslCAFile", "/etc/mongodb-ssl-internal/ca.crt",
+				"--sslPEMKeyFile", "/tmp/tls-internal.pem")
 		}
 
 		if cr.CompareVersion("1.15.0") < 0 {
@@ -977,7 +977,7 @@ func (h *HiddenSpec) setLivenessProbe(cr *PerconaServerMongoDB, rs *ReplsetSpec)
 		if cr.TLSEnabled() {
 			h.LivenessProbe.Exec.Command = append(
 				h.LivenessProbe.Exec.Command,
-				"--ssl", "--sslInsecure", "--sslCAFile", "/etc/mongodb-ssl/ca.crt", "--sslPEMKeyFile", "/tmp/tls.pem",
+				"--ssl", "--sslInsecure", "--sslCAFile", "/etc/mongodb-ssl-internal/ca.crt", "--sslPEMKeyFile", "/tmp/tls-internal.pem",
 			)
 		}
 	}
@@ -1005,8 +1005,8 @@ func (h *HiddenSpec) setReadinessProbe(cr *PerconaServerMongoDB, rs *ReplsetSpec
 		if cr.CompareVersion("1.22.0") >= 0 && cr.TLSEnabled() {
 			h.ReadinessProbe.Exec.Command = append(h.ReadinessProbe.Exec.Command,
 				"--ssl", "--sslInsecure",
-				"--sslCAFile", "/etc/mongodb-ssl/ca.crt",
-				"--sslPEMKeyFile", "/tmp/tls.pem")
+				"--sslCAFile", "/etc/mongodb-ssl-internal/ca.crt",
+				"--sslPEMKeyFile", "/tmp/tls-internal.pem")
 		}
 	}
 	if h.ReadinessProbe.InitialDelaySeconds < 1 {

--- a/pkg/apis/psmdb/v1/psmdb_defaults.go
+++ b/pkg/apis/psmdb/v1/psmdb_defaults.go
@@ -251,7 +251,7 @@ func (cr *PerconaServerMongoDB) CheckNSetDefaults(ctx context.Context, platform 
 			if cr.TLSEnabled() {
 				var tlsArgs []string
 				// Prioritize internal certificates if configured
-				if cr.Spec.Secrets.SSLInternal != "" {
+				if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets.SSLInternal != "" {
 					tlsArgs = []string{
 						"--ssl", "--sslInsecure",
 						"--sslCAFile", "/etc/mongodb-ssl-internal/ca.crt",
@@ -309,7 +309,7 @@ func (cr *PerconaServerMongoDB) CheckNSetDefaults(ctx context.Context, platform 
 			if cr.TLSEnabled() {
 				var tlsArgs []string
 				// Prioritize internal certificates if configured
-				if cr.Spec.Secrets.SSLInternal != "" {
+				if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets.SSLInternal != "" {
 					tlsArgs = []string{
 						"--ssl", "--sslInsecure",
 						"--sslCAFile", "/etc/mongodb-ssl-internal/ca.crt",
@@ -483,11 +483,11 @@ func (cr *PerconaServerMongoDB) CheckNSetDefaults(ctx context.Context, platform 
 				Command: []string{"mongodb-healthcheck", "k8s", "liveness"},
 			}
 
-			replset.LivenessProbe.Probe.Exec.Command[0] = "/data/db/mongodb-healthcheck"
+			replset.LivenessProbe.Exec.Command[0] = "/data/db/mongodb-healthcheck"
 			if cr.TLSEnabled() {
 				var tlsArgs []string
 				// Prioritize internal certificates if configured
-				if cr.Spec.Secrets.SSLInternal != "" {
+				if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets.SSLInternal != "" {
 					tlsArgs = []string{
 						"--ssl", "--sslInsecure",
 						"--sslCAFile", "/etc/mongodb-ssl-internal/ca.crt",
@@ -502,7 +502,7 @@ func (cr *PerconaServerMongoDB) CheckNSetDefaults(ctx context.Context, platform 
 					}
 				}
 
-				replset.LivenessProbe.Probe.Exec.Command = append(replset.LivenessProbe.Probe.Exec.Command, tlsArgs...)
+				replset.LivenessProbe.Exec.Command = append(replset.LivenessProbe.Exec.Command, tlsArgs...)
 			}
 
 			if cr.CompareVersion("1.4.0") >= 0 && !replset.LivenessProbe.CommandHas(startupDelaySecondsFlag) {
@@ -544,7 +544,7 @@ func (cr *PerconaServerMongoDB) CheckNSetDefaults(ctx context.Context, platform 
 			if cr.TLSEnabled() {
 				var tlsArgs []string
 				// Prioritize internal certificates if configured
-				if cr.Spec.Secrets.SSLInternal != "" {
+				if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets.SSLInternal != "" {
 					tlsArgs = []string{
 						"--ssl", "--sslInsecure",
 						"--sslCAFile", "/etc/mongodb-ssl-internal/ca.crt",
@@ -929,7 +929,7 @@ func (nv *NonVotingSpec) SetDefaults(cr *PerconaServerMongoDB, rs *ReplsetSpec) 
 		if cr.TLSEnabled() {
 			var tlsArgs []string
 			// Prioritize internal certificates if configured
-			if cr.Spec.Secrets.SSLInternal != "" {
+			if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets.SSLInternal != "" {
 				tlsArgs = []string{
 					"--ssl", "--sslInsecure",
 					"--sslCAFile", "/etc/mongodb-ssl-internal/ca.crt",
@@ -944,11 +944,11 @@ func (nv *NonVotingSpec) SetDefaults(cr *PerconaServerMongoDB, rs *ReplsetSpec) 
 				}
 			}
 
-			nv.LivenessProbe.Probe.ProbeHandler.Exec.Command = append(nv.LivenessProbe.Probe.ProbeHandler.Exec.Command, tlsArgs...)
+			nv.LivenessProbe.Exec.Command = append(nv.LivenessProbe.Exec.Command, tlsArgs...)
 		}
 
 		if cr.CompareVersion("1.14.0") >= 0 {
-			nv.LivenessProbe.Probe.ProbeHandler.Exec.Command[0] = "/opt/percona/mongodb-healthcheck"
+			nv.LivenessProbe.Exec.Command[0] = "/opt/percona/mongodb-healthcheck"
 		}
 	}
 	if !nv.LivenessProbe.CommandHas(startupDelaySecondsFlag) {
@@ -972,7 +972,7 @@ func (nv *NonVotingSpec) SetDefaults(cr *PerconaServerMongoDB, rs *ReplsetSpec) 
 		if cr.TLSEnabled() {
 			var tlsArgs []string
 			// Prioritize internal certificates if configured
-			if cr.Spec.Secrets.SSLInternal != "" {
+			if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets.SSLInternal != "" {
 				tlsArgs = []string{
 					"--ssl", "--sslInsecure",
 					"--sslCAFile", "/etc/mongodb-ssl-internal/ca.crt",
@@ -1061,7 +1061,7 @@ func (h *HiddenSpec) setLivenessProbe(cr *PerconaServerMongoDB, rs *ReplsetSpec)
 		if cr.TLSEnabled() {
 			var tlsArgs []string
 			// Prioritize internal certificates if configured
-			if cr.Spec.Secrets.SSLInternal != "" {
+			if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets.SSLInternal != "" {
 				tlsArgs = []string{
 					"--ssl", "--sslInsecure",
 					"--sslCAFile", "/etc/mongodb-ssl-internal/ca.crt",
@@ -1103,7 +1103,7 @@ func (h *HiddenSpec) setReadinessProbe(cr *PerconaServerMongoDB, rs *ReplsetSpec
 		if cr.TLSEnabled() {
 			var tlsArgs []string
 			// Prioritize internal certificates if configured
-			if cr.Spec.Secrets.SSLInternal != "" {
+			if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets.SSLInternal != "" {
 				tlsArgs = []string{
 					"--ssl", "--sslInsecure",
 					"--sslCAFile", "/etc/mongodb-ssl-internal/ca.crt",

--- a/pkg/apis/psmdb/v1/psmdb_defaults.go
+++ b/pkg/apis/psmdb/v1/psmdb_defaults.go
@@ -541,7 +541,7 @@ func (cr *PerconaServerMongoDB) CheckNSetDefaults(ctx context.Context, platform 
 					"--component", "mongod",
 				},
 			}
-			if cr.TLSEnabled() {
+			if cr.TLSEnabled() && cr.CompareVersion("1.22.0") >= 0 {
 				var tlsArgs []string
 				// Prioritize internal certificates if configured
 				if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets.SSLInternal != "" && cr.Spec.Secrets.SSLInternal != cr.Spec.Secrets.SSL {
@@ -558,7 +558,6 @@ func (cr *PerconaServerMongoDB) CheckNSetDefaults(ctx context.Context, platform 
 						"--sslPEMKeyFile", "/tmp/tls.pem",
 					}
 				}
-
 				replset.ReadinessProbe.Exec.Command = append(replset.ReadinessProbe.Exec.Command, tlsArgs...)
 			}
 
@@ -969,7 +968,7 @@ func (nv *NonVotingSpec) SetDefaults(cr *PerconaServerMongoDB, rs *ReplsetSpec) 
 				"--component", "mongod",
 			},
 		}
-		if cr.TLSEnabled() {
+		if cr.TLSEnabled() && cr.CompareVersion("1.22.0") >= 0 {
 			var tlsArgs []string
 			// Prioritize internal certificates if configured
 			if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets.SSLInternal != "" && cr.Spec.Secrets.SSLInternal != cr.Spec.Secrets.SSL {
@@ -1100,7 +1099,7 @@ func (h *HiddenSpec) setReadinessProbe(cr *PerconaServerMongoDB, rs *ReplsetSpec
 				"--component", "mongod",
 			},
 		}
-		if cr.TLSEnabled() {
+		if cr.TLSEnabled() && cr.CompareVersion("1.22.0") >= 0 {
 			var tlsArgs []string
 			// Prioritize internal certificates if configured
 			if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets.SSLInternal != "" && cr.Spec.Secrets.SSLInternal != cr.Spec.Secrets.SSL {

--- a/pkg/apis/psmdb/v1/psmdb_defaults.go
+++ b/pkg/apis/psmdb/v1/psmdb_defaults.go
@@ -306,7 +306,7 @@ func (cr *PerconaServerMongoDB) CheckNSetDefaults(ctx context.Context, platform 
 				},
 			}
 
-			if cr.TLSEnabled() {
+			if cr.TLSEnabled() && cr.CompareVersion("1.22.0") >= 0 {
 				var tlsArgs []string
 				// Prioritize internal certificates if configured
 				if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets.SSLInternal != "" {
@@ -541,7 +541,7 @@ func (cr *PerconaServerMongoDB) CheckNSetDefaults(ctx context.Context, platform 
 					"--component", "mongod",
 				},
 			}
-			if cr.TLSEnabled() {
+			if cr.TLSEnabled() && cr.CompareVersion("1.22.0") >= 0 {
 				var tlsArgs []string
 				// Prioritize internal certificates if configured
 				if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets.SSLInternal != "" {
@@ -969,7 +969,7 @@ func (nv *NonVotingSpec) SetDefaults(cr *PerconaServerMongoDB, rs *ReplsetSpec) 
 				"--component", "mongod",
 			},
 		}
-		if cr.TLSEnabled() {
+		if cr.TLSEnabled() && cr.CompareVersion("1.22.0") >= 0 {
 			var tlsArgs []string
 			// Prioritize internal certificates if configured
 			if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets.SSLInternal != "" {
@@ -1100,7 +1100,7 @@ func (h *HiddenSpec) setReadinessProbe(cr *PerconaServerMongoDB, rs *ReplsetSpec
 				"--component", "mongod",
 			},
 		}
-		if cr.TLSEnabled() {
+		if cr.TLSEnabled() && cr.CompareVersion("1.22.0") >= 0 {
 			var tlsArgs []string
 			// Prioritize internal certificates if configured
 			if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets.SSLInternal != "" {

--- a/pkg/apis/psmdb/v1/psmdb_defaults.go
+++ b/pkg/apis/psmdb/v1/psmdb_defaults.go
@@ -306,7 +306,7 @@ func (cr *PerconaServerMongoDB) CheckNSetDefaults(ctx context.Context, platform 
 				},
 			}
 
-			if cr.TLSEnabled() && cr.CompareVersion("1.22.0") >= 0 {
+			if cr.TLSEnabled() {
 				var tlsArgs []string
 				// Prioritize internal certificates if configured
 				if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets.SSLInternal != "" && cr.Spec.Secrets.SSLInternal != cr.Spec.Secrets.SSL {
@@ -541,7 +541,7 @@ func (cr *PerconaServerMongoDB) CheckNSetDefaults(ctx context.Context, platform 
 					"--component", "mongod",
 				},
 			}
-			if cr.TLSEnabled() && cr.CompareVersion("1.22.0") >= 0 {
+			if cr.TLSEnabled() {
 				var tlsArgs []string
 				// Prioritize internal certificates if configured
 				if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets.SSLInternal != "" && cr.Spec.Secrets.SSLInternal != cr.Spec.Secrets.SSL {
@@ -969,7 +969,7 @@ func (nv *NonVotingSpec) SetDefaults(cr *PerconaServerMongoDB, rs *ReplsetSpec) 
 				"--component", "mongod",
 			},
 		}
-		if cr.TLSEnabled() && cr.CompareVersion("1.22.0") >= 0 {
+		if cr.TLSEnabled() {
 			var tlsArgs []string
 			// Prioritize internal certificates if configured
 			if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets.SSLInternal != "" && cr.Spec.Secrets.SSLInternal != cr.Spec.Secrets.SSL {
@@ -1100,7 +1100,7 @@ func (h *HiddenSpec) setReadinessProbe(cr *PerconaServerMongoDB, rs *ReplsetSpec
 				"--component", "mongod",
 			},
 		}
-		if cr.TLSEnabled() && cr.CompareVersion("1.22.0") >= 0 {
+		if cr.TLSEnabled() {
 			var tlsArgs []string
 			// Prioritize internal certificates if configured
 			if cr.CompareVersion("1.23.0") >= 0 && cr.Spec.Secrets.SSLInternal != "" && cr.Spec.Secrets.SSLInternal != cr.Spec.Secrets.SSL {

--- a/pkg/apis/psmdb/v1/psmdb_defaults.go
+++ b/pkg/apis/psmdb/v1/psmdb_defaults.go
@@ -249,10 +249,24 @@ func (cr *PerconaServerMongoDB) CheckNSetDefaults(ctx context.Context, platform 
 			}
 
 			if cr.TLSEnabled() {
-				cr.Spec.Sharding.Mongos.LivenessProbe.Exec.Command = append(cr.Spec.Sharding.Mongos.LivenessProbe.Exec.Command,
-					"--ssl", "--sslInsecure",
-					"--sslCAFile", "/etc/mongodb-ssl-internal/ca.crt",
-					"--sslPEMKeyFile", "/tmp/tls-internal.pem")
+				var tlsArgs []string
+				// Prioritize internal certificates if configured
+				if cr.Spec.Secrets.SSLInternal != "" {
+					tlsArgs = []string{
+						"--ssl", "--sslInsecure",
+						"--sslCAFile", "/etc/mongodb-ssl-internal/ca.crt",
+						"--sslPEMKeyFile", "/tmp/tls-internal.pem",
+					}
+				} else {
+					// Fallback to standard external certificates
+					tlsArgs = []string{
+						"--ssl", "--sslInsecure",
+						"--sslCAFile", "/etc/mongodb-ssl/ca.crt",
+						"--sslPEMKeyFile", "/tmp/tls.pem",
+					}
+				}
+
+				cr.Spec.Sharding.Mongos.LivenessProbe.Exec.Command = append(cr.Spec.Sharding.Mongos.LivenessProbe.Exec.Command, tlsArgs...)
 			}
 
 			if cr.CompareVersion("1.11.0") >= 0 && !cr.Spec.Sharding.Mongos.LivenessProbe.CommandHas(startupDelaySecondsFlag) {
@@ -293,10 +307,24 @@ func (cr *PerconaServerMongoDB) CheckNSetDefaults(ctx context.Context, platform 
 			}
 
 			if cr.TLSEnabled() {
-				cr.Spec.Sharding.Mongos.ReadinessProbe.Exec.Command = append(cr.Spec.Sharding.Mongos.ReadinessProbe.Exec.Command,
-					"--ssl", "--sslInsecure",
-					"--sslCAFile", "/etc/mongodb-ssl-internal/ca.crt",
-					"--sslPEMKeyFile", "/tmp/tls-internal.pem")
+				var tlsArgs []string
+				// Prioritize internal certificates if configured
+				if cr.Spec.Secrets.SSLInternal != "" {
+					tlsArgs = []string{
+						"--ssl", "--sslInsecure",
+						"--sslCAFile", "/etc/mongodb-ssl-internal/ca.crt",
+						"--sslPEMKeyFile", "/tmp/tls-internal.pem",
+					}
+				} else {
+					// Fallback to standard external certificates
+					tlsArgs = []string{
+						"--ssl", "--sslInsecure",
+						"--sslCAFile", "/etc/mongodb-ssl/ca.crt",
+						"--sslPEMKeyFile", "/tmp/tls.pem",
+					}
+				}
+
+				cr.Spec.Sharding.Mongos.ReadinessProbe.Exec.Command = append(cr.Spec.Sharding.Mongos.ReadinessProbe.Exec.Command, tlsArgs...)
 			}
 
 			if cr.CompareVersion("1.14.0") >= 0 {
@@ -457,10 +485,24 @@ func (cr *PerconaServerMongoDB) CheckNSetDefaults(ctx context.Context, platform 
 
 			replset.LivenessProbe.Probe.Exec.Command[0] = "/data/db/mongodb-healthcheck"
 			if cr.TLSEnabled() {
-				replset.LivenessProbe.Probe.Exec.Command = append(replset.LivenessProbe.Probe.Exec.Command,
-					"--ssl", "--sslInsecure",
-					"--sslCAFile", "/etc/mongodb-ssl-internal/ca.crt",
-					"--sslPEMKeyFile", "/tmp/tls-internal.pem")
+				var tlsArgs []string
+				// Prioritize internal certificates if configured
+				if cr.Spec.Secrets.SSLInternal != "" {
+					tlsArgs = []string{
+						"--ssl", "--sslInsecure",
+						"--sslCAFile", "/etc/mongodb-ssl-internal/ca.crt",
+						"--sslPEMKeyFile", "/tmp/tls-internal.pem",
+					}
+				} else {
+					// Fallback to standard external certificates
+					tlsArgs = []string{
+						"--ssl", "--sslInsecure",
+						"--sslCAFile", "/etc/mongodb-ssl/ca.crt",
+						"--sslPEMKeyFile", "/tmp/tls.pem",
+					}
+				}
+
+				replset.LivenessProbe.Probe.Exec.Command = append(replset.LivenessProbe.Probe.Exec.Command, tlsArgs...)
 			}
 
 			if cr.CompareVersion("1.4.0") >= 0 && !replset.LivenessProbe.CommandHas(startupDelaySecondsFlag) {
@@ -499,11 +541,25 @@ func (cr *PerconaServerMongoDB) CheckNSetDefaults(ctx context.Context, platform 
 					"--component", "mongod",
 				},
 			}
-			if cr.TLSEnabled() && cr.CompareVersion("1.22.0") >= 0 {
-				replset.ReadinessProbe.Exec.Command = append(replset.ReadinessProbe.Exec.Command,
-					"--ssl", "--sslInsecure",
-					"--sslCAFile", "/etc/mongodb-ssl-internal/ca.crt",
-					"--sslPEMKeyFile", "/tmp/tls-internal.pem")
+			if cr.TLSEnabled() {
+				var tlsArgs []string
+				// Prioritize internal certificates if configured
+				if cr.Spec.Secrets.SSLInternal != "" {
+					tlsArgs = []string{
+						"--ssl", "--sslInsecure",
+						"--sslCAFile", "/etc/mongodb-ssl-internal/ca.crt",
+						"--sslPEMKeyFile", "/tmp/tls-internal.pem",
+					}
+				} else {
+					// Fallback to standard external certificates
+					tlsArgs = []string{
+						"--ssl", "--sslInsecure",
+						"--sslCAFile", "/etc/mongodb-ssl/ca.crt",
+						"--sslPEMKeyFile", "/tmp/tls.pem",
+					}
+				}
+
+				replset.ReadinessProbe.Exec.Command = append(replset.ReadinessProbe.Exec.Command, tlsArgs...)
 			}
 
 			if cr.CompareVersion("1.15.0") < 0 {
@@ -871,10 +927,24 @@ func (nv *NonVotingSpec) SetDefaults(cr *PerconaServerMongoDB, rs *ReplsetSpec) 
 		}
 
 		if cr.TLSEnabled() {
-			nv.LivenessProbe.Probe.ProbeHandler.Exec.Command = append(
-				nv.LivenessProbe.Probe.ProbeHandler.Exec.Command,
-				"--ssl", "--sslInsecure", "--sslCAFile", "/etc/mongodb-ssl-internal/ca.crt", "--sslPEMKeyFile", "/tmp/tls-internal.pem",
-			)
+			var tlsArgs []string
+			// Prioritize internal certificates if configured
+			if cr.Spec.Secrets.SSLInternal != "" {
+				tlsArgs = []string{
+					"--ssl", "--sslInsecure",
+					"--sslCAFile", "/etc/mongodb-ssl-internal/ca.crt",
+					"--sslPEMKeyFile", "/tmp/tls-internal.pem",
+				}
+			} else {
+				// Fallback to standard external certificates
+				tlsArgs = []string{
+					"--ssl", "--sslInsecure",
+					"--sslCAFile", "/etc/mongodb-ssl/ca.crt",
+					"--sslPEMKeyFile", "/tmp/tls.pem",
+				}
+			}
+
+			nv.LivenessProbe.Probe.ProbeHandler.Exec.Command = append(nv.LivenessProbe.Probe.ProbeHandler.Exec.Command, tlsArgs...)
 		}
 
 		if cr.CompareVersion("1.14.0") >= 0 {
@@ -899,11 +969,25 @@ func (nv *NonVotingSpec) SetDefaults(cr *PerconaServerMongoDB, rs *ReplsetSpec) 
 				"--component", "mongod",
 			},
 		}
-		if cr.TLSEnabled() && cr.CompareVersion("1.22.0") >= 0 {
-			nv.ReadinessProbe.Exec.Command = append(nv.ReadinessProbe.Exec.Command,
-				"--ssl", "--sslInsecure",
-				"--sslCAFile", "/etc/mongodb-ssl-internal/ca.crt",
-				"--sslPEMKeyFile", "/tmp/tls-internal.pem")
+		if cr.TLSEnabled() {
+			var tlsArgs []string
+			// Prioritize internal certificates if configured
+			if cr.Spec.Secrets.SSLInternal != "" {
+				tlsArgs = []string{
+					"--ssl", "--sslInsecure",
+					"--sslCAFile", "/etc/mongodb-ssl-internal/ca.crt",
+					"--sslPEMKeyFile", "/tmp/tls-internal.pem",
+				}
+			} else {
+				// Fallback to standard external certificates
+				tlsArgs = []string{
+					"--ssl", "--sslInsecure",
+					"--sslCAFile", "/etc/mongodb-ssl/ca.crt",
+					"--sslPEMKeyFile", "/tmp/tls.pem",
+				}
+			}
+
+			nv.ReadinessProbe.Exec.Command = append(nv.ReadinessProbe.Exec.Command, tlsArgs...)
 		}
 
 		if cr.CompareVersion("1.15.0") < 0 {
@@ -975,10 +1059,24 @@ func (h *HiddenSpec) setLivenessProbe(cr *PerconaServerMongoDB, rs *ReplsetSpec)
 		}
 
 		if cr.TLSEnabled() {
-			h.LivenessProbe.Exec.Command = append(
-				h.LivenessProbe.Exec.Command,
-				"--ssl", "--sslInsecure", "--sslCAFile", "/etc/mongodb-ssl-internal/ca.crt", "--sslPEMKeyFile", "/tmp/tls-internal.pem",
-			)
+			var tlsArgs []string
+			// Prioritize internal certificates if configured
+			if cr.Spec.Secrets.SSLInternal != "" {
+				tlsArgs = []string{
+					"--ssl", "--sslInsecure",
+					"--sslCAFile", "/etc/mongodb-ssl-internal/ca.crt",
+					"--sslPEMKeyFile", "/tmp/tls-internal.pem",
+				}
+			} else {
+				// Fallback to standard external certificates
+				tlsArgs = []string{
+					"--ssl", "--sslInsecure",
+					"--sslCAFile", "/etc/mongodb-ssl/ca.crt",
+					"--sslPEMKeyFile", "/tmp/tls.pem",
+				}
+			}
+
+			h.LivenessProbe.Exec.Command = append(h.LivenessProbe.Exec.Command, tlsArgs...)
 		}
 	}
 	startupDelaySecondsFlag := "--startupDelaySeconds"
@@ -1002,11 +1100,25 @@ func (h *HiddenSpec) setReadinessProbe(cr *PerconaServerMongoDB, rs *ReplsetSpec
 				"--component", "mongod",
 			},
 		}
-		if cr.CompareVersion("1.22.0") >= 0 && cr.TLSEnabled() {
-			h.ReadinessProbe.Exec.Command = append(h.ReadinessProbe.Exec.Command,
-				"--ssl", "--sslInsecure",
-				"--sslCAFile", "/etc/mongodb-ssl-internal/ca.crt",
-				"--sslPEMKeyFile", "/tmp/tls-internal.pem")
+		if cr.TLSEnabled() {
+			var tlsArgs []string
+			// Prioritize internal certificates if configured
+			if cr.Spec.Secrets.SSLInternal != "" {
+				tlsArgs = []string{
+					"--ssl", "--sslInsecure",
+					"--sslCAFile", "/etc/mongodb-ssl-internal/ca.crt",
+					"--sslPEMKeyFile", "/tmp/tls-internal.pem",
+				}
+			} else {
+				// Fallback to standard external certificates
+				tlsArgs = []string{
+					"--ssl", "--sslInsecure",
+					"--sslCAFile", "/etc/mongodb-ssl/ca.crt",
+					"--sslPEMKeyFile", "/tmp/tls.pem",
+				}
+			}
+
+			h.ReadinessProbe.Exec.Command = append(h.ReadinessProbe.Exec.Command, tlsArgs...)
 		}
 	}
 	if h.ReadinessProbe.InitialDelaySeconds < 1 {

--- a/pkg/controller/perconaservermongodb/testdata/reconcile-statefulset/cfg-arbiter.yaml
+++ b/pkg/controller/perconaservermongodb/testdata/reconcile-statefulset/cfg-arbiter.yaml
@@ -105,9 +105,9 @@ spec:
             - --ssl
             - --sslInsecure
             - --sslCAFile
-            - /etc/mongodb-ssl/ca.crt
+            - /etc/mongodb-ssl-internal/ca.crt
             - --sslPEMKeyFile
-            - /tmp/tls.pem
+            - /tmp/tls-internal.pem
             - --startupDelaySeconds
             - "7200"
           failureThreshold: 4
@@ -129,9 +129,9 @@ spec:
             - --ssl
             - --sslInsecure
             - --sslCAFile
-            - /etc/mongodb-ssl/ca.crt
+            - /etc/mongodb-ssl-internal/ca.crt
             - --sslPEMKeyFile
-            - /tmp/tls.pem
+            - /tmp/tls-internal.pem
           failureThreshold: 3
           initialDelaySeconds: 10
           periodSeconds: 3

--- a/pkg/controller/perconaservermongodb/testdata/reconcile-statefulset/cfg-hidden.yaml
+++ b/pkg/controller/perconaservermongodb/testdata/reconcile-statefulset/cfg-hidden.yaml
@@ -105,9 +105,9 @@ spec:
             - --ssl
             - --sslInsecure
             - --sslCAFile
-            - /etc/mongodb-ssl/ca.crt
+            - /etc/mongodb-ssl-internal/ca.crt
             - --sslPEMKeyFile
-            - /tmp/tls.pem
+            - /tmp/tls-internal.pem
             - --startupDelaySeconds
             - "7200"
           failureThreshold: 4
@@ -129,9 +129,9 @@ spec:
             - --ssl
             - --sslInsecure
             - --sslCAFile
-            - /etc/mongodb-ssl/ca.crt
+            - /etc/mongodb-ssl-internal/ca.crt
             - --sslPEMKeyFile
-            - /tmp/tls.pem
+            - /tmp/tls-internal.pem
           failureThreshold: 3
           initialDelaySeconds: 10
           periodSeconds: 3

--- a/pkg/controller/perconaservermongodb/testdata/reconcile-statefulset/cfg-mongod.yaml
+++ b/pkg/controller/perconaservermongodb/testdata/reconcile-statefulset/cfg-mongod.yaml
@@ -105,9 +105,9 @@ spec:
             - --ssl
             - --sslInsecure
             - --sslCAFile
-            - /etc/mongodb-ssl/ca.crt
+            - /etc/mongodb-ssl-internal/ca.crt
             - --sslPEMKeyFile
-            - /tmp/tls.pem
+            - /tmp/tls-internal.pem
             - --startupDelaySeconds
             - "7200"
           failureThreshold: 4
@@ -129,9 +129,9 @@ spec:
             - --ssl
             - --sslInsecure
             - --sslCAFile
-            - /etc/mongodb-ssl/ca.crt
+            - /etc/mongodb-ssl-internal/ca.crt
             - --sslPEMKeyFile
-            - /tmp/tls.pem
+            - /tmp/tls-internal.pem
           failureThreshold: 3
           initialDelaySeconds: 10
           periodSeconds: 3

--- a/pkg/controller/perconaservermongodb/testdata/reconcile-statefulset/cfg-nv.yaml
+++ b/pkg/controller/perconaservermongodb/testdata/reconcile-statefulset/cfg-nv.yaml
@@ -105,9 +105,9 @@ spec:
             - --ssl
             - --sslInsecure
             - --sslCAFile
-            - /etc/mongodb-ssl/ca.crt
+            - /etc/mongodb-ssl-internal/ca.crt
             - --sslPEMKeyFile
-            - /tmp/tls.pem
+            - /tmp/tls-internal.pem
             - --startupDelaySeconds
             - "7200"
           failureThreshold: 4
@@ -129,9 +129,9 @@ spec:
             - --ssl
             - --sslInsecure
             - --sslCAFile
-            - /etc/mongodb-ssl/ca.crt
+            - /etc/mongodb-ssl-internal/ca.crt
             - --sslPEMKeyFile
-            - /tmp/tls.pem
+            - /tmp/tls-internal.pem
           failureThreshold: 3
           initialDelaySeconds: 10
           periodSeconds: 3

--- a/pkg/controller/perconaservermongodb/testdata/reconcile-statefulset/rs0-arbiter.yaml
+++ b/pkg/controller/perconaservermongodb/testdata/reconcile-statefulset/rs0-arbiter.yaml
@@ -105,9 +105,9 @@ spec:
             - --ssl
             - --sslInsecure
             - --sslCAFile
-            - /etc/mongodb-ssl/ca.crt
+            - /etc/mongodb-ssl-internal/ca.crt
             - --sslPEMKeyFile
-            - /tmp/tls.pem
+            - /tmp/tls-internal.pem
             - --startupDelaySeconds
             - "7200"
           failureThreshold: 4
@@ -129,9 +129,9 @@ spec:
             - --ssl
             - --sslInsecure
             - --sslCAFile
-            - /etc/mongodb-ssl/ca.crt
+            - /etc/mongodb-ssl-internal/ca.crt
             - --sslPEMKeyFile
-            - /tmp/tls.pem
+            - /tmp/tls-internal.pem
           failureThreshold: 8
           initialDelaySeconds: 10
           periodSeconds: 3

--- a/pkg/controller/perconaservermongodb/testdata/reconcile-statefulset/rs0-hidden.yaml
+++ b/pkg/controller/perconaservermongodb/testdata/reconcile-statefulset/rs0-hidden.yaml
@@ -105,9 +105,9 @@ spec:
             - --ssl
             - --sslInsecure
             - --sslCAFile
-            - /etc/mongodb-ssl/ca.crt
+            - /etc/mongodb-ssl-internal/ca.crt
             - --sslPEMKeyFile
-            - /tmp/tls.pem
+            - /tmp/tls-internal.pem
             - --startupDelaySeconds
             - "7200"
           failureThreshold: 4
@@ -129,9 +129,9 @@ spec:
             - --ssl
             - --sslInsecure
             - --sslCAFile
-            - /etc/mongodb-ssl/ca.crt
+            - /etc/mongodb-ssl-internal/ca.crt
             - --sslPEMKeyFile
-            - /tmp/tls.pem
+            - /tmp/tls-internal.pem
           failureThreshold: 8
           initialDelaySeconds: 10
           periodSeconds: 3

--- a/pkg/controller/perconaservermongodb/testdata/reconcile-statefulset/rs0-logrotate.yaml
+++ b/pkg/controller/perconaservermongodb/testdata/reconcile-statefulset/rs0-logrotate.yaml
@@ -105,9 +105,9 @@ spec:
             - --ssl
             - --sslInsecure
             - --sslCAFile
-            - /etc/mongodb-ssl/ca.crt
+            - /etc/mongodb-ssl-internal/ca.crt
             - --sslPEMKeyFile
-            - /tmp/tls.pem
+            - /tmp/tls-internal.pem
             - --startupDelaySeconds
             - "7200"
           failureThreshold: 4
@@ -129,9 +129,9 @@ spec:
             - --ssl
             - --sslInsecure
             - --sslCAFile
-            - /etc/mongodb-ssl/ca.crt
+            - /etc/mongodb-ssl-internal/ca.crt
             - --sslPEMKeyFile
-            - /tmp/tls.pem
+            - /tmp/tls-internal.pem
           failureThreshold: 8
           initialDelaySeconds: 10
           periodSeconds: 3

--- a/pkg/controller/perconaservermongodb/testdata/reconcile-statefulset/rs0-mongod.yaml
+++ b/pkg/controller/perconaservermongodb/testdata/reconcile-statefulset/rs0-mongod.yaml
@@ -105,9 +105,9 @@ spec:
             - --ssl
             - --sslInsecure
             - --sslCAFile
-            - /etc/mongodb-ssl/ca.crt
+            - /etc/mongodb-ssl-internal/ca.crt
             - --sslPEMKeyFile
-            - /tmp/tls.pem
+            - /tmp/tls-internal.pem
             - --startupDelaySeconds
             - "7200"
           failureThreshold: 4
@@ -129,9 +129,9 @@ spec:
             - --ssl
             - --sslInsecure
             - --sslCAFile
-            - /etc/mongodb-ssl/ca.crt
+            - /etc/mongodb-ssl-internal/ca.crt
             - --sslPEMKeyFile
-            - /tmp/tls.pem
+            - /tmp/tls-internal.pem
           failureThreshold: 8
           initialDelaySeconds: 10
           periodSeconds: 3

--- a/pkg/controller/perconaservermongodb/testdata/reconcile-statefulset/rs0-nv.yaml
+++ b/pkg/controller/perconaservermongodb/testdata/reconcile-statefulset/rs0-nv.yaml
@@ -105,9 +105,9 @@ spec:
             - --ssl
             - --sslInsecure
             - --sslCAFile
-            - /etc/mongodb-ssl/ca.crt
+            - /etc/mongodb-ssl-internal/ca.crt
             - --sslPEMKeyFile
-            - /tmp/tls.pem
+            - /tmp/tls-internal.pem
             - --startupDelaySeconds
             - "7200"
           failureThreshold: 4
@@ -129,9 +129,9 @@ spec:
             - --ssl
             - --sslInsecure
             - --sslCAFile
-            - /etc/mongodb-ssl/ca.crt
+            - /etc/mongodb-ssl-internal/ca.crt
             - --sslPEMKeyFile
-            - /tmp/tls.pem
+            - /tmp/tls-internal.pem
           failureThreshold: 8
           initialDelaySeconds: 10
           periodSeconds: 3


### PR DESCRIPTION
Fixes Issue: https://github.com/percona/percona-server-mongodb-operator/issues/2310

Description of the Problem:
When deploying a Percona Server for MongoDB cluster using an externally signed certificate (e.g., Let's Encrypt via cert-manager) for the ssl secret, the cluster fails to bootstrap and pods get permanently stuck in a Pending or non-Ready state.

This occurs because certificates issued by public authorities explicitly lack the Client Authentication flag (TLS Web Client Authentication EKU). Because the operator's liveness and readiness probes hardcoded the mongodb-healthcheck binary to use the external certificate, mongod rejects the connection, preventing rs.initiate() from ever being called.

Proposed Changes:

Modified the probe generation logic to prioritize using the internal certificate (sslInternal) for local healthchecks instead of assuming the external certificate is capable of client authentication.

Updated the --sslCAFile and --sslPEMKeyFile arguments to target /etc/mongodb-ssl-internal/ca.crt and /tmp/tls-internal.pem.

Applied this fix universally across all 8 probe generation blocks, encompassing Mongos, standard Replset members, NonVoting members, and Hidden nodes to ensure consistency across all supported cluster topologies.

How to Test:

Deploy the operator locally using a test cluster (e.g., kind).

Apply a PerconaServerMongoDB custom resource configured with a dummy external TLS secret.

Run kubectl describe pod <mongod-pod-name> and verify that the Liveness and Readiness probe Exec actions correctly append the -internal paths for the TLS arguments.