### PR TITLE
K8SPSMDB-1644: Provide env variables required for OCI okeWorkloadIdentity

### DIFF
--- a/pkg/apis/psmdb/v1/psmdb_defaults.go
+++ b/pkg/apis/psmdb/v1/psmdb_defaults.go
@@ -652,6 +652,10 @@ func (cr *PerconaServerMongoDB) CheckNSetDefaults(ctx context.Context, platform 
 				cr.Spec.Backup.Storages[name] = stg
 			}
 		}
+
+		if err := validateOCIStorages(cr); err != nil {
+			return errors.Wrap(err, "validate oci storages")
+		}
 	}
 
 	if !cr.Spec.Backup.Enabled {
@@ -1312,4 +1316,24 @@ func (cr *PerconaServerMongoDB) setSearchDefaults(platform version.Platform) {
 			FSGroup:    userId,
 		}
 	}
+}
+
+func validateOCIStorages(cr *PerconaServerMongoDB) error {
+	var okeWorkloadIdentityRegion string
+
+	for _, stg := range cr.Spec.Backup.Storages {
+		if stg.Type != BackupStorageOCI {
+			continue
+		}
+
+		if stg.OCI.Credentials.Type == AuthTypeOkeWorkloadIdentity {
+			if okeWorkloadIdentityRegion == "" {
+				okeWorkloadIdentityRegion = stg.OCI.Region
+			} else if okeWorkloadIdentityRegion != stg.OCI.Region {
+				return errors.New("all OCI storages using okeWorkloadIdentity need to be in the same region")
+			}
+		}
+	}
+
+	return nil
 }

--- a/pkg/controller/perconaservermongodbrestore/physical.go
+++ b/pkg/controller/perconaservermongodbrestore/physical.go
@@ -444,6 +444,9 @@ func (r *ReconcilePerconaServerMongoDBRestore) updateStatefulSetForPhysicalResto
 	if cluster.CompareVersion("1.23.0") >= 0 && psmdb.ShouldSetAWSSDKChecksumEnvVars(cluster) {
 		sts.Spec.Template.Spec.Containers[0].Env = append(sts.Spec.Template.Spec.Containers[0].Env, psmdb.AWSSDKChecksumEnvVars()...)
 	}
+	if cluster.CompareVersion("1.23.0") >= 0 && psmdb.ShouldSetOCIResourcePrincipalEnvVars(cluster) {
+		sts.Spec.Template.Spec.Containers[0].Env = append(sts.Spec.Template.Spec.Containers[0].Env, psmdb.OCIResourcePrincipalEnvVars(cluster)...)
+	}
 
 	sslSecret := new(corev1.Secret)
 	err = r.client.Get(ctx, types.NamespacedName{Name: api.SSLSecretName(cluster), Namespace: cluster.Namespace}, sslSecret)

--- a/pkg/psmdb/backup/pbm.go
+++ b/pkg/psmdb/backup/pbm.go
@@ -1008,6 +1008,16 @@ func (b *pbmC) ValidateBackupInStorage(ctx context.Context, cfg *config.Config, 
 		return nil
 	}
 
+	if cfg.Storage.Type == storage.OCI && cfg.Storage.OCI != nil && cfg.Storage.OCI.Credentials.Type == oci.AuthTypeOkeWorkloadIdentity {
+		if err := os.Setenv("OCI_RESOURCE_PRINCIPAL_VERSION", psmdb.OCIResourcePrincipalVersion); err != nil {
+			return errors.Wrap(err, "set OCI_RESOURCE_PRINCIPAL_VERSION")
+		}
+
+		if err := os.Setenv("OCI_RESOURCE_PRINCIPAL_REGION", cfg.Storage.OCI.Region); err != nil {
+			return errors.Wrap(err, "set OCI_RESOURCE_PRINCIPAL_REGION")
+		}
+	}
+
 	e := b.Logger().NewEvent(string(ctrl.CmdRestore), "", "", bson.Timestamp{})
 	stg, err := util.StorageFromConfig(&cfg.Storage, "", e)
 	if err != nil {

--- a/pkg/psmdb/statefulset.go
+++ b/pkg/psmdb/statefulset.go
@@ -637,8 +637,13 @@ func backupAgentContainer(ctx context.Context, cr *api.PerconaServerMongoDB, rep
 		c.Env[0].ValueFrom.SecretKeyRef.Key = "MONGODB_BACKUP_USER"
 		c.Env[1].ValueFrom.SecretKeyRef.Key = "MONGODB_BACKUP_PASSWORD"
 	}
+
 	if cr.CompareVersion("1.23.0") >= 0 && ShouldSetAWSSDKChecksumEnvVars(cr) {
 		c.Env = append(c.Env, AWSSDKChecksumEnvVars()...)
+	}
+
+	if cr.CompareVersion("1.23.0") >= 0 && ShouldSetOCIResourcePrincipalEnvVars(cr) {
+		c.Env = append(c.Env, OCIResourcePrincipalEnvVars(cr)...)
 	}
 
 	if cr.Spec.Sharding.Enabled {
@@ -718,6 +723,43 @@ func ShouldSetAWSSDKChecksumEnvVars(cr *api.PerconaServerMongoDB) bool {
 	}
 
 	return false
+}
+
+func ShouldSetOCIResourcePrincipalEnvVars(cr *api.PerconaServerMongoDB) bool {
+	pbm2150OrOlder, err := cr.ComparePBMAgentVersion("2.15.0")
+	if err != nil || pbm2150OrOlder < 0 {
+		return false
+	}
+
+	for _, storage := range cr.Spec.Backup.Storages {
+		if storage.Type == api.BackupStorageOCI && storage.OCI.Credentials.Type == api.AuthTypeOkeWorkloadIdentity {
+			return true
+		}
+	}
+
+	return false
+}
+
+func OCIResourcePrincipalEnvVars(cr *api.PerconaServerMongoDB) []corev1.EnvVar {
+	var oci api.BackupStorageOCISpec
+	for _, storage := range cr.Spec.Backup.Storages {
+		if storage.Type == api.BackupStorageOCI && storage.OCI.Credentials.Type == api.AuthTypeOkeWorkloadIdentity {
+			oci = storage.OCI
+		}
+	}
+
+	return []corev1.EnvVar{
+		{
+			Name:  "OCI_RESOURCE_PRINCIPAL_VERSION",
+			Value: "2.2",
+		},
+		{
+			// if user defines more than one OCI storages and tries to use okeWorkloadIdentity for them
+			// all storages need to be in same region
+			Name:  "OCI_RESOURCE_PRINCIPAL_REGION",
+			Value: oci.Region,
+		},
+	}
 }
 
 func BuildMongoDBURI(ctx context.Context, tlsEnabled bool, sslSecret *corev1.Secret) string {

--- a/pkg/psmdb/statefulset.go
+++ b/pkg/psmdb/statefulset.go
@@ -726,8 +726,8 @@ func ShouldSetAWSSDKChecksumEnvVars(cr *api.PerconaServerMongoDB) bool {
 }
 
 func ShouldSetOCIResourcePrincipalEnvVars(cr *api.PerconaServerMongoDB) bool {
-	pbm2150OrOlder, err := cr.ComparePBMAgentVersion("2.15.0")
-	if err != nil || pbm2150OrOlder < 0 {
+	pbm2150OrNewer, err := cr.ComparePBMAgentVersion("2.15.0")
+	if err != nil || pbm2150OrNewer < 0 {
 		return false
 	}
 
@@ -740,18 +740,21 @@ func ShouldSetOCIResourcePrincipalEnvVars(cr *api.PerconaServerMongoDB) bool {
 	return false
 }
 
+const OCIResourcePrincipalVersion = "2.2"
+
 func OCIResourcePrincipalEnvVars(cr *api.PerconaServerMongoDB) []corev1.EnvVar {
 	var oci api.BackupStorageOCISpec
 	for _, storage := range cr.Spec.Backup.Storages {
 		if storage.Type == api.BackupStorageOCI && storage.OCI.Credentials.Type == api.AuthTypeOkeWorkloadIdentity {
 			oci = storage.OCI
+			break
 		}
 	}
 
 	return []corev1.EnvVar{
 		{
 			Name:  "OCI_RESOURCE_PRINCIPAL_VERSION",
-			Value: "2.2",
+			Value: OCIResourcePrincipalVersion,
 		},
 		{
 			// if user defines more than one OCI storages and tries to use okeWorkloadIdentity for them


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
okeWorkloadIdentity doesn't work unless you provide OCI_RESOURCE_PRINCIPAL_VERSION and OCI_RESOURCE_PRINCIPAL_REGION environment variables.

**Solution:**
If OCI storage is configured to use okeWorkloadIdentity, automatically add env variables.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
