### PR TITLE
K8SPSMDB-1610 clustersync fix for multiple crs when finalized

### DIFF
--- a/pkg/controller/perconaservermongodbclustersync/psmdb_clustersync_controller.go
+++ b/pkg/controller/perconaservermongodbclustersync/psmdb_clustersync_controller.go
@@ -107,8 +107,10 @@ func (r *ReconcilePerconaServerMongoDBClusterSync) Reconcile(ctx context.Context
 	if !cr.DeletionTimestamp.IsZero() {
 		return r.handleDeletion(ctx, cr)
 	}
-	
-	if cr.Status.State == psmdbv1.ClusterSyncStateFinalized {
+
+	// Gate on spec.Mode so a new CR inheriting finalized state from a
+	// previous sync on the same target doesn't short-circuit.
+	if cr.Spec.Mode == psmdbv1.ClusterSyncModeFinalized && cr.Status.State == psmdbv1.ClusterSyncStateFinalized {
 		if err := r.releaseClusterSyncLease(ctx, cr); err != nil {
 			return reconcile.Result{}, errors.Wrap(err, "release clustersync lease after finalize")
 		}
@@ -194,11 +196,10 @@ func (r *ReconcilePerconaServerMongoDBClusterSync) Reconcile(ctx context.Context
 		return reconcile.Result{}, errors.Wrap(err, "reconcile mode")
 	}
 
-	// PCSM has stopped replicating; the cluster is free again. We keep
-	// the finalizer (released on CR delete) but drop the lease so
-	// backups/restores can proceed without waiting for the user to
-	// delete the CR.
-	if cr.Status.State == psmdbv1.ClusterSyncStateFinalized {
+	// Drop the lease once the user-requested finalize completes so
+	// backups/restores don't wait on CR deletion. Same gate as the
+	// early-exit above.
+	if cr.Spec.Mode == psmdbv1.ClusterSyncModeFinalized && cr.Status.State == psmdbv1.ClusterSyncStateFinalized {
 		if err := r.releaseClusterSyncLease(ctx, cr); err != nil {
 			return reconcile.Result{}, errors.Wrap(err, "release clustersync lease after finalize")
 		}
@@ -413,6 +414,18 @@ func (r *ReconcilePerconaServerMongoDBClusterSync) reconcileMode(ctx context.Con
 		log.Error(statusErr, "pcsm status failed")
 	} else {
 		applyObservedStatus(newStatus, observed)
+	}
+
+	// StartedAt==nil + observed finalized means the state belongs to a
+	// previous sync on the same target — PCSM persists lifecycle state
+	// on the target cluster. Surface, don't keep retrying /start.
+	if newStatus.State == psmdbv1.ClusterSyncStateFinalized &&
+		newStatus.StartedAt == nil &&
+		cr.Spec.Mode != psmdbv1.ClusterSyncModeFinalized {
+		newStatus.Error = "PCSM reports state=finalized inherited from a previous ClusterSync against this target; PCSM lifecycle state must be reset on the target cluster before a new ClusterSync can start"
+		r.recorder.Eventf(cr, corev1.EventTypeWarning, "PCSMTargetAlreadyFinalized",
+			"target cluster %q has PCSM state=finalized from a previous ClusterSync; reset PCSM state on the target before starting a new sync", cr.Spec.ClusterName)
+		return r.writeStatus(ctx, cr, *newStatus)
 	}
 
 	action, mirror := nextAction(newStatus.Mode, cr.Spec.Mode, newStatus.State, newStatus.StartedAt != nil)

--- a/pkg/controller/perconaservermongodbclustersync/psmdb_clustersync_controller_test.go
+++ b/pkg/controller/perconaservermongodbclustersync/psmdb_clustersync_controller_test.go
@@ -13,6 +13,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	psmdbv1 "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
 )
@@ -230,6 +233,77 @@ func TestInvokeAction(t *testing.T) {
 			require.NoError(t, err)
 			if tc.assert != nil {
 				tc.assert(t, f)
+			}
+		})
+	}
+}
+
+func TestReconcileModeTargetAlreadyFinalized(t *testing.T) {
+	tests := map[string]struct {
+		spec        psmdbv1.PerconaServerMongoDBClusterSyncSpec
+		status      psmdbv1.PerconaServerMongoDBClusterSyncStatus
+		observed    client.Status
+		wantErrSubs string
+		wantEvent   bool
+	}{
+		"new CR inherits finalized from a previous sync on this target: surfaces conflict, no action": {
+			spec: psmdbv1.PerconaServerMongoDBClusterSyncSpec{
+				ClusterName: "tgt",
+				Mode:        psmdbv1.ClusterSyncModeRunning,
+			},
+			observed:    client.Status{State: "finalized", LagTimeSeconds: 297},
+			wantErrSubs: "inherited from a previous ClusterSync",
+			wantEvent:   true,
+		},
+		"intentional finalize from running: no inherited-state error, normal flow": {
+			spec: psmdbv1.PerconaServerMongoDBClusterSyncSpec{
+				ClusterName: "tgt",
+				Mode:        psmdbv1.ClusterSyncModeFinalized,
+			},
+			status: psmdbv1.PerconaServerMongoDBClusterSyncStatus{
+				Mode:      psmdbv1.ClusterSyncModeRunning,
+				StartedAt: &metav1.Time{Time: time.Now().Add(-time.Hour)},
+			},
+			observed: client.Status{State: "finalized"},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			cr := &psmdbv1.PerconaServerMongoDBClusterSync{
+				ObjectMeta: metav1.ObjectMeta{Name: "sync3", Namespace: "ns", UID: "u"},
+				Spec:       tc.spec,
+				Status:     tc.status,
+			}
+			cl := fake.NewClientBuilder().
+				WithScheme(clusterSyncScheme(t)).
+				WithStatusSubresource(cr).
+				WithObjects(cr).
+				Build()
+			rec := record.NewFakeRecorder(4)
+			r := &ReconcilePerconaServerMongoDBClusterSync{client: cl, recorder: rec}
+
+			f := &fakePCSM{statusResp: tc.observed}
+
+			err := r.reconcileMode(context.Background(), cr, f)
+			require.NoError(t, err)
+
+			got := &psmdbv1.PerconaServerMongoDBClusterSync{}
+			require.NoError(t, cl.Get(context.Background(), types.NamespacedName{Name: cr.Name, Namespace: cr.Namespace}, got))
+
+			if tc.wantErrSubs != "" {
+				assert.Contains(t, got.Status.Error, tc.wantErrSubs)
+				assert.Nil(t, f.started, "should not have issued /start while target already finalized")
+				assert.Zero(t, f.finalized, "should not have issued /finalize either")
+			} else {
+				assert.NotContains(t, got.Status.Error, "inherited from a previous ClusterSync")
+			}
+
+			select {
+			case ev := <-rec.Events:
+				assert.True(t, tc.wantEvent, "did not expect a recorded event, got %q", ev)
+			default:
+				assert.False(t, tc.wantEvent, "expected a recorded event")
 			}
 		})
 	}


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**

## Problem

  Applying a new `PerconaServerMongoDBClusterSync` against a target cluster that had a previously finalized ClusterSync leaves the new CR stuck in `state: finalized` with no path forward.

  PCSM persists its lifecycle state on the target cluster. When a fresh CR's PCSM deployment starts up, its first `pcsm status` call returns the finalized state inherited from the previous sync. The reconciler then early-exits because `cr.Status.State == finalized`, even though the user's `spec.Mode` is `running`. The lease is released, no actions are taken, the CR sits idle.
  
  ## Fix

  - Gate the "finalize complete" early-exit and lease release on `cr.Spec.Mode == Finalized`, not on observed state alone. Observed state can come from a previous sync; spec is
  the user's actual intent.
  - In `reconcileMode`, detect the inherited-finalized case (`State == Finalized`, `StartedAt == nil`, spec is not Finalized) and surface a clear `status.Error` plus a `PCSMTargetAlreadyFinalized` event, instead of silently re-issuing `pcsm start` on a PCSM that will not budge.


**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
