### PR TITLE
K8SPSMDB-1710: inject writable /tmp for mongod and backup agent with readOnlyRootFilesystem

### DIFF
--- a/e2e-tests/security-context/compare/statefulset_sec-context-rs0-changed.yml
+++ b/e2e-tests/security-context/compare/statefulset_sec-context-rs0-changed.yml
@@ -124,6 +124,7 @@ spec:
               memory: 100M
           securityContext:
             privileged: false
+            readOnlyRootFilesystem: true
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           volumeMounts:
@@ -146,6 +147,8 @@ spec:
               readOnly: true
             - mountPath: /etc/users-secret
               name: users-secret-file
+            - mountPath: /tmp
+              name: tmp
           workingDir: /data/db
         - args:
             - pbm-agent-entrypoint
@@ -186,6 +189,7 @@ spec:
           resources: {}
           securityContext:
             privileged: false
+            readOnlyRootFilesystem: true
             runAsNonRoot: true
             runAsUser: 1001
           terminationMessagePath: /dev/termination-log
@@ -199,6 +203,8 @@ spec:
               readOnly: true
             - mountPath: /data/db
               name: mongod-data
+            - mountPath: /tmp
+              name: tmp
       dnsPolicy: ClusterFirst
       initContainers:
         - command:
@@ -235,6 +241,8 @@ spec:
           name: bin
         - emptyDir: {}
           name: mongosh
+        - emptyDir: {}
+          name: tmp
         - configMap:
             defaultMode: 420
             name: sec-context-rs0-mongod

--- a/e2e-tests/security-context/conf/sec-context-rs0-changed.yml
+++ b/e2e-tests/security-context/conf/sec-context-rs0-changed.yml
@@ -52,6 +52,7 @@ spec:
             prefixCompression: true
     containerSecurityContext:
       privileged: false
+      readOnlyRootFilesystem: true
     podSecurityContext:
       fsGroup: 1001
       supplementalGroups: [1001, 1003]
@@ -62,6 +63,7 @@ spec:
       privileged: false
       runAsNonRoot: true
       runAsUser: 1001
+      readOnlyRootFilesystem: true
     podSecurityContext:
       fsGroup: 1001
       supplementalGroups: [1001, 1002, 1003]

--- a/pkg/psmdb/container.go
+++ b/pkg/psmdb/container.go
@@ -140,6 +140,16 @@ func container(ctx context.Context, cr *api.PerconaServerMongoDB, params contain
 		})
 	}
 
+	// mongod requires a writable /tmp (WiredTiger temp/sort-spill files) when
+	// the root filesystem is read-only. The matching emptyDir volume is added
+	// to the pod spec in StatefulSpec.
+	if cr.CompareVersion("1.23.0") >= 0 && readOnlyRootFilesystemEnabled(containerSecurityContext) {
+		volumes = append(volumes, corev1.VolumeMount{
+			Name:      tmpVolumeName,
+			MountPath: tmpMountPath,
+		})
+	}
+
 	rsName := replset.Name
 	if name, err := replset.CustomReplsetName(); err == nil {
 		rsName = name

--- a/pkg/psmdb/statefulset.go
+++ b/pkg/psmdb/statefulset.go
@@ -58,13 +58,17 @@ func readOnlyRootFilesystemEnabled(sc *corev1.SecurityContext) bool {
 // needsTmpVolume reports whether a shared writable /tmp emptyDir must be added
 // to the pod because the mongod or backup agent container runs with a read-only
 // root filesystem.
-func needsTmpVolume(cr *api.PerconaServerMongoDB, containerSecurityContext *corev1.SecurityContext) bool {
+func needsTmpVolume(cr *api.PerconaServerMongoDB, mongodSecurityContext *corev1.SecurityContext) bool {
 	if cr.CompareVersion("1.23.0") < 0 {
 		return false
 	}
-	if readOnlyRootFilesystemEnabled(containerSecurityContext) {
+	// mongod needs a writable /tmp whenever its own root filesystem is read-only,
+	// regardless of whether the backup agent is running.
+	if readOnlyRootFilesystemEnabled(mongodSecurityContext) {
 		return true
 	}
+	// Otherwise the shared volume is only needed for an enabled backup agent that
+	// runs with a read-only root filesystem.
 	return cr.Spec.Backup.Enabled && readOnlyRootFilesystemEnabled(cr.Spec.Backup.ContainerSecurityContext)
 }
 

--- a/pkg/psmdb/statefulset.go
+++ b/pkg/psmdb/statefulset.go
@@ -40,6 +40,34 @@ func NewStatefulSet(name, namespace string) *appsv1.StatefulSet {
 
 var secretFileMode int32 = 288
 
+// tmpVolumeName and tmpMountPath define the writable /tmp emptyDir that is
+// injected into containers running with readOnlyRootFilesystem enabled. mongod
+// (WiredTiger temp/sort-spill files) and the backup agent (pbm-entry.sh writes
+// /tmp/tls.pem) both require a writable /tmp at runtime.
+const (
+	tmpVolumeName = "tmp"
+	tmpMountPath  = "/tmp"
+)
+
+// readOnlyRootFilesystemEnabled reports whether the given container security
+// context requests a read-only root filesystem.
+func readOnlyRootFilesystemEnabled(sc *corev1.SecurityContext) bool {
+	return sc != nil && sc.ReadOnlyRootFilesystem != nil && *sc.ReadOnlyRootFilesystem
+}
+
+// needsTmpVolume reports whether a shared writable /tmp emptyDir must be added
+// to the pod because the mongod or backup agent container runs with a read-only
+// root filesystem.
+func needsTmpVolume(cr *api.PerconaServerMongoDB, containerSecurityContext *corev1.SecurityContext) bool {
+	if cr.CompareVersion("1.23.0") < 0 {
+		return false
+	}
+	if readOnlyRootFilesystemEnabled(containerSecurityContext) {
+		return true
+	}
+	return cr.Spec.Backup.Enabled && readOnlyRootFilesystemEnabled(cr.Spec.Backup.ContainerSecurityContext)
+}
+
 // StatefulSpecSecretParams contains secrets params for the StatefulSpec.
 type StatefulSpecSecretParams struct {
 	UsersSecret   *corev1.Secret
@@ -165,6 +193,18 @@ func StatefulSpec(ctx context.Context, cr *api.PerconaServerMongoDB, replset *ap
 	if cr.CompareVersion("1.21.0") >= 0 {
 		volumes = append(volumes, corev1.Volume{
 			Name: config.MongoshHomeVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		})
+	}
+
+	// When readOnlyRootFilesystem is enabled on the mongod or backup agent
+	// container, the pod needs a shared writable /tmp emptyDir. The matching
+	// volumeMounts are added to the respective containers below.
+	if needsTmpVolume(cr, containerSecurityContext) {
+		volumes = append(volumes, corev1.Volume{
+			Name: tmpVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
@@ -517,6 +557,12 @@ func backupAgentContainer(ctx context.Context, cr *api.PerconaServerMongoDB, rep
 	}
 	if len(cr.Spec.Backup.VolumeMounts) > 0 {
 		volumeMounts = append(volumeMounts, cr.Spec.Backup.VolumeMounts...)
+	}
+	if cr.CompareVersion("1.23.0") >= 0 && readOnlyRootFilesystemEnabled(cr.Spec.Backup.ContainerSecurityContext) {
+		volumeMounts = append(volumeMounts, corev1.VolumeMount{
+			Name:      tmpVolumeName,
+			MountPath: tmpMountPath,
+		})
 	}
 	if attachHookScript {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{

--- a/pkg/psmdb/statefulset_test.go
+++ b/pkg/psmdb/statefulset_test.go
@@ -376,3 +376,211 @@ func TestBackupAgentContainerProbes(t *testing.T) {
 		})
 	}
 }
+
+func rorfsSecurityContext(enabled bool) *corev1.SecurityContext {
+	return &corev1.SecurityContext{ReadOnlyRootFilesystem: &enabled}
+}
+
+func TestReadOnlyRootFilesystemEnabled(t *testing.T) {
+	tests := []struct {
+		name string
+		sc   *corev1.SecurityContext
+		want bool
+	}{
+		{name: "nil context", sc: nil, want: false},
+		{name: "nil flag", sc: &corev1.SecurityContext{}, want: false},
+		{name: "explicitly false", sc: rorfsSecurityContext(false), want: false},
+		{name: "explicitly true", sc: rorfsSecurityContext(true), want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, readOnlyRootFilesystemEnabled(tt.sc))
+		})
+	}
+}
+
+func TestNeedsTmpVolume(t *testing.T) {
+	newCR := func(setup func(cr *api.PerconaServerMongoDB)) *api.PerconaServerMongoDB {
+		cr := &api.PerconaServerMongoDB{
+			Spec: api.PerconaServerMongoDBSpec{
+				CRVersion: version.Version(),
+			},
+		}
+		setup(cr)
+		return cr
+	}
+
+	tests := []struct {
+		name     string
+		cr       *api.PerconaServerMongoDB
+		mongodSC *corev1.SecurityContext
+		want     bool
+	}{
+		{
+			name:     "no readOnlyRootFilesystem anywhere",
+			cr:       newCR(func(*api.PerconaServerMongoDB) {}),
+			mongodSC: nil,
+			want:     false,
+		},
+		{
+			name:     "mongod readOnlyRootFilesystem",
+			cr:       newCR(func(*api.PerconaServerMongoDB) {}),
+			mongodSC: rorfsSecurityContext(true),
+			want:     true,
+		},
+		{
+			name: "backup agent readOnlyRootFilesystem with backup enabled",
+			cr: newCR(func(cr *api.PerconaServerMongoDB) {
+				cr.Spec.Backup.Enabled = true
+				cr.Spec.Backup.ContainerSecurityContext = rorfsSecurityContext(true)
+			}),
+			mongodSC: nil,
+			want:     true,
+		},
+		{
+			name: "backup agent readOnlyRootFilesystem but backup disabled",
+			cr: newCR(func(cr *api.PerconaServerMongoDB) {
+				cr.Spec.Backup.Enabled = false
+				cr.Spec.Backup.ContainerSecurityContext = rorfsSecurityContext(true)
+			}),
+			mongodSC: nil,
+			want:     false,
+		},
+		{
+			name: "mongod readOnlyRootFilesystem ignored on <1.23.0",
+			cr: newCR(func(cr *api.PerconaServerMongoDB) {
+				cr.Spec.CRVersion = "1.22.0"
+			}),
+			mongodSC: rorfsSecurityContext(true),
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, needsTmpVolume(tt.cr, tt.mongodSC))
+		})
+	}
+}
+
+func TestContainerReadOnlyRootFilesystemTmpMount(t *testing.T) {
+	allowInvalidCerts := true
+	tmpMount := corev1.VolumeMount{Name: tmpVolumeName, MountPath: tmpMountPath}
+
+	newCR := func(crVersion string) *api.PerconaServerMongoDB {
+		return &api.PerconaServerMongoDB{
+			Spec: api.PerconaServerMongoDBSpec{
+				CRVersion: crVersion,
+				Secrets:   &api.SecretsSpec{Users: "some-users"},
+				TLS: &api.TLSSpec{
+					Mode:                     api.TLSModePrefer,
+					AllowInvalidCertificates: &allowInvalidCerts,
+				},
+			},
+		}
+	}
+
+	newParams := func(sc *corev1.SecurityContext) containerFnParams {
+		return containerFnParams{
+			replset: &api.ReplsetSpec{
+				Name:    "rs0",
+				Storage: &api.MongodSpecStorage{},
+			},
+			name:                     naming.ContainerMongod,
+			livenessProbe:            &api.LivenessProbeExtended{},
+			containerSecurityContext: sc,
+		}
+	}
+
+	tests := []struct {
+		name      string
+		crVersion string
+		sc        *corev1.SecurityContext
+		wantMount bool
+	}{
+		{name: "no security context", crVersion: version.Version(), sc: nil, wantMount: false},
+		{name: "readOnlyRootFilesystem false", crVersion: version.Version(), sc: rorfsSecurityContext(false), wantMount: false},
+		{name: "readOnlyRootFilesystem true", crVersion: version.Version(), sc: rorfsSecurityContext(true), wantMount: true},
+		{name: "readOnlyRootFilesystem true ignored on <1.23.0", crVersion: "1.22.0", sc: rorfsSecurityContext(true), wantMount: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := container(context.Background(), newCR(tt.crVersion), newParams(tt.sc))
+			require.NoError(t, err)
+
+			if tt.wantMount {
+				assert.Contains(t, c.VolumeMounts, tmpMount)
+			} else {
+				assert.NotContains(t, c.VolumeMounts, tmpMount)
+			}
+		})
+	}
+}
+
+func TestBackupAgentContainerReadOnlyRootFilesystemTmpMount(t *testing.T) {
+	tmpMount := corev1.VolumeMount{Name: tmpVolumeName, MountPath: tmpMountPath}
+
+	newCR := func() *api.PerconaServerMongoDB {
+		return &api.PerconaServerMongoDB{
+			Spec: api.PerconaServerMongoDBSpec{
+				CRVersion: version.Version(),
+				Secrets:   &api.SecretsSpec{Users: "some-users"},
+				Backup: api.BackupSpec{
+					Enabled: true,
+					Image:   "backup-image",
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name      string
+		setup     func(cr *api.PerconaServerMongoDB)
+		wantMount bool
+	}{
+		{
+			name:      "no security context",
+			setup:     func(*api.PerconaServerMongoDB) {},
+			wantMount: false,
+		},
+		{
+			name: "readOnlyRootFilesystem false",
+			setup: func(cr *api.PerconaServerMongoDB) {
+				cr.Spec.Backup.ContainerSecurityContext = rorfsSecurityContext(false)
+			},
+			wantMount: false,
+		},
+		{
+			name: "readOnlyRootFilesystem true",
+			setup: func(cr *api.PerconaServerMongoDB) {
+				cr.Spec.Backup.ContainerSecurityContext = rorfsSecurityContext(true)
+			},
+			wantMount: true,
+		},
+		{
+			name: "readOnlyRootFilesystem true ignored on <1.23.0",
+			setup: func(cr *api.PerconaServerMongoDB) {
+				cr.Spec.CRVersion = "1.22.0"
+				cr.Spec.Backup.ContainerSecurityContext = rorfsSecurityContext(true)
+			},
+			wantMount: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cr := newCR()
+			tt.setup(cr)
+
+			c := backupAgentContainer(context.Background(), cr, "rs0", 27017, false, &corev1.Secret{})
+
+			if tt.wantMount {
+				assert.Contains(t, c.VolumeMounts, tmpMount)
+			} else {
+				assert.NotContains(t, c.VolumeMounts, tmpMount)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Addresses #1793 (Jira: K8SPSMDB-809)

**CHANGE DESCRIPTION**
---
**Problem:**
Setting `containerSecurityContext.readOnlyRootFilesystem: true` makes the mongod container CrashLoopBackOff on startup (exit code 14), and breaks the backup agent the same way. The operator applies the security context to the StatefulSet but never gives the containers a writable `/tmp`.

**Cause:**
mongod needs a writable `/tmp` at runtime — WiredTiger writes temp and sort-spill files there during queries, aggregations and index builds. The backup agent needs it too: `pbm-entry.sh` writes `/tmp/tls.pem`. With a read-only root and no `/tmp` mount, both fail immediately. `sidecarVolumes` doesn't help because those volumes aren't mounted into the mongod container.

**Solution:**
When `readOnlyRootFilesystem` is enabled on the mongod or backup agent container, add a shared `tmp` emptyDir to the pod and mount it at `/tmp` in those containers. Gated behind crVersion 1.23.0. This is the same thing percona-helm-charts already does for the operator's own pod.

I kept this scoped to the read-only-root-filesystem case rather than a generic "configurable volumeMounts" API (also mentioned in #1793) — happy to take it that way instead if you'd prefer.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [x] Is an E2E test/test case added for the new feature/change?
- [x] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)? — n/a, the `security-context` test has no `-oc.yml` variant; the standard `compare/statefulset_sec-context-rs0-changed.yml` is updated.

I extended the existing `security-context` E2E test: its `-changed` step now enables `readOnlyRootFilesystem` on the replset and backup container security contexts, and the golden StatefulSet asserts the injected `tmp` emptyDir volume and the `/tmp` mounts on both the mongod and backup-agent containers.

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [x] Did we ensure compatibility with the previous version or cluster upgrade process?
- [x] Does the change support oldest and newest supported MongoDB version?
- [x] Does the change support oldest and newest supported Kubernetes version?

