### PR TITLE
K8SPSMDB-1644 fix credential rotation given the usage of storage.MaskedString

### DIFF
--- a/pkg/controller/perconaservermongodb/pbm.go
+++ b/pkg/controller/perconaservermongodb/pbm.go
@@ -201,6 +201,7 @@ func hashPBMConfiguration(c []config.Config, cr *psmdbv1.PerconaServerMongoDB) (
 	// storage.MaskedString masks credentials in JSON and YAML but not in BSON,
 	// so BSON is the only marshaller that lets credential rotation change the hash.
 	if cr.CompareVersion("1.23.0") >= 0 {
+		// bson.Marshal requires a top-level document since it can't marshal a bare slice, that's why configs was used.
 		v, err := bson.Marshal(struct {
 			Configs []config.Config `bson:"configs"`
 		}{Configs: c})

--- a/pkg/controller/perconaservermongodb/pbm.go
+++ b/pkg/controller/perconaservermongodb/pbm.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.mongodb.org/mongo-driver/v2/x/bsonx/bsoncore"
 	"gopkg.in/yaml.v3"
@@ -21,7 +22,6 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/percona/percona-backup-mongodb/pbm/config"
-	"github.com/percona/percona-backup-mongodb/pbm/storage"
 	pbmVersion "github.com/percona/percona-backup-mongodb/pbm/version"
 
 	psmdbv1 "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
@@ -158,7 +158,6 @@ func (r *ReconcilePerconaServerMongoDB) reconcilePBMConfig(ctx context.Context, 
 	// Hashes can be equal even if the actual PBM configuration differs from the one that was hashed
 	// For example, a restore can modify the PBM config
 	// We should use `isResyncNeeded` to compare the current configuration with the one we need
-	// Also, storage credentials are not hashed since they are excluded from JSON representation. `isResyncNeeded` will handle it.
 	if cr.Status.BackupConfigHash == hash && !isResyncNeeded(currentCfg, &main) {
 		return nil
 	}
@@ -199,7 +198,20 @@ func (r *ReconcilePerconaServerMongoDB) reconcilePBMConfig(ctx context.Context, 
 }
 
 func hashPBMConfiguration(c []config.Config, cr *psmdbv1.PerconaServerMongoDB) (string, error) {
-	// Use YAML marshaller so that even credentials are included
+	// storage.MaskedString masks credentials in JSON and YAML but not in BSON,
+	// so BSON is the only marshaller that lets credential rotation change the hash.
+	if cr.CompareVersion("1.23.0") >= 0 {
+		v, err := bson.Marshal(struct {
+			Configs []config.Config `bson:"configs"`
+		}{Configs: c})
+		if err != nil {
+			return "", err
+		}
+		return sha256Hash(v), nil
+	}
+	// 1.22.0 used yaml, earlier versions used json. Both mask credentials in
+	// storage.MaskedString fields, so credential rotation is not detected
+	// through the hash on those versions.
 	if cr.CompareVersion("1.22.0") >= 0 {
 		v, err := yaml.Marshal(c)
 		if err != nil {
@@ -207,7 +219,6 @@ func hashPBMConfiguration(c []config.Config, cr *psmdbv1.PerconaServerMongoDB) (
 		}
 		return sha256Hash(v), nil
 	}
-	// Use JSON for versions prior to 1.22.0
 	v, err := json.Marshal(c)
 	if err != nil {
 		return "", err
@@ -216,50 +227,7 @@ func hashPBMConfiguration(c []config.Config, cr *psmdbv1.PerconaServerMongoDB) (
 }
 
 func isResyncNeeded(currentCfg *config.Config, newCfg *config.Config) bool {
-	if !currentCfg.Storage.IsSameStorage(&newCfg.Storage) {
-		return true
-	}
-	return !sameStorageCredentials(&currentCfg.Storage, &newCfg.Storage)
-}
-
-func sameStorageCredentials(a, b *config.StorageConf) bool {
-	if a.Type != b.Type {
-		return false
-	}
-	switch a.Type {
-	case storage.S3:
-		if a.S3 == nil || b.S3 == nil {
-			return a.S3 == b.S3
-		}
-		return reflect.DeepEqual(a.S3.Credentials, b.S3.Credentials)
-	case storage.Minio:
-		if a.Minio == nil || b.Minio == nil {
-			return a.Minio == b.Minio
-		}
-		return reflect.DeepEqual(a.Minio.Credentials, b.Minio.Credentials)
-	case storage.Azure:
-		if a.Azure == nil || b.Azure == nil {
-			return a.Azure == b.Azure
-		}
-		return reflect.DeepEqual(a.Azure.Credentials, b.Azure.Credentials)
-	case storage.GCS:
-		if a.GCS == nil || b.GCS == nil {
-			return a.GCS == b.GCS
-		}
-		return reflect.DeepEqual(a.GCS.Credentials, b.GCS.Credentials)
-	case storage.OSS:
-		if a.OSS == nil || b.OSS == nil {
-			return a.OSS == b.OSS
-		}
-		return reflect.DeepEqual(a.OSS.Credentials, b.OSS.Credentials)
-	case storage.OCI:
-		if a.OCI == nil || b.OCI == nil {
-			return a.OCI == b.OCI
-		}
-		return reflect.DeepEqual(a.OCI.Credentials, b.OCI.Credentials)
-	default:
-		return true
-	}
+	return !currentCfg.Storage.IsSameStorage(&newCfg.Storage)
 }
 
 func (r *ReconcilePerconaServerMongoDB) reconcilePiTRStorageLegacy(

--- a/pkg/controller/perconaservermongodb/pbm.go
+++ b/pkg/controller/perconaservermongodb/pbm.go
@@ -21,6 +21,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/percona/percona-backup-mongodb/pbm/config"
+	"github.com/percona/percona-backup-mongodb/pbm/storage"
 	pbmVersion "github.com/percona/percona-backup-mongodb/pbm/version"
 
 	psmdbv1 "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
@@ -215,7 +216,50 @@ func hashPBMConfiguration(c []config.Config, cr *psmdbv1.PerconaServerMongoDB) (
 }
 
 func isResyncNeeded(currentCfg *config.Config, newCfg *config.Config) bool {
-	return !currentCfg.Storage.IsSameStorage(&newCfg.Storage)
+	if !currentCfg.Storage.IsSameStorage(&newCfg.Storage) {
+		return true
+	}
+	return !sameStorageCredentials(&currentCfg.Storage, &newCfg.Storage)
+}
+
+func sameStorageCredentials(a, b *config.StorageConf) bool {
+	if a.Type != b.Type {
+		return false
+	}
+	switch a.Type {
+	case storage.S3:
+		if a.S3 == nil || b.S3 == nil {
+			return a.S3 == b.S3
+		}
+		return reflect.DeepEqual(a.S3.Credentials, b.S3.Credentials)
+	case storage.Minio:
+		if a.Minio == nil || b.Minio == nil {
+			return a.Minio == b.Minio
+		}
+		return reflect.DeepEqual(a.Minio.Credentials, b.Minio.Credentials)
+	case storage.Azure:
+		if a.Azure == nil || b.Azure == nil {
+			return a.Azure == b.Azure
+		}
+		return reflect.DeepEqual(a.Azure.Credentials, b.Azure.Credentials)
+	case storage.GCS:
+		if a.GCS == nil || b.GCS == nil {
+			return a.GCS == b.GCS
+		}
+		return reflect.DeepEqual(a.GCS.Credentials, b.GCS.Credentials)
+	case storage.OSS:
+		if a.OSS == nil || b.OSS == nil {
+			return a.OSS == b.OSS
+		}
+		return reflect.DeepEqual(a.OSS.Credentials, b.OSS.Credentials)
+	case storage.OCI:
+		if a.OCI == nil || b.OCI == nil {
+			return a.OCI == b.OCI
+		}
+		return reflect.DeepEqual(a.OCI.Credentials, b.OCI.Credentials)
+	default:
+		return true
+	}
 }
 
 func (r *ReconcilePerconaServerMongoDB) reconcilePiTRStorageLegacy(
@@ -231,21 +275,21 @@ func (r *ReconcilePerconaServerMongoDB) reconcilePiTRStorageLegacy(
 	}
 
 	// if PiTR is enabled user can configure only one storage
-	var storage psmdbv1.BackupStorageSpec
-	for name, stg := range cr.Spec.Backup.Storages {
-		storage = stg
+	var stg psmdbv1.BackupStorageSpec
+	for name, s := range cr.Spec.Backup.Storages {
+		stg = s
 		log.Info("Configuring PBM with storage", "storage", name)
 		break
 	}
 
 	var secretName string
-	switch storage.Type {
+	switch stg.Type {
 	case psmdbv1.BackupStorageS3:
-		secretName = storage.S3.CredentialsSecret
+		secretName = stg.S3.CredentialsSecret
 	case psmdbv1.BackupStorageAzure:
-		secretName = storage.Azure.CredentialsSecret
+		secretName = stg.Azure.CredentialsSecret
 	case psmdbv1.BackupStorageOSS:
-		secretName = storage.OSS.CredentialsSecret
+		secretName = stg.OSS.CredentialsSecret
 	}
 
 	if secretName != "" {
@@ -260,7 +304,7 @@ func (r *ReconcilePerconaServerMongoDB) reconcilePiTRStorageLegacy(
 		}
 	}
 
-	err := pbm.GetNSetConfigLegacy(ctx, r.client, cr, storage)
+	err := pbm.GetNSetConfigLegacy(ctx, r.client, cr, stg)
 	if err != nil {
 		return errors.Wrap(err, "set PBM config")
 	}

--- a/pkg/controller/perconaservermongodb/pbm.go
+++ b/pkg/controller/perconaservermongodb/pbm.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"reflect"
 	"slices"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -201,10 +202,7 @@ func hashPBMConfiguration(c []config.Config, cr *psmdbv1.PerconaServerMongoDB) (
 	// storage.MaskedString masks credentials in JSON and YAML but not in BSON,
 	// so BSON is the only marshaller that lets credential rotation change the hash.
 	if cr.CompareVersion("1.23.0") >= 0 {
-		// bson.Marshal requires a top-level document since it can't marshal a bare slice, that's why configs was used.
-		v, err := bson.Marshal(struct {
-			Configs []config.Config `bson:"configs"`
-		}{Configs: c})
+		v, err := canonicalConfigBSON(c)
 		if err != nil {
 			return "", err
 		}
@@ -225,6 +223,37 @@ func hashPBMConfiguration(c []config.Config, cr *psmdbv1.PerconaServerMongoDB) (
 		return "", err
 	}
 	return sha256Hash(v), nil
+}
+
+func canonicalConfigBSON(c []config.Config) ([]byte, error) {
+	// bson.Marshal requires a top-level document since it can't marshal a bare slice, that's why configs was used.
+	raw, err := bson.Marshal(struct {
+		Configs []config.Config `bson:"configs"`
+	}{Configs: c})
+	if err != nil {
+		return nil, err
+	}
+	var d bson.D
+	if err := bson.Unmarshal(raw, &d); err != nil {
+		return nil, err
+	}
+	sortBSONKeys(d)
+	return bson.Marshal(d)
+}
+
+// sortBSONKeys recursively sorts keys in every bson.D reachable from v.
+func sortBSONKeys(v any) {
+	switch x := v.(type) {
+	case bson.D:
+		sort.Slice(x, func(i, j int) bool { return x[i].Key < x[j].Key })
+		for i := range x {
+			sortBSONKeys(x[i].Value)
+		}
+	case bson.A:
+		for i := range x {
+			sortBSONKeys(x[i])
+		}
+	}
 }
 
 func isResyncNeeded(currentCfg *config.Config, newCfg *config.Config) bool {

--- a/pkg/controller/perconaservermongodb/pbm_test.go
+++ b/pkg/controller/perconaservermongodb/pbm_test.go
@@ -676,4 +676,75 @@ func TestHashPBMConfiguration(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEqual(t, hash1, hash2)
 	})
+	t.Run("map fields produce a deterministic hash across repeated calls", func(t *testing.T) {
+		cr := &psmdbv1.PerconaServerMongoDB{Spec: psmdbv1.PerconaServerMongoDBSpec{CRVersion: version.Version()}}
+		cfg := []config.Config{
+			{
+				Name: "test",
+				Storage: config.StorageConf{
+					S3: &s3.Config{
+						Bucket: "operator-testing",
+						Region: "us-east-1",
+						EndpointURLMap: map[string]string{
+							"rs0-0": "https://endpoint-0.example.com",
+							"rs0-1": "https://endpoint-1.example.com",
+							"rs0-2": "https://endpoint-2.example.com",
+							"rs0-3": "https://endpoint-3.example.com",
+							"rs0-4": "https://endpoint-4.example.com",
+						},
+						Credentials: s3.Credentials{
+							AccessKeyID:     "KEY",
+							SecretAccessKey: "SECRET",
+						},
+					},
+				},
+				Backup: &config.BackupConf{
+					Priority: config.Priority{
+						"host-a": 1.0,
+						"host-b": 2.0,
+						"host-c": 3.0,
+						"host-d": 4.0,
+						"host-e": 5.0,
+					},
+				},
+				Restore: &config.RestoreConf{
+					MongodLocationMap: map[string]string{
+						"rs0-0": "/usr/bin/mongod-0",
+						"rs0-1": "/usr/bin/mongod-1",
+						"rs0-2": "/usr/bin/mongod-2",
+						"rs0-3": "/usr/bin/mongod-3",
+						"rs0-4": "/usr/bin/mongod-4",
+					},
+				},
+			},
+		}
+		hash1, err := hashPBMConfiguration(cfg, cr)
+		require.NoError(t, err)
+		for i := 0; i < 200; i++ {
+			h, err := hashPBMConfiguration(cfg, cr)
+			require.NoError(t, err)
+			require.Equal(t, hash1, h, "hash flapped on iteration %d", i)
+		}
+	})
+	t.Run("changing map contents changes hash", func(t *testing.T) {
+		cr := &psmdbv1.PerconaServerMongoDB{Spec: psmdbv1.PerconaServerMongoDBSpec{CRVersion: version.Version()}}
+		cfg := []config.Config{
+			{
+				Name: "test",
+				Storage: config.StorageConf{
+					S3: &s3.Config{Bucket: "operator-testing"},
+				},
+				Restore: &config.RestoreConf{
+					MongodLocationMap: map[string]string{"rs0-0": "/usr/bin/mongod"},
+				},
+			},
+		}
+		hash1, err := hashPBMConfiguration(cfg, cr)
+		require.NoError(t, err)
+
+		cfg[0].Restore.MongodLocationMap["rs0-1"] = "/usr/bin/mongod-alt"
+		hash2, err := hashPBMConfiguration(cfg, cr)
+		require.NoError(t, err)
+		require.NotEqual(t, hash1, hash2)
+	})
 }

--- a/pkg/controller/perconaservermongodb/pbm_test.go
+++ b/pkg/controller/perconaservermongodb/pbm_test.go
@@ -628,4 +628,38 @@ func TestHashPBMConfiguration(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEqual(t, hash1, hash2)
 	})
+
+	// storage.MaskedString marshals any non-empty value to "***", so rotating
+	// credentials between two non-empty values produces an identical hash.
+	// This is why isResyncNeeded must compare credentials directly.
+	t.Run("rotating non-empty credentials does not change hash", func(t *testing.T) {
+		cr := &psmdbv1.PerconaServerMongoDB{Spec: psmdbv1.PerconaServerMongoDBSpec{CRVersion: "1.22.0"}}
+		cfg := []config.Config{
+			{
+				Name: "test",
+				Storage: config.StorageConf{
+					S3: &s3.Config{
+						Bucket:      "operator-testing",
+						Region:      "us-east-1",
+						EndpointURL: "https://s3.amazonaws.com",
+						Prefix:      "prefix",
+						Credentials: s3.Credentials{
+							AccessKeyID:     "OLD_KEY",
+							SecretAccessKey: "OLD_SECRET",
+						},
+					},
+				},
+			},
+		}
+		hash1, err := hashPBMConfiguration(cfg, cr)
+		require.NoError(t, err)
+
+		cfg[0].Storage.S3.Credentials = s3.Credentials{
+			AccessKeyID:     "NEW_KEY",
+			SecretAccessKey: "NEW_SECRET",
+		}
+		hash2, err := hashPBMConfiguration(cfg, cr)
+		require.NoError(t, err)
+		require.Equal(t, hash1, hash2)
+	})
 }

--- a/pkg/controller/perconaservermongodb/pbm_test.go
+++ b/pkg/controller/perconaservermongodb/pbm_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/percona/percona-backup-mongodb/pbm/storage/fs"
 	"github.com/percona/percona-backup-mongodb/pbm/storage/gcs"
 	"github.com/percona/percona-backup-mongodb/pbm/storage/mio"
+	"github.com/percona/percona-backup-mongodb/pbm/storage/oci"
+	"github.com/percona/percona-backup-mongodb/pbm/storage/oss"
 	"github.com/percona/percona-backup-mongodb/pbm/storage/s3"
 	"github.com/stretchr/testify/require"
 
@@ -420,6 +422,170 @@ func TestIsResyncNeeded(t *testing.T) {
 				},
 			},
 			expected: false,
+		},
+		{
+			name: "s3: access key rotated",
+			currentCfg: &config.Config{
+				Storage: config.StorageConf{
+					Type: storage.S3,
+					S3: &s3.Config{
+						Bucket: "operator-testing",
+						Region: "us-east-1",
+						Credentials: s3.Credentials{
+							AccessKeyID:     "OLD_KEY",
+							SecretAccessKey: "OLD_SECRET",
+						},
+					},
+				},
+			},
+			newCfg: &config.Config{
+				Storage: config.StorageConf{
+					Type: storage.S3,
+					S3: &s3.Config{
+						Bucket: "operator-testing",
+						Region: "us-east-1",
+						Credentials: s3.Credentials{
+							AccessKeyID:     "NEW_KEY",
+							SecretAccessKey: "OLD_SECRET",
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "minio: secret key rotated",
+			currentCfg: &config.Config{
+				Storage: config.StorageConf{
+					Type: storage.Minio,
+					Minio: &mio.Config{
+						Bucket: "operator-testing",
+						Credentials: mio.Credentials{
+							AccessKeyID:     "KEY",
+							SecretAccessKey: "OLD_SECRET",
+						},
+					},
+				},
+			},
+			newCfg: &config.Config{
+				Storage: config.StorageConf{
+					Type: storage.Minio,
+					Minio: &mio.Config{
+						Bucket: "operator-testing",
+						Credentials: mio.Credentials{
+							AccessKeyID:     "KEY",
+							SecretAccessKey: "NEW_SECRET",
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "azure: key rotated",
+			currentCfg: &config.Config{
+				Storage: config.StorageConf{
+					Type: storage.Azure,
+					Azure: &azure.Config{
+						Account:     "operator-account",
+						Container:   "operator-testing",
+						Credentials: azure.Credentials{Key: "OLD_KEY"},
+					},
+				},
+			},
+			newCfg: &config.Config{
+				Storage: config.StorageConf{
+					Type: storage.Azure,
+					Azure: &azure.Config{
+						Account:     "operator-account",
+						Container:   "operator-testing",
+						Credentials: azure.Credentials{Key: "NEW_KEY"},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "gcs: hmac secret rotated",
+			currentCfg: &config.Config{
+				Storage: config.StorageConf{
+					Type: storage.GCS,
+					GCS: &gcs.Config{
+						Bucket: "operator-testing",
+						Credentials: gcs.Credentials{
+							HMACAccessKey: "KEY",
+							HMACSecret:    "OLD_SECRET",
+						},
+					},
+				},
+			},
+			newCfg: &config.Config{
+				Storage: config.StorageConf{
+					Type: storage.GCS,
+					GCS: &gcs.Config{
+						Bucket: "operator-testing",
+						Credentials: gcs.Credentials{
+							HMACAccessKey: "KEY",
+							HMACSecret:    "NEW_SECRET",
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "oss: access key rotated",
+			currentCfg: &config.Config{
+				Storage: config.StorageConf{
+					Type: storage.OSS,
+					OSS: &oss.Config{
+						Bucket:      "operator-testing",
+						Credentials: oss.Credentials{AccessKeyID: "OLD_KEY", AccessKeySecret: "S"},
+					},
+				},
+			},
+			newCfg: &config.Config{
+				Storage: config.StorageConf{
+					Type: storage.OSS,
+					OSS: &oss.Config{
+						Bucket:      "operator-testing",
+						Credentials: oss.Credentials{AccessKeyID: "NEW_KEY", AccessKeySecret: "S"},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "oci: user principal private key rotated",
+			currentCfg: &config.Config{
+				Storage: config.StorageConf{
+					Type: storage.OCI,
+					OCI: &oci.Config{
+						Bucket: "operator-testing",
+						Credentials: oci.Credentials{
+							UserPrincipal: &oci.UserPrincipalCredentials{
+								Tenancy: "t", User: "u", Fingerprint: "f",
+								PrivateKey: "OLD_KEY",
+							},
+						},
+					},
+				},
+			},
+			newCfg: &config.Config{
+				Storage: config.StorageConf{
+					Type: storage.OCI,
+					OCI: &oci.Config{
+						Bucket: "operator-testing",
+						Credentials: oci.Credentials{
+							UserPrincipal: &oci.UserPrincipalCredentials{
+								Tenancy: "t", User: "u", Fingerprint: "f",
+								PrivateKey: "NEW_KEY",
+							},
+						},
+					},
+				},
+			},
+			expected: true,
 		},
 	}
 

--- a/pkg/controller/perconaservermongodb/pbm_test.go
+++ b/pkg/controller/perconaservermongodb/pbm_test.go
@@ -493,7 +493,6 @@ func TestHashPBMConfiguration(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEqual(t, hash1, hash2)
 	})
-
 	t.Run("rotating profile credentials changes hash", func(t *testing.T) {
 		cr := &psmdbv1.PerconaServerMongoDB{Spec: psmdbv1.PerconaServerMongoDBSpec{CRVersion: version.Version()}}
 		cfg := []config.Config{
@@ -530,6 +529,149 @@ func TestHashPBMConfiguration(t *testing.T) {
 			AccessKeyID:     "NEW_PROFILE_KEY",
 			SecretAccessKey: "NEW_PROFILE_SECRET",
 		}
+		hash2, err := hashPBMConfiguration(cfg, cr)
+		require.NoError(t, err)
+		require.NotEqual(t, hash1, hash2)
+	})
+	t.Run("identical config produces identical hash", func(t *testing.T) {
+		cr := &psmdbv1.PerconaServerMongoDB{Spec: psmdbv1.PerconaServerMongoDBSpec{CRVersion: version.Version()}}
+		cfg := []config.Config{
+			{
+				Name: "test",
+				Storage: config.StorageConf{
+					S3: &s3.Config{
+						Bucket:      "operator-testing",
+						Region:      "us-east-1",
+						EndpointURL: "https://s3.amazonaws.com",
+						Credentials: s3.Credentials{
+							AccessKeyID:     "KEY",
+							SecretAccessKey: "SECRET",
+						},
+					},
+				},
+			},
+		}
+		hash1, err := hashPBMConfiguration(cfg, cr)
+		require.NoError(t, err)
+		hash2, err := hashPBMConfiguration(cfg, cr)
+		require.NoError(t, err)
+		require.Equal(t, hash1, hash2)
+	})
+	t.Run("non-credential change changes hash", func(t *testing.T) {
+		cr := &psmdbv1.PerconaServerMongoDB{Spec: psmdbv1.PerconaServerMongoDBSpec{CRVersion: version.Version()}}
+		cfg := []config.Config{
+			{
+				Name: "test",
+				Storage: config.StorageConf{
+					S3: &s3.Config{
+						Bucket: "operator-testing",
+						Region: "us-east-1",
+					},
+				},
+			},
+		}
+		hash1, err := hashPBMConfiguration(cfg, cr)
+		require.NoError(t, err)
+
+		cfg[0].Storage.S3.Bucket = "operator-testing-2"
+		hash2, err := hashPBMConfiguration(cfg, cr)
+		require.NoError(t, err)
+		require.NotEqual(t, hash1, hash2)
+	})
+	t.Run("yaml path (1.22.0): credential rotation does not change hash", func(t *testing.T) {
+		cr := &psmdbv1.PerconaServerMongoDB{Spec: psmdbv1.PerconaServerMongoDBSpec{CRVersion: "1.22.0"}}
+		cfg := []config.Config{
+			{
+				Name: "test",
+				Storage: config.StorageConf{
+					S3: &s3.Config{
+						Bucket: "operator-testing",
+						Region: "us-east-1",
+						Credentials: s3.Credentials{
+							AccessKeyID:     "OLD_KEY",
+							SecretAccessKey: "OLD_SECRET",
+						},
+					},
+				},
+			},
+		}
+		hash1, err := hashPBMConfiguration(cfg, cr)
+		require.NoError(t, err)
+
+		cfg[0].Storage.S3.Credentials = s3.Credentials{
+			AccessKeyID:     "NEW_KEY",
+			SecretAccessKey: "NEW_SECRET",
+		}
+		hash2, err := hashPBMConfiguration(cfg, cr)
+		require.NoError(t, err)
+		require.Equal(t, hash1, hash2)
+	})
+	t.Run("yaml path (1.22.0): non-credential change changes hash", func(t *testing.T) {
+		cr := &psmdbv1.PerconaServerMongoDB{Spec: psmdbv1.PerconaServerMongoDBSpec{CRVersion: "1.22.0"}}
+		cfg := []config.Config{
+			{
+				Name: "test",
+				Storage: config.StorageConf{
+					S3: &s3.Config{
+						Bucket: "operator-testing",
+						Region: "us-east-1",
+					},
+				},
+			},
+		}
+		hash1, err := hashPBMConfiguration(cfg, cr)
+		require.NoError(t, err)
+
+		cfg[0].Storage.S3.Bucket = "operator-testing-2"
+		hash2, err := hashPBMConfiguration(cfg, cr)
+		require.NoError(t, err)
+		require.NotEqual(t, hash1, hash2)
+	})
+	t.Run("json path (1.21.0): credential rotation does not change hash", func(t *testing.T) {
+		cr := &psmdbv1.PerconaServerMongoDB{Spec: psmdbv1.PerconaServerMongoDBSpec{CRVersion: "1.21.0"}}
+		cfg := []config.Config{
+			{
+				Name: "test",
+				Storage: config.StorageConf{
+					S3: &s3.Config{
+						Bucket: "operator-testing",
+						Region: "us-east-1",
+						Credentials: s3.Credentials{
+							AccessKeyID:     "OLD_KEY",
+							SecretAccessKey: "OLD_SECRET",
+						},
+					},
+				},
+			},
+		}
+		hash1, err := hashPBMConfiguration(cfg, cr)
+		require.NoError(t, err)
+
+		cfg[0].Storage.S3.Credentials = s3.Credentials{
+			AccessKeyID:     "NEW_KEY",
+			SecretAccessKey: "NEW_SECRET",
+		}
+		hash2, err := hashPBMConfiguration(cfg, cr)
+		require.NoError(t, err)
+		require.Equal(t, hash1, hash2)
+	})
+	t.Run("json path (1.21.0): non-credential change changes hash", func(t *testing.T) {
+		cr := &psmdbv1.PerconaServerMongoDB{Spec: psmdbv1.PerconaServerMongoDBSpec{CRVersion: "1.21.0"}}
+		cfg := []config.Config{
+			{
+				Name: "test",
+				Storage: config.StorageConf{
+					S3: &s3.Config{
+						Bucket: "operator-testing",
+						Region: "us-east-1",
+					},
+				},
+			},
+		}
+		hash1, err := hashPBMConfiguration(cfg, cr)
+		require.NoError(t, err)
+
+		cfg[0].Storage.S3.Bucket = "operator-testing-2"
 		hash2, err := hashPBMConfiguration(cfg, cr)
 		require.NoError(t, err)
 		require.NotEqual(t, hash1, hash2)

--- a/pkg/controller/perconaservermongodb/pbm_test.go
+++ b/pkg/controller/perconaservermongodb/pbm_test.go
@@ -9,9 +9,8 @@ import (
 	"github.com/percona/percona-backup-mongodb/pbm/storage/fs"
 	"github.com/percona/percona-backup-mongodb/pbm/storage/gcs"
 	"github.com/percona/percona-backup-mongodb/pbm/storage/mio"
-	"github.com/percona/percona-backup-mongodb/pbm/storage/oci"
-	"github.com/percona/percona-backup-mongodb/pbm/storage/oss"
 	"github.com/percona/percona-backup-mongodb/pbm/storage/s3"
+	"github.com/percona/percona-server-mongodb-operator/pkg/version"
 	"github.com/stretchr/testify/require"
 
 	psmdbv1 "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
@@ -423,170 +422,6 @@ func TestIsResyncNeeded(t *testing.T) {
 			},
 			expected: false,
 		},
-		{
-			name: "s3: access key rotated",
-			currentCfg: &config.Config{
-				Storage: config.StorageConf{
-					Type: storage.S3,
-					S3: &s3.Config{
-						Bucket: "operator-testing",
-						Region: "us-east-1",
-						Credentials: s3.Credentials{
-							AccessKeyID:     "OLD_KEY",
-							SecretAccessKey: "OLD_SECRET",
-						},
-					},
-				},
-			},
-			newCfg: &config.Config{
-				Storage: config.StorageConf{
-					Type: storage.S3,
-					S3: &s3.Config{
-						Bucket: "operator-testing",
-						Region: "us-east-1",
-						Credentials: s3.Credentials{
-							AccessKeyID:     "NEW_KEY",
-							SecretAccessKey: "OLD_SECRET",
-						},
-					},
-				},
-			},
-			expected: true,
-		},
-		{
-			name: "minio: secret key rotated",
-			currentCfg: &config.Config{
-				Storage: config.StorageConf{
-					Type: storage.Minio,
-					Minio: &mio.Config{
-						Bucket: "operator-testing",
-						Credentials: mio.Credentials{
-							AccessKeyID:     "KEY",
-							SecretAccessKey: "OLD_SECRET",
-						},
-					},
-				},
-			},
-			newCfg: &config.Config{
-				Storage: config.StorageConf{
-					Type: storage.Minio,
-					Minio: &mio.Config{
-						Bucket: "operator-testing",
-						Credentials: mio.Credentials{
-							AccessKeyID:     "KEY",
-							SecretAccessKey: "NEW_SECRET",
-						},
-					},
-				},
-			},
-			expected: true,
-		},
-		{
-			name: "azure: key rotated",
-			currentCfg: &config.Config{
-				Storage: config.StorageConf{
-					Type: storage.Azure,
-					Azure: &azure.Config{
-						Account:     "operator-account",
-						Container:   "operator-testing",
-						Credentials: azure.Credentials{Key: "OLD_KEY"},
-					},
-				},
-			},
-			newCfg: &config.Config{
-				Storage: config.StorageConf{
-					Type: storage.Azure,
-					Azure: &azure.Config{
-						Account:     "operator-account",
-						Container:   "operator-testing",
-						Credentials: azure.Credentials{Key: "NEW_KEY"},
-					},
-				},
-			},
-			expected: true,
-		},
-		{
-			name: "gcs: hmac secret rotated",
-			currentCfg: &config.Config{
-				Storage: config.StorageConf{
-					Type: storage.GCS,
-					GCS: &gcs.Config{
-						Bucket: "operator-testing",
-						Credentials: gcs.Credentials{
-							HMACAccessKey: "KEY",
-							HMACSecret:    "OLD_SECRET",
-						},
-					},
-				},
-			},
-			newCfg: &config.Config{
-				Storage: config.StorageConf{
-					Type: storage.GCS,
-					GCS: &gcs.Config{
-						Bucket: "operator-testing",
-						Credentials: gcs.Credentials{
-							HMACAccessKey: "KEY",
-							HMACSecret:    "NEW_SECRET",
-						},
-					},
-				},
-			},
-			expected: true,
-		},
-		{
-			name: "oss: access key rotated",
-			currentCfg: &config.Config{
-				Storage: config.StorageConf{
-					Type: storage.OSS,
-					OSS: &oss.Config{
-						Bucket:      "operator-testing",
-						Credentials: oss.Credentials{AccessKeyID: "OLD_KEY", AccessKeySecret: "S"},
-					},
-				},
-			},
-			newCfg: &config.Config{
-				Storage: config.StorageConf{
-					Type: storage.OSS,
-					OSS: &oss.Config{
-						Bucket:      "operator-testing",
-						Credentials: oss.Credentials{AccessKeyID: "NEW_KEY", AccessKeySecret: "S"},
-					},
-				},
-			},
-			expected: true,
-		},
-		{
-			name: "oci: user principal private key rotated",
-			currentCfg: &config.Config{
-				Storage: config.StorageConf{
-					Type: storage.OCI,
-					OCI: &oci.Config{
-						Bucket: "operator-testing",
-						Credentials: oci.Credentials{
-							UserPrincipal: &oci.UserPrincipalCredentials{
-								Tenancy: "t", User: "u", Fingerprint: "f",
-								PrivateKey: "OLD_KEY",
-							},
-						},
-					},
-				},
-			},
-			newCfg: &config.Config{
-				Storage: config.StorageConf{
-					Type: storage.OCI,
-					OCI: &oci.Config{
-						Bucket: "operator-testing",
-						Credentials: oci.Credentials{
-							UserPrincipal: &oci.UserPrincipalCredentials{
-								Tenancy: "t", User: "u", Fingerprint: "f",
-								PrivateKey: "NEW_KEY",
-							},
-						},
-					},
-				},
-			},
-			expected: true,
-		},
 	}
 
 	for _, tt := range tests {
@@ -603,7 +438,7 @@ func TestIsResyncNeeded(t *testing.T) {
 
 func TestHashPBMConfiguration(t *testing.T) {
 	t.Run("updating credentials changes hash", func(t *testing.T) {
-		cr := &psmdbv1.PerconaServerMongoDB{Spec: psmdbv1.PerconaServerMongoDBSpec{CRVersion: "1.22.0"}}
+		cr := &psmdbv1.PerconaServerMongoDB{Spec: psmdbv1.PerconaServerMongoDBSpec{CRVersion: version.Version()}}
 		cfg := []config.Config{
 			{
 				Name: "test",
@@ -628,12 +463,8 @@ func TestHashPBMConfiguration(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEqual(t, hash1, hash2)
 	})
-
-	// storage.MaskedString marshals any non-empty value to "***", so rotating
-	// credentials between two non-empty values produces an identical hash.
-	// This is why isResyncNeeded must compare credentials directly.
-	t.Run("rotating non-empty credentials does not change hash", func(t *testing.T) {
-		cr := &psmdbv1.PerconaServerMongoDB{Spec: psmdbv1.PerconaServerMongoDBSpec{CRVersion: "1.22.0"}}
+	t.Run("rotating non-empty credentials changes hash", func(t *testing.T) {
+		cr := &psmdbv1.PerconaServerMongoDB{Spec: psmdbv1.PerconaServerMongoDBSpec{CRVersion: version.Version()}}
 		cfg := []config.Config{
 			{
 				Name: "test",
@@ -660,6 +491,47 @@ func TestHashPBMConfiguration(t *testing.T) {
 		}
 		hash2, err := hashPBMConfiguration(cfg, cr)
 		require.NoError(t, err)
-		require.Equal(t, hash1, hash2)
+		require.NotEqual(t, hash1, hash2)
+	})
+
+	t.Run("rotating profile credentials changes hash", func(t *testing.T) {
+		cr := &psmdbv1.PerconaServerMongoDB{Spec: psmdbv1.PerconaServerMongoDBSpec{CRVersion: version.Version()}}
+		cfg := []config.Config{
+			{
+				Name: "main",
+				Storage: config.StorageConf{
+					S3: &s3.Config{
+						Bucket: "main-bucket",
+						Credentials: s3.Credentials{
+							AccessKeyID:     "MAIN_KEY",
+							SecretAccessKey: "MAIN_SECRET",
+						},
+					},
+				},
+			},
+			{
+				Name:      "profile-a",
+				IsProfile: true,
+				Storage: config.StorageConf{
+					S3: &s3.Config{
+						Bucket: "profile-bucket",
+						Credentials: s3.Credentials{
+							AccessKeyID:     "OLD_PROFILE_KEY",
+							SecretAccessKey: "OLD_PROFILE_SECRET",
+						},
+					},
+				},
+			},
+		}
+		hash1, err := hashPBMConfiguration(cfg, cr)
+		require.NoError(t, err)
+
+		cfg[1].Storage.S3.Credentials = s3.Credentials{
+			AccessKeyID:     "NEW_PROFILE_KEY",
+			SecretAccessKey: "NEW_PROFILE_SECRET",
+		}
+		hash2, err := hashPBMConfiguration(cfg, cr)
+		require.NoError(t, err)
+		require.NotEqual(t, hash1, hash2)
 	})
 }


### PR DESCRIPTION
Tracked this bug while testing: https://perconadev.atlassian.net/browse/K8SPSMDB-1644

**CHANGE DESCRIPTION**
---
**Problem:**

With this https://github.com/percona/percona-server-mongodb-operator/pull/2411 we started using `storage.MaskedString`, which marshals to JSON like the following function

```
type MaskedString string

// MarshalJSON implements the json.Marshaler interface.
// It returns "***" for non-empty strings, hiding the actual value.
func (s MaskedString) MarshalJSON() ([]byte, error) {
	if s == "" {
		return []byte(`""`), nil
	}
	return []byte(`"***"`), nil
}
```

This means that our logic for hashing the pbm configuration, that is, creating the hash using `json.Marshal(c)` will not work properly and will create identical hashes, given that sensitive credentials are always returned with "***", so their rotation will not be captured. 

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**

use bson marshaller to encode the configuration information before hashing them. Add missing unit tests. 

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
