### PR TITLE
K8SPSMDB-1763 run go fix as part of generate make command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ generate: controller-gen mockgen go-fix ## Generate CRDs and RBAC files
 
 .PHONY: go-fix
 go-fix: ## Run go fix on all packages
-	go fix ./pkg/...
+	go fix ./pkg/... ./cmd/...
 
 $(DEPLOYDIR)/crd.yaml: kustomize generate
 	$(KUSTOMIZE) build config/crd/ > $(DEPLOYDIR)/crd.yaml

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ generate: controller-gen mockgen go-fix ## Generate CRDs and RBAC files
 
 .PHONY: go-fix
 go-fix: ## Run go fix on all packages
-	go fix ./...
+	go fix ./pkg/...
 
 $(DEPLOYDIR)/crd.yaml: kustomize generate
 	$(KUSTOMIZE) build config/crd/ > $(DEPLOYDIR)/crd.yaml

--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,14 @@ all: build
 help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
-generate: controller-gen mockgen  ## Generate CRDs and RBAC files
+generate: controller-gen mockgen go-fix ## Generate CRDs and RBAC files
 	go generate ./...
 	$(CONTROLLER_GEN) crd:maxDescLen=0,allowDangerousTypes=true rbac:roleName=$(NAME) webhook paths="./..." output:crd:artifacts:config=config/crd/bases  ## Generate WebhookConfiguration, Role and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) object paths="./..." ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
+
+.PHONY: go-fix
+go-fix: ## Run go fix on all packages
+	go fix ./...
 
 $(DEPLOYDIR)/crd.yaml: kustomize generate
 	$(KUSTOMIZE) build config/crd/ > $(DEPLOYDIR)/crd.yaml

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ generate: controller-gen mockgen go-fix ## Generate CRDs and RBAC files
 
 .PHONY: go-fix
 go-fix: ## Run go fix on all packages
-	go fix ./pkg/... ./cmd/...
+	go fix ./...
 
 $(DEPLOYDIR)/crd.yaml: kustomize generate
 	$(KUSTOMIZE) build config/crd/ > $(DEPLOYDIR)/crd.yaml

--- a/config/crd/bases/psmdb.percona.com_perconaservermongodbbackups.yaml
+++ b/config/crd/bases/psmdb.percona.com_perconaservermongodbbackups.yaml
@@ -209,7 +209,7 @@ spec:
                     x-kubernetes-validations:
                     - message: secretName must be set when credentials type is userPrincipal
                       rule: '!has(self.type) || self.type != ''userPrincipal'' ||
-                        (has(self.secretName) && self.secretName != '''')'
+                        (has(self.secretName) && self.secretName != ”)'
                   maxObjSizeGB:
                     type: number
                   namespace:

--- a/config/crd/bases/psmdb.percona.com_perconaservermongodbbackups.yaml
+++ b/config/crd/bases/psmdb.percona.com_perconaservermongodbbackups.yaml
@@ -203,6 +203,7 @@ spec:
                     properties:
                       secretName:
                         maxLength: 253
+                        minLength: 1
                         type: string
                       type:
                         type: string
@@ -210,7 +211,7 @@ spec:
                     x-kubernetes-validations:
                     - message: secretName must be set when credentials type is userPrincipal
                       rule: '!has(self.type) || self.type != ''userPrincipal'' ||
-                        (has(self.secretName) && size(self.secretName) > 0)'
+                        has(self.secretName)'
                   maxObjSizeGB:
                     type: number
                   namespace:

--- a/config/crd/bases/psmdb.percona.com_perconaservermongodbbackups.yaml
+++ b/config/crd/bases/psmdb.percona.com_perconaservermongodbbackups.yaml
@@ -209,7 +209,7 @@ spec:
                     x-kubernetes-validations:
                     - message: secretName must be set when credentials type is userPrincipal
                       rule: '!has(self.type) || self.type != ''userPrincipal'' ||
-                        (has(self.secretName) && self.secretName != ”)'
+                        (has(self.secretName) && size(self.secretName) > 0)'
                   maxObjSizeGB:
                     type: number
                   namespace:

--- a/config/crd/bases/psmdb.percona.com_perconaservermongodbbackups.yaml
+++ b/config/crd/bases/psmdb.percona.com_perconaservermongodbbackups.yaml
@@ -202,6 +202,7 @@ spec:
                   credentials:
                     properties:
                       secretName:
+                        maxLength: 253
                         type: string
                       type:
                         type: string

--- a/config/crd/bases/psmdb.percona.com_perconaservermongodbbackups.yaml
+++ b/config/crd/bases/psmdb.percona.com_perconaservermongodbbackups.yaml
@@ -209,7 +209,7 @@ spec:
                     x-kubernetes-validations:
                     - message: secretName must be set when credentials type is userPrincipal
                       rule: '!has(self.type) || self.type != ''userPrincipal'' ||
-                        (has(self.secretName) && self.secretName != ”)'
+                        (has(self.secretName) && self.secretName != '''')'
                   maxObjSizeGB:
                     type: number
                   namespace:

--- a/config/crd/bases/psmdb.percona.com_perconaservermongodbrestores.yaml
+++ b/config/crd/bases/psmdb.percona.com_perconaservermongodbrestores.yaml
@@ -168,7 +168,7 @@ spec:
                         - message: secretName must be set when credentials type is
                             userPrincipal
                           rule: '!has(self.type) || self.type != ''userPrincipal''
-                            || (has(self.secretName) && self.secretName != ”)'
+                            || (has(self.secretName) && size(self.secretName) > 0)'
                       maxObjSizeGB:
                         type: number
                       namespace:

--- a/config/crd/bases/psmdb.percona.com_perconaservermongodbrestores.yaml
+++ b/config/crd/bases/psmdb.percona.com_perconaservermongodbrestores.yaml
@@ -160,6 +160,7 @@ spec:
                       credentials:
                         properties:
                           secretName:
+                            maxLength: 253
                             type: string
                           type:
                             type: string

--- a/config/crd/bases/psmdb.percona.com_perconaservermongodbrestores.yaml
+++ b/config/crd/bases/psmdb.percona.com_perconaservermongodbrestores.yaml
@@ -168,7 +168,7 @@ spec:
                         - message: secretName must be set when credentials type is
                             userPrincipal
                           rule: '!has(self.type) || self.type != ''userPrincipal''
-                            || (has(self.secretName) && self.secretName != '''')'
+                            || (has(self.secretName) && self.secretName != ”)'
                       maxObjSizeGB:
                         type: number
                       namespace:

--- a/config/crd/bases/psmdb.percona.com_perconaservermongodbrestores.yaml
+++ b/config/crd/bases/psmdb.percona.com_perconaservermongodbrestores.yaml
@@ -168,7 +168,7 @@ spec:
                         - message: secretName must be set when credentials type is
                             userPrincipal
                           rule: '!has(self.type) || self.type != ''userPrincipal''
-                            || (has(self.secretName) && self.secretName != ”)'
+                            || (has(self.secretName) && self.secretName != '''')'
                       maxObjSizeGB:
                         type: number
                       namespace:

--- a/config/crd/bases/psmdb.percona.com_perconaservermongodbrestores.yaml
+++ b/config/crd/bases/psmdb.percona.com_perconaservermongodbrestores.yaml
@@ -161,6 +161,7 @@ spec:
                         properties:
                           secretName:
                             maxLength: 253
+                            minLength: 1
                             type: string
                           type:
                             type: string
@@ -169,7 +170,7 @@ spec:
                         - message: secretName must be set when credentials type is
                             userPrincipal
                           rule: '!has(self.type) || self.type != ''userPrincipal''
-                            || (has(self.secretName) && size(self.secretName) > 0)'
+                            || has(self.secretName)'
                       maxObjSizeGB:
                         type: number
                       namespace:

--- a/config/crd/bases/psmdb.percona.com_perconaservermongodbs.yaml
+++ b/config/crd/bases/psmdb.percona.com_perconaservermongodbs.yaml
@@ -587,7 +587,8 @@ spec:
                               - message: secretName must be set when credentials type
                                   is userPrincipal
                                 rule: '!has(self.type) || self.type != ''userPrincipal''
-                                  || (has(self.secretName) && self.secretName != ”)'
+                                  || (has(self.secretName) && size(self.secretName)
+                                  > 0)'
                             maxObjSizeGB:
                               type: number
                             namespace:

--- a/config/crd/bases/psmdb.percona.com_perconaservermongodbs.yaml
+++ b/config/crd/bases/psmdb.percona.com_perconaservermongodbs.yaml
@@ -579,6 +579,7 @@ spec:
                             credentials:
                               properties:
                                 secretName:
+                                  maxLength: 253
                                   type: string
                                 type:
                                   type: string

--- a/config/crd/bases/psmdb.percona.com_perconaservermongodbs.yaml
+++ b/config/crd/bases/psmdb.percona.com_perconaservermongodbs.yaml
@@ -587,7 +587,7 @@ spec:
                               - message: secretName must be set when credentials type
                                   is userPrincipal
                                 rule: '!has(self.type) || self.type != ''userPrincipal''
-                                  || (has(self.secretName) && self.secretName != ”)'
+                                  || (has(self.secretName) && self.secretName != '''')'
                             maxObjSizeGB:
                               type: number
                             namespace:

--- a/config/crd/bases/psmdb.percona.com_perconaservermongodbs.yaml
+++ b/config/crd/bases/psmdb.percona.com_perconaservermongodbs.yaml
@@ -580,6 +580,7 @@ spec:
                               properties:
                                 secretName:
                                   maxLength: 253
+                                  minLength: 1
                                   type: string
                                 type:
                                   type: string
@@ -588,8 +589,7 @@ spec:
                               - message: secretName must be set when credentials type
                                   is userPrincipal
                                 rule: '!has(self.type) || self.type != ''userPrincipal''
-                                  || (has(self.secretName) && size(self.secretName)
-                                  > 0)'
+                                  || has(self.secretName)'
                             maxObjSizeGB:
                               type: number
                             namespace:

--- a/config/crd/bases/psmdb.percona.com_perconaservermongodbs.yaml
+++ b/config/crd/bases/psmdb.percona.com_perconaservermongodbs.yaml
@@ -587,7 +587,7 @@ spec:
                               - message: secretName must be set when credentials type
                                   is userPrincipal
                                 rule: '!has(self.type) || self.type != ''userPrincipal''
-                                  || (has(self.secretName) && self.secretName != '''')'
+                                  || (has(self.secretName) && self.secretName != ”)'
                             maxObjSizeGB:
                               type: number
                             namespace:

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -213,7 +213,7 @@ spec:
                     x-kubernetes-validations:
                     - message: secretName must be set when credentials type is userPrincipal
                       rule: '!has(self.type) || self.type != ''userPrincipal'' ||
-                        (has(self.secretName) && self.secretName != '''')'
+                        (has(self.secretName) && self.secretName != ”)'
                   maxObjSizeGB:
                     type: number
                   namespace:
@@ -1631,7 +1631,7 @@ spec:
                         - message: secretName must be set when credentials type is
                             userPrincipal
                           rule: '!has(self.type) || self.type != ''userPrincipal''
-                            || (has(self.secretName) && self.secretName != '''')'
+                            || (has(self.secretName) && self.secretName != ”)'
                       maxObjSizeGB:
                         type: number
                       namespace:
@@ -2810,7 +2810,7 @@ spec:
                               - message: secretName must be set when credentials type
                                   is userPrincipal
                                 rule: '!has(self.type) || self.type != ''userPrincipal''
-                                  || (has(self.secretName) && self.secretName != '''')'
+                                  || (has(self.secretName) && self.secretName != ”)'
                             maxObjSizeGB:
                               type: number
                             namespace:

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -213,7 +213,7 @@ spec:
                     x-kubernetes-validations:
                     - message: secretName must be set when credentials type is userPrincipal
                       rule: '!has(self.type) || self.type != ''userPrincipal'' ||
-                        (has(self.secretName) && self.secretName != ”)'
+                        (has(self.secretName) && size(self.secretName) > 0)'
                   maxObjSizeGB:
                     type: number
                   namespace:
@@ -1631,7 +1631,7 @@ spec:
                         - message: secretName must be set when credentials type is
                             userPrincipal
                           rule: '!has(self.type) || self.type != ''userPrincipal''
-                            || (has(self.secretName) && self.secretName != ”)'
+                            || (has(self.secretName) && size(self.secretName) > 0)'
                       maxObjSizeGB:
                         type: number
                       namespace:
@@ -2810,7 +2810,8 @@ spec:
                               - message: secretName must be set when credentials type
                                   is userPrincipal
                                 rule: '!has(self.type) || self.type != ''userPrincipal''
-                                  || (has(self.secretName) && self.secretName != ”)'
+                                  || (has(self.secretName) && size(self.secretName)
+                                  > 0)'
                             maxObjSizeGB:
                               type: number
                             namespace:

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -206,6 +206,7 @@ spec:
                   credentials:
                     properties:
                       secretName:
+                        maxLength: 253
                         type: string
                       type:
                         type: string
@@ -1623,6 +1624,7 @@ spec:
                       credentials:
                         properties:
                           secretName:
+                            maxLength: 253
                             type: string
                           type:
                             type: string
@@ -2802,6 +2804,7 @@ spec:
                             credentials:
                               properties:
                                 secretName:
+                                  maxLength: 253
                                   type: string
                                 type:
                                   type: string

--- a/deploy/bundle.yaml
+++ b/deploy/bundle.yaml
@@ -207,6 +207,7 @@ spec:
                     properties:
                       secretName:
                         maxLength: 253
+                        minLength: 1
                         type: string
                       type:
                         type: string
@@ -214,7 +215,7 @@ spec:
                     x-kubernetes-validations:
                     - message: secretName must be set when credentials type is userPrincipal
                       rule: '!has(self.type) || self.type != ''userPrincipal'' ||
-                        (has(self.secretName) && size(self.secretName) > 0)'
+                        has(self.secretName)'
                   maxObjSizeGB:
                     type: number
                   namespace:
@@ -1625,6 +1626,7 @@ spec:
                         properties:
                           secretName:
                             maxLength: 253
+                            minLength: 1
                             type: string
                           type:
                             type: string
@@ -1633,7 +1635,7 @@ spec:
                         - message: secretName must be set when credentials type is
                             userPrincipal
                           rule: '!has(self.type) || self.type != ''userPrincipal''
-                            || (has(self.secretName) && size(self.secretName) > 0)'
+                            || has(self.secretName)'
                       maxObjSizeGB:
                         type: number
                       namespace:
@@ -2805,6 +2807,7 @@ spec:
                               properties:
                                 secretName:
                                   maxLength: 253
+                                  minLength: 1
                                   type: string
                                 type:
                                   type: string
@@ -2813,8 +2816,7 @@ spec:
                               - message: secretName must be set when credentials type
                                   is userPrincipal
                                 rule: '!has(self.type) || self.type != ''userPrincipal''
-                                  || (has(self.secretName) && size(self.secretName)
-                                  > 0)'
+                                  || has(self.secretName)'
                             maxObjSizeGB:
                               type: number
                             namespace:

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -213,7 +213,7 @@ spec:
                     x-kubernetes-validations:
                     - message: secretName must be set when credentials type is userPrincipal
                       rule: '!has(self.type) || self.type != ''userPrincipal'' ||
-                        (has(self.secretName) && self.secretName != '''')'
+                        (has(self.secretName) && self.secretName != ”)'
                   maxObjSizeGB:
                     type: number
                   namespace:
@@ -1631,7 +1631,7 @@ spec:
                         - message: secretName must be set when credentials type is
                             userPrincipal
                           rule: '!has(self.type) || self.type != ''userPrincipal''
-                            || (has(self.secretName) && self.secretName != '''')'
+                            || (has(self.secretName) && self.secretName != ”)'
                       maxObjSizeGB:
                         type: number
                       namespace:
@@ -2810,7 +2810,7 @@ spec:
                               - message: secretName must be set when credentials type
                                   is userPrincipal
                                 rule: '!has(self.type) || self.type != ''userPrincipal''
-                                  || (has(self.secretName) && self.secretName != '''')'
+                                  || (has(self.secretName) && self.secretName != ”)'
                             maxObjSizeGB:
                               type: number
                             namespace:

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -213,7 +213,7 @@ spec:
                     x-kubernetes-validations:
                     - message: secretName must be set when credentials type is userPrincipal
                       rule: '!has(self.type) || self.type != ''userPrincipal'' ||
-                        (has(self.secretName) && self.secretName != ”)'
+                        (has(self.secretName) && size(self.secretName) > 0)'
                   maxObjSizeGB:
                     type: number
                   namespace:
@@ -1631,7 +1631,7 @@ spec:
                         - message: secretName must be set when credentials type is
                             userPrincipal
                           rule: '!has(self.type) || self.type != ''userPrincipal''
-                            || (has(self.secretName) && self.secretName != ”)'
+                            || (has(self.secretName) && size(self.secretName) > 0)'
                       maxObjSizeGB:
                         type: number
                       namespace:
@@ -2810,7 +2810,8 @@ spec:
                               - message: secretName must be set when credentials type
                                   is userPrincipal
                                 rule: '!has(self.type) || self.type != ''userPrincipal''
-                                  || (has(self.secretName) && self.secretName != ”)'
+                                  || (has(self.secretName) && size(self.secretName)
+                                  > 0)'
                             maxObjSizeGB:
                               type: number
                             namespace:

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -206,6 +206,7 @@ spec:
                   credentials:
                     properties:
                       secretName:
+                        maxLength: 253
                         type: string
                       type:
                         type: string
@@ -1623,6 +1624,7 @@ spec:
                       credentials:
                         properties:
                           secretName:
+                            maxLength: 253
                             type: string
                           type:
                             type: string
@@ -2802,6 +2804,7 @@ spec:
                             credentials:
                               properties:
                                 secretName:
+                                  maxLength: 253
                                   type: string
                                 type:
                                   type: string

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -207,6 +207,7 @@ spec:
                     properties:
                       secretName:
                         maxLength: 253
+                        minLength: 1
                         type: string
                       type:
                         type: string
@@ -214,7 +215,7 @@ spec:
                     x-kubernetes-validations:
                     - message: secretName must be set when credentials type is userPrincipal
                       rule: '!has(self.type) || self.type != ''userPrincipal'' ||
-                        (has(self.secretName) && size(self.secretName) > 0)'
+                        has(self.secretName)'
                   maxObjSizeGB:
                     type: number
                   namespace:
@@ -1625,6 +1626,7 @@ spec:
                         properties:
                           secretName:
                             maxLength: 253
+                            minLength: 1
                             type: string
                           type:
                             type: string
@@ -1633,7 +1635,7 @@ spec:
                         - message: secretName must be set when credentials type is
                             userPrincipal
                           rule: '!has(self.type) || self.type != ''userPrincipal''
-                            || (has(self.secretName) && size(self.secretName) > 0)'
+                            || has(self.secretName)'
                       maxObjSizeGB:
                         type: number
                       namespace:
@@ -2805,6 +2807,7 @@ spec:
                               properties:
                                 secretName:
                                   maxLength: 253
+                                  minLength: 1
                                   type: string
                                 type:
                                   type: string
@@ -2813,8 +2816,7 @@ spec:
                               - message: secretName must be set when credentials type
                                   is userPrincipal
                                 rule: '!has(self.type) || self.type != ''userPrincipal''
-                                  || (has(self.secretName) && size(self.secretName)
-                                  > 0)'
+                                  || has(self.secretName)'
                             maxObjSizeGB:
                               type: number
                             namespace:

--- a/deploy/cw-bundle.yaml
+++ b/deploy/cw-bundle.yaml
@@ -213,7 +213,7 @@ spec:
                     x-kubernetes-validations:
                     - message: secretName must be set when credentials type is userPrincipal
                       rule: '!has(self.type) || self.type != ''userPrincipal'' ||
-                        (has(self.secretName) && self.secretName != '''')'
+                        (has(self.secretName) && self.secretName != ”)'
                   maxObjSizeGB:
                     type: number
                   namespace:
@@ -1631,7 +1631,7 @@ spec:
                         - message: secretName must be set when credentials type is
                             userPrincipal
                           rule: '!has(self.type) || self.type != ''userPrincipal''
-                            || (has(self.secretName) && self.secretName != '''')'
+                            || (has(self.secretName) && self.secretName != ”)'
                       maxObjSizeGB:
                         type: number
                       namespace:
@@ -2810,7 +2810,7 @@ spec:
                               - message: secretName must be set when credentials type
                                   is userPrincipal
                                 rule: '!has(self.type) || self.type != ''userPrincipal''
-                                  || (has(self.secretName) && self.secretName != '''')'
+                                  || (has(self.secretName) && self.secretName != ”)'
                             maxObjSizeGB:
                               type: number
                             namespace:

--- a/deploy/cw-bundle.yaml
+++ b/deploy/cw-bundle.yaml
@@ -213,7 +213,7 @@ spec:
                     x-kubernetes-validations:
                     - message: secretName must be set when credentials type is userPrincipal
                       rule: '!has(self.type) || self.type != ''userPrincipal'' ||
-                        (has(self.secretName) && self.secretName != ”)'
+                        (has(self.secretName) && size(self.secretName) > 0)'
                   maxObjSizeGB:
                     type: number
                   namespace:
@@ -1631,7 +1631,7 @@ spec:
                         - message: secretName must be set when credentials type is
                             userPrincipal
                           rule: '!has(self.type) || self.type != ''userPrincipal''
-                            || (has(self.secretName) && self.secretName != ”)'
+                            || (has(self.secretName) && size(self.secretName) > 0)'
                       maxObjSizeGB:
                         type: number
                       namespace:
@@ -2810,7 +2810,8 @@ spec:
                               - message: secretName must be set when credentials type
                                   is userPrincipal
                                 rule: '!has(self.type) || self.type != ''userPrincipal''
-                                  || (has(self.secretName) && self.secretName != ”)'
+                                  || (has(self.secretName) && size(self.secretName)
+                                  > 0)'
                             maxObjSizeGB:
                               type: number
                             namespace:

--- a/deploy/cw-bundle.yaml
+++ b/deploy/cw-bundle.yaml
@@ -206,6 +206,7 @@ spec:
                   credentials:
                     properties:
                       secretName:
+                        maxLength: 253
                         type: string
                       type:
                         type: string
@@ -1623,6 +1624,7 @@ spec:
                       credentials:
                         properties:
                           secretName:
+                            maxLength: 253
                             type: string
                           type:
                             type: string
@@ -2802,6 +2804,7 @@ spec:
                             credentials:
                               properties:
                                 secretName:
+                                  maxLength: 253
                                   type: string
                                 type:
                                   type: string

--- a/deploy/cw-bundle.yaml
+++ b/deploy/cw-bundle.yaml
@@ -207,6 +207,7 @@ spec:
                     properties:
                       secretName:
                         maxLength: 253
+                        minLength: 1
                         type: string
                       type:
                         type: string
@@ -214,7 +215,7 @@ spec:
                     x-kubernetes-validations:
                     - message: secretName must be set when credentials type is userPrincipal
                       rule: '!has(self.type) || self.type != ''userPrincipal'' ||
-                        (has(self.secretName) && size(self.secretName) > 0)'
+                        has(self.secretName)'
                   maxObjSizeGB:
                     type: number
                   namespace:
@@ -1625,6 +1626,7 @@ spec:
                         properties:
                           secretName:
                             maxLength: 253
+                            minLength: 1
                             type: string
                           type:
                             type: string
@@ -1633,7 +1635,7 @@ spec:
                         - message: secretName must be set when credentials type is
                             userPrincipal
                           rule: '!has(self.type) || self.type != ''userPrincipal''
-                            || (has(self.secretName) && size(self.secretName) > 0)'
+                            || has(self.secretName)'
                       maxObjSizeGB:
                         type: number
                       namespace:
@@ -2805,6 +2807,7 @@ spec:
                               properties:
                                 secretName:
                                   maxLength: 253
+                                  minLength: 1
                                   type: string
                                 type:
                                   type: string
@@ -2813,8 +2816,7 @@ spec:
                               - message: secretName must be set when credentials type
                                   is userPrincipal
                                 rule: '!has(self.type) || self.type != ''userPrincipal''
-                                  || (has(self.secretName) && size(self.secretName)
-                                  > 0)'
+                                  || has(self.secretName)'
                             maxObjSizeGB:
                               type: number
                             namespace:

--- a/e2e-tests/version-service/conf/crd.yaml
+++ b/e2e-tests/version-service/conf/crd.yaml
@@ -213,7 +213,7 @@ spec:
                     x-kubernetes-validations:
                     - message: secretName must be set when credentials type is userPrincipal
                       rule: '!has(self.type) || self.type != ''userPrincipal'' ||
-                        (has(self.secretName) && self.secretName != '''')'
+                        (has(self.secretName) && self.secretName != ”)'
                   maxObjSizeGB:
                     type: number
                   namespace:
@@ -1631,7 +1631,7 @@ spec:
                         - message: secretName must be set when credentials type is
                             userPrincipal
                           rule: '!has(self.type) || self.type != ''userPrincipal''
-                            || (has(self.secretName) && self.secretName != '''')'
+                            || (has(self.secretName) && self.secretName != ”)'
                       maxObjSizeGB:
                         type: number
                       namespace:
@@ -2810,7 +2810,7 @@ spec:
                               - message: secretName must be set when credentials type
                                   is userPrincipal
                                 rule: '!has(self.type) || self.type != ''userPrincipal''
-                                  || (has(self.secretName) && self.secretName != '''')'
+                                  || (has(self.secretName) && self.secretName != ”)'
                             maxObjSizeGB:
                               type: number
                             namespace:

--- a/e2e-tests/version-service/conf/crd.yaml
+++ b/e2e-tests/version-service/conf/crd.yaml
@@ -213,7 +213,7 @@ spec:
                     x-kubernetes-validations:
                     - message: secretName must be set when credentials type is userPrincipal
                       rule: '!has(self.type) || self.type != ''userPrincipal'' ||
-                        (has(self.secretName) && self.secretName != ”)'
+                        (has(self.secretName) && size(self.secretName) > 0)'
                   maxObjSizeGB:
                     type: number
                   namespace:
@@ -1631,7 +1631,7 @@ spec:
                         - message: secretName must be set when credentials type is
                             userPrincipal
                           rule: '!has(self.type) || self.type != ''userPrincipal''
-                            || (has(self.secretName) && self.secretName != ”)'
+                            || (has(self.secretName) && size(self.secretName) > 0)'
                       maxObjSizeGB:
                         type: number
                       namespace:
@@ -2810,7 +2810,8 @@ spec:
                               - message: secretName must be set when credentials type
                                   is userPrincipal
                                 rule: '!has(self.type) || self.type != ''userPrincipal''
-                                  || (has(self.secretName) && self.secretName != ”)'
+                                  || (has(self.secretName) && size(self.secretName)
+                                  > 0)'
                             maxObjSizeGB:
                               type: number
                             namespace:

--- a/e2e-tests/version-service/conf/crd.yaml
+++ b/e2e-tests/version-service/conf/crd.yaml
@@ -206,6 +206,7 @@ spec:
                   credentials:
                     properties:
                       secretName:
+                        maxLength: 253
                         type: string
                       type:
                         type: string
@@ -1623,6 +1624,7 @@ spec:
                       credentials:
                         properties:
                           secretName:
+                            maxLength: 253
                             type: string
                           type:
                             type: string
@@ -2802,6 +2804,7 @@ spec:
                             credentials:
                               properties:
                                 secretName:
+                                  maxLength: 253
                                   type: string
                                 type:
                                   type: string

--- a/e2e-tests/version-service/conf/crd.yaml
+++ b/e2e-tests/version-service/conf/crd.yaml
@@ -207,6 +207,7 @@ spec:
                     properties:
                       secretName:
                         maxLength: 253
+                        minLength: 1
                         type: string
                       type:
                         type: string
@@ -214,7 +215,7 @@ spec:
                     x-kubernetes-validations:
                     - message: secretName must be set when credentials type is userPrincipal
                       rule: '!has(self.type) || self.type != ''userPrincipal'' ||
-                        (has(self.secretName) && size(self.secretName) > 0)'
+                        has(self.secretName)'
                   maxObjSizeGB:
                     type: number
                   namespace:
@@ -1625,6 +1626,7 @@ spec:
                         properties:
                           secretName:
                             maxLength: 253
+                            minLength: 1
                             type: string
                           type:
                             type: string
@@ -1633,7 +1635,7 @@ spec:
                         - message: secretName must be set when credentials type is
                             userPrincipal
                           rule: '!has(self.type) || self.type != ''userPrincipal''
-                            || (has(self.secretName) && size(self.secretName) > 0)'
+                            || has(self.secretName)'
                       maxObjSizeGB:
                         type: number
                       namespace:
@@ -2805,6 +2807,7 @@ spec:
                               properties:
                                 secretName:
                                   maxLength: 253
+                                  minLength: 1
                                   type: string
                                 type:
                                   type: string
@@ -2813,8 +2816,7 @@ spec:
                               - message: secretName must be set when credentials type
                                   is userPrincipal
                                 rule: '!has(self.type) || self.type != ''userPrincipal''
-                                  || (has(self.secretName) && size(self.secretName)
-                                  > 0)'
+                                  || has(self.secretName)'
                             maxObjSizeGB:
                               type: number
                             namespace:

--- a/pkg/apis/psmdb/v1/psmdb_types.go
+++ b/pkg/apis/psmdb/v1/psmdb_types.go
@@ -1407,7 +1407,7 @@ const (
 	AuthTypeOkeWorkloadIdentity OCIAuthType = "okeWorkloadIdentity"
 )
 
-// +kubebuilder:validation:XValidation:rule="!has(self.type) || self.type != 'userPrincipal' || (has(self.secretName) && self.secretName != ”)",message="secretName must be set when credentials type is userPrincipal"
+// +kubebuilder:validation:XValidation:rule="!has(self.type) || self.type != 'userPrincipal' || (has(self.secretName) && size(self.secretName) > 0)",message="secretName must be set when credentials type is userPrincipal"
 type OCICredentialsSpec struct {
 	Type       OCIAuthType `json:"type,omitempty"`
 	SecretName string      `json:"secretName,omitempty"`

--- a/pkg/apis/psmdb/v1/psmdb_types.go
+++ b/pkg/apis/psmdb/v1/psmdb_types.go
@@ -1407,9 +1407,10 @@ const (
 	AuthTypeOkeWorkloadIdentity OCIAuthType = "okeWorkloadIdentity"
 )
 
-// +kubebuilder:validation:XValidation:rule="!has(self.type) || self.type != 'userPrincipal' || (has(self.secretName) && size(self.secretName) > 0)",message="secretName must be set when credentials type is userPrincipal"
+// +kubebuilder:validation:XValidation:rule="!has(self.type) || self.type != 'userPrincipal' || has(self.secretName)",message="secretName must be set when credentials type is userPrincipal"
 type OCICredentialsSpec struct {
 	Type OCIAuthType `json:"type,omitempty"`
+	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
 	SecretName string `json:"secretName,omitempty"`
 }

--- a/pkg/apis/psmdb/v1/psmdb_types.go
+++ b/pkg/apis/psmdb/v1/psmdb_types.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -694,8 +695,8 @@ func (h *HiddenSpec) GetSize() int32 {
 
 type MongoConfiguration string
 
-func (conf MongoConfiguration) GetOptions(name string) (map[interface{}]interface{}, error) {
-	m := make(map[string]interface{})
+func (conf MongoConfiguration) GetOptions(name string) (map[any]any, error) {
+	m := make(map[string]any)
 	err := yaml.Unmarshal([]byte(conf), m)
 	if err != nil {
 		return nil, err
@@ -704,7 +705,7 @@ func (conf MongoConfiguration) GetOptions(name string) (map[interface{}]interfac
 	if !ok {
 		return nil, nil
 	}
-	options, _ := val.(map[interface{}]interface{})
+	options, _ := val.(map[any]any)
 	return options, nil
 }
 
@@ -849,7 +850,7 @@ func (conf *MongoConfiguration) SetPort(port int32) error {
 
 // setEncryptionDefaults sets encryptionKeyFile to a default value if enableEncryption is specified.
 func (conf *MongoConfiguration) setEncryptionDefaults() error {
-	m := make(map[string]interface{})
+	m := make(map[string]any)
 
 	err := yaml.Unmarshal([]byte(*conf), m)
 	if err != nil {
@@ -861,7 +862,7 @@ func (conf *MongoConfiguration) setEncryptionDefaults() error {
 		return nil
 	}
 
-	security, ok := val.(map[interface{}]interface{})
+	security, ok := val.(map[any]any)
 	if !ok {
 		return errors.New("security configuration section is invalid")
 	}
@@ -1024,13 +1025,7 @@ func (l LivenessProbeExtended) CommandHas(flag string) bool {
 		return false
 	}
 
-	for _, v := range l.ProbeHandler.Exec.Command {
-		if v == flag {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(l.ProbeHandler.Exec.Command, flag)
 }
 
 type VolumeSpec struct {
@@ -1412,7 +1407,7 @@ const (
 	AuthTypeOkeWorkloadIdentity OCIAuthType = "okeWorkloadIdentity"
 )
 
-// +kubebuilder:validation:XValidation:rule="!has(self.type) || self.type != 'userPrincipal' || (has(self.secretName) && self.secretName != '')",message="secretName must be set when credentials type is userPrincipal"
+// +kubebuilder:validation:XValidation:rule="!has(self.type) || self.type != 'userPrincipal' || (has(self.secretName) && self.secretName != ”)",message="secretName must be set when credentials type is userPrincipal"
 type OCICredentialsSpec struct {
 	Type       OCIAuthType `json:"type,omitempty"`
 	SecretName string      `json:"secretName,omitempty"`

--- a/pkg/apis/psmdb/v1/psmdb_types.go
+++ b/pkg/apis/psmdb/v1/psmdb_types.go
@@ -1409,8 +1409,9 @@ const (
 
 // +kubebuilder:validation:XValidation:rule="!has(self.type) || self.type != 'userPrincipal' || (has(self.secretName) && size(self.secretName) > 0)",message="secretName must be set when credentials type is userPrincipal"
 type OCICredentialsSpec struct {
-	Type       OCIAuthType `json:"type,omitempty"`
-	SecretName string      `json:"secretName,omitempty"`
+	Type OCIAuthType `json:"type,omitempty"`
+	// +kubebuilder:validation:MaxLength=253
+	SecretName string `json:"secretName,omitempty"`
 }
 
 type OCIRetryerSpec struct {

--- a/pkg/apis/psmdb/v1/psmdb_types.go
+++ b/pkg/apis/psmdb/v1/psmdb_types.go
@@ -1021,11 +1021,11 @@ type LivenessProbeExtended struct {
 }
 
 func (l LivenessProbeExtended) CommandHas(flag string) bool {
-	if l.ProbeHandler.Exec == nil {
+	if l.Exec == nil {
 		return false
 	}
 
-	return slices.Contains(l.ProbeHandler.Exec.Command, flag)
+	return slices.Contains(l.Exec.Command, flag)
 }
 
 type VolumeSpec struct {

--- a/pkg/controller/perconaservermongodb/backup.go
+++ b/pkg/controller/perconaservermongodb/backup.go
@@ -135,7 +135,7 @@ func (r *ReconcilePerconaServerMongoDB) createOrUpdateBackupTask(ctx context.Con
 func (r *ReconcilePerconaServerMongoDB) deleteOldBackupTasks(ctx context.Context, cr *api.PerconaServerMongoDB, ctasks map[string]api.BackupTaskSpec) error {
 	log := logf.FromContext(ctx)
 
-	r.crons.backupJobs.Range(func(k, v interface{}) bool {
+	r.crons.backupJobs.Range(func(k, v any) bool {
 		item := v.(BackupScheduleJob)
 
 		if item.ClusterName != "" && item.ClusterName != cr.NamespacedName().String() {
@@ -269,11 +269,11 @@ func (h minHeap) Less(i, j int) bool {
 
 func (h minHeap) Swap(i, j int) { h[i], h[j] = h[j], h[i] }
 
-func (h *minHeap) Push(x interface{}) {
+func (h *minHeap) Push(x any) {
 	*h = append(*h, x.(api.PerconaServerMongoDBBackup))
 }
 
-func (h *minHeap) Pop() interface{} {
+func (h *minHeap) Pop() any {
 	old := *h
 	n := len(old)
 	x := old[n-1]
@@ -355,7 +355,6 @@ func getLatestBackup(ctx context.Context, cl client.Client, cr *api.PerconaServe
 
 	var latest *api.PerconaServerMongoDBBackup
 	for _, b := range backups.Items {
-		b := b
 
 		if b.Status.State != api.BackupStateReady || b.Spec.GetClusterName() != cr.Name {
 			continue

--- a/pkg/controller/perconaservermongodb/custom_users.go
+++ b/pkg/controller/perconaservermongodb/custom_users.go
@@ -278,7 +278,7 @@ func toMongoRoleModel(role api.Role) (*mongo.Role, error) {
 
 		rp := mongo.RolePrivilege{
 			Actions:  p.Actions,
-			Resource: make(map[string]interface{}, 3),
+			Resource: make(map[string]any, 3),
 		}
 
 		if p.Resource.Cluster != nil {

--- a/pkg/controller/perconaservermongodb/custom_users_test.go
+++ b/pkg/controller/perconaservermongodb/custom_users_test.go
@@ -122,14 +122,14 @@ func TestRolesChanged(t *testing.T) {
 	r2 := &mongo.Role{
 		Privileges: []mongo.RolePrivilege{
 			{
-				Resource: map[string]interface{}{
+				Resource: map[string]any{
 					"db":         "test",
 					"collection": "test",
 				},
 				Actions: []string{"find"},
 			},
 			{
-				Resource: map[string]interface{}{
+				Resource: map[string]any{
 					"db":         "test-two",
 					"collection": "test-two",
 				},
@@ -169,14 +169,14 @@ func TestRolesChanged(t *testing.T) {
 			r1: &mongo.Role{
 				Privileges: []mongo.RolePrivilege{
 					{
-						Resource: map[string]interface{}{
+						Resource: map[string]any{
 							"collection": "test",
 							"db":         "test",
 						},
 						Actions: []string{"find"},
 					},
 					{
-						Resource: map[string]interface{}{
+						Resource: map[string]any{
 							"db":         "test-two",
 							"collection": "test-two",
 						},
@@ -211,14 +211,14 @@ func TestRolesChanged(t *testing.T) {
 			r1: &mongo.Role{
 				Privileges: []mongo.RolePrivilege{
 					{
-						Resource: map[string]interface{}{
+						Resource: map[string]any{
 							"collection": "test",
 							"db":         "test",
 						},
 						Actions: []string{"find", "update"},
 					},
 					{
-						Resource: map[string]interface{}{
+						Resource: map[string]any{
 							"db":         "test-two",
 							"collection": "test-two-different",
 						},
@@ -257,14 +257,14 @@ func TestRolesChanged(t *testing.T) {
 			r1: &mongo.Role{
 				Privileges: []mongo.RolePrivilege{
 					{
-						Resource: map[string]interface{}{
+						Resource: map[string]any{
 							"collection": "test",
 							"db":         "test",
 						},
 						Actions: []string{"find", "update"},
 					},
 					{
-						Resource: map[string]interface{}{
+						Resource: map[string]any{
 							"db":         "test-two",
 							"collection": "test-two-different",
 						},
@@ -299,14 +299,14 @@ func TestRolesChanged(t *testing.T) {
 			r1: &mongo.Role{
 				Privileges: []mongo.RolePrivilege{
 					{
-						Resource: map[string]interface{}{
+						Resource: map[string]any{
 							"db":         "test",
 							"collection": "test",
 						},
 						Actions: []string{"find"},
 					},
 					{
-						Resource: map[string]interface{}{
+						Resource: map[string]any{
 							"collection": "test-two",
 							"db":         "test-two",
 						},

--- a/pkg/controller/perconaservermongodb/mgo.go
+++ b/pkg/controller/perconaservermongodb/mgo.go
@@ -20,7 +20,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
-	"k8s.io/utils/ptr"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
@@ -269,7 +268,7 @@ func (r *ReconcilePerconaServerMongoDB) reconcileCluster(ctx context.Context, cr
 				log.Info("added to shard", "rs", rsName)
 			}
 
-			rsStatus.AddedAsShard = ptr.To(true)
+			rsStatus.AddedAsShard = new(true)
 			cr.Status.Replsets[replset.Name] = rsStatus
 		} else {
 			return api.AppStateInit, nil, nil
@@ -976,7 +975,7 @@ func getRoles(cr *api.PerconaServerMongoDB, role api.SystemUserRole) []mongo.Rol
 }
 
 // compareResources compares two map[string]interface{} values and returns true if they are equal
-func compareResources(x, y map[string]interface{}) bool {
+func compareResources(x, y map[string]any) bool {
 	if len(x) != len(y) {
 		return false
 	}
@@ -1097,7 +1096,7 @@ func (r *ReconcilePerconaServerMongoDB) createOrUpdateSystemUsers(ctx context.Co
 	if cr.CompareVersion("1.12.0") >= 0 {
 		privileges := []mongo.RolePrivilege{
 			{
-				Resource: map[string]interface{}{
+				Resource: map[string]any{
 					"db":         "",
 					"collection": "system.profile",
 				},
@@ -1114,7 +1113,7 @@ func (r *ReconcilePerconaServerMongoDB) createOrUpdateSystemUsers(ctx context.Co
 		if cr.CompareVersion("1.15.0") >= 0 {
 			privileges = []mongo.RolePrivilege{
 				{
-					Resource: map[string]interface{}{
+					Resource: map[string]any{
 						"db":         "",
 						"collection": "",
 					},
@@ -1128,7 +1127,7 @@ func (r *ReconcilePerconaServerMongoDB) createOrUpdateSystemUsers(ctx context.Co
 					},
 				},
 				{
-					Resource: map[string]interface{}{
+					Resource: map[string]any{
 						"db":         "",
 						"collection": "system.profile",
 					},
@@ -1142,7 +1141,7 @@ func (r *ReconcilePerconaServerMongoDB) createOrUpdateSystemUsers(ctx context.Co
 		}
 		if cr.CompareVersion("1.16.0") >= 0 {
 			privileges = append(privileges, mongo.RolePrivilege{
-				Resource: map[string]interface{}{
+				Resource: map[string]any{
 					"db":         "admin",
 					"collection": "system.version",
 				},
@@ -1160,7 +1159,7 @@ func (r *ReconcilePerconaServerMongoDB) createOrUpdateSystemUsers(ctx context.Co
 
 	err = r.createOrUpdateSystemRoles(ctx, cli, "pbmAnyAction",
 		[]mongo.RolePrivilege{{
-			Resource: map[string]interface{}{"anyResource": true},
+			Resource: map[string]any{"anyResource": true},
 			Actions:  []string{"anyAction"},
 		}})
 	if err != nil {

--- a/pkg/controller/perconaservermongodb/pbm_test.go
+++ b/pkg/controller/perconaservermongodb/pbm_test.go
@@ -720,7 +720,7 @@ func TestHashPBMConfiguration(t *testing.T) {
 		}
 		hash1, err := hashPBMConfiguration(cfg, cr)
 		require.NoError(t, err)
-		for i := 0; i < 200; i++ {
+		for i := range 200 {
 			h, err := hashPBMConfiguration(cfg, cr)
 			require.NoError(t, err)
 			require.Equal(t, hash1, h, "hash flapped on iteration %d", i)

--- a/pkg/controller/perconaservermongodb/psmdb_controller.go
+++ b/pkg/controller/perconaservermongodb/psmdb_controller.go
@@ -6,6 +6,7 @@ import (
 	stderrors "errors"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"sort"
 	"strings"
@@ -650,9 +651,7 @@ func (r *ReconcilePerconaServerMongoDB) reconcileReplsets(ctx context.Context, c
 
 		if rs, ok := cr.Status.Replsets[replset.Name]; ok {
 			rs.Members = make(map[string]api.ReplsetMemberStatus)
-			for pod, member := range members {
-				rs.Members[pod] = member
-			}
+			maps.Copy(rs.Members, members)
 			cr.Status.Replsets[replset.Name] = rs
 		}
 	}
@@ -1047,8 +1046,8 @@ func (r *ReconcilePerconaServerMongoDB) deleteOrphanPVCs(ctx context.Context, cr
 				mongodPodsMap[pod.Name] = true
 			}
 			for _, pvc := range mongodPVCs.Items {
-				if strings.HasPrefix(pvc.Name, psmdbconfig.MongodDataVolClaimName+"-") {
-					podName := strings.TrimPrefix(pvc.Name, psmdbconfig.MongodDataVolClaimName+"-")
+				if after, ok := strings.CutPrefix(pvc.Name, psmdbconfig.MongodDataVolClaimName+"-"); ok {
+					podName := after
 					if _, ok := mongodPodsMap[podName]; !ok {
 						// remove the orphan pvc
 						logf.FromContext(ctx).Info("remove orphan pvc", "pvc", pvc.Name)
@@ -1557,9 +1556,7 @@ func (r *ReconcilePerconaServerMongoDB) reconcileMongosStatefulset(ctx context.C
 		templateSpec.Annotations = make(map[string]string)
 	}
 
-	for k, v := range sslAnn {
-		templateSpec.Annotations[k] = v
-	}
+	maps.Copy(templateSpec.Annotations, sslAnn)
 
 	secret := new(corev1.Secret)
 	err = r.client.Get(ctx, types.NamespacedName{Name: api.UserSecretName(cr), Namespace: cr.Namespace}, secret)

--- a/pkg/controller/perconaservermongodb/smart.go
+++ b/pkg/controller/perconaservermongodb/smart.go
@@ -520,7 +520,7 @@ func (r *ReconcilePerconaServerMongoDB) applyNWait(ctx context.Context, cr *api.
 }
 
 func (r *ReconcilePerconaServerMongoDB) waitPodRestart(ctx context.Context, cr *api.PerconaServerMongoDB, updateRevision string, pod *corev1.Pod, waitLimit int) error {
-	for i := 0; i < waitLimit; i++ {
+	for range waitLimit {
 		time.Sleep(time.Second * 1)
 
 		err := r.client.Get(ctx, types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}, pod)

--- a/pkg/controller/perconaservermongodb/statefulset_test.go
+++ b/pkg/controller/perconaservermongodb/statefulset_test.go
@@ -12,7 +12,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/yaml"
@@ -54,7 +53,7 @@ func TestReconcileStatefulSet(t *testing.T) {
 				LocalObjectReference: corev1.LocalObjectReference{
 					Name: "test-configmap",
 				},
-				Optional: ptr.To(true),
+				Optional: new(true),
 			},
 		},
 	}
@@ -68,7 +67,7 @@ func TestReconcileStatefulSet(t *testing.T) {
 				LocalObjectReference: corev1.LocalObjectReference{
 					Name: "test-configmap-cfg",
 				},
-				Optional: ptr.To(true),
+				Optional: new(true),
 			},
 		},
 	}

--- a/pkg/controller/perconaservermongodb/volume_autoscaling.go
+++ b/pkg/controller/perconaservermongodb/volume_autoscaling.go
@@ -255,8 +255,8 @@ func (r *ReconcilePerconaServerMongoDB) updateAutoscalingStatus(
 // Pod format: "<statefulset-name>-<index>"
 func extractPodNameFromPVC(pvcName string, stsName string) string {
 	prefix := config.MongodDataVolClaimName + "-"
-	if strings.HasPrefix(pvcName, prefix) {
-		return strings.TrimPrefix(pvcName, prefix)
+	if after, ok := strings.CutPrefix(pvcName, prefix); ok {
+		return after
 	}
 	return ""
 }

--- a/pkg/controller/perconaservermongodbbackup/backup_test.go
+++ b/pkg/controller/perconaservermongodbbackup/backup_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	bsonv2 "go.mongodb.org/mongo-driver/v2/bson"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	pbmBackup "github.com/percona/percona-backup-mongodb/pbm/backup"
 	"github.com/percona/percona-backup-mongodb/pbm/defs"
@@ -286,7 +285,7 @@ func TestBackup_Status(t *testing.T) {
 			cluster: &api.PerconaServerMongoDB{
 				Spec: api.PerconaServerMongoDBSpec{
 					Backup: api.BackupSpec{
-						StartingDeadlineSeconds: ptr.To(int64(10)),
+						StartingDeadlineSeconds: new(int64(10)),
 					},
 				},
 			},

--- a/pkg/controller/perconaservermongodbbackup/deadline_test.go
+++ b/pkg/controller/perconaservermongodbbackup/deadline_test.go
@@ -10,7 +10,6 @@ import (
 	. "github.com/onsi/gomega"
 	_ "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/yaml"
 
 	psmdbv1 "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
@@ -40,7 +39,7 @@ var _ = Describe("Starting deadline", func() {
 		bcp, err := readDefaultBackup("backup1", "test")
 		Expect(err).ToNot(HaveOccurred())
 
-		cluster.Spec.Backup.StartingDeadlineSeconds = ptr.To(int64(60))
+		cluster.Spec.Backup.StartingDeadlineSeconds = new(int64(60))
 
 		bcp.Status.State = psmdbv1.BackupStateNew
 		bcp.CreationTimestamp = metav1.NewTime(time.Now().Add(-2 * time.Minute))
@@ -56,11 +55,11 @@ var _ = Describe("Starting deadline", func() {
 		bcp, err := readDefaultBackup("backup1", "test")
 		Expect(err).ToNot(HaveOccurred())
 
-		cluster.Spec.Backup.StartingDeadlineSeconds = ptr.To(int64(600))
+		cluster.Spec.Backup.StartingDeadlineSeconds = new(int64(600))
 
 		bcp.Status.State = psmdbv1.BackupStateNew
 		bcp.CreationTimestamp = metav1.NewTime(time.Now().Add(-2 * time.Minute))
-		bcp.Spec.StartingDeadlineSeconds = ptr.To(int64(60))
+		bcp.Spec.StartingDeadlineSeconds = new(int64(60))
 
 		err = checkStartingDeadline(context.Background(), cluster, bcp)
 		Expect(err).To(HaveOccurred())
@@ -73,11 +72,11 @@ var _ = Describe("Starting deadline", func() {
 		bcp, err := readDefaultBackup("backup1", "test")
 		Expect(err).ToNot(HaveOccurred())
 
-		cluster.Spec.Backup.StartingDeadlineSeconds = ptr.To(int64(600))
+		cluster.Spec.Backup.StartingDeadlineSeconds = new(int64(600))
 
 		bcp.Status.State = psmdbv1.BackupStateNew
 		bcp.CreationTimestamp = metav1.NewTime(time.Now().Add(-2 * time.Minute))
-		bcp.Spec.StartingDeadlineSeconds = ptr.To(int64(300))
+		bcp.Spec.StartingDeadlineSeconds = new(int64(300))
 
 		err = checkStartingDeadline(context.Background(), cluster, bcp)
 		Expect(err).ToNot(HaveOccurred())

--- a/pkg/controller/perconaservermongodbbackup/lease_test.go
+++ b/pkg/controller/perconaservermongodbbackup/lease_test.go
@@ -221,6 +221,3 @@ func backupWithState(name, namespace, uid, clusterName string, state psmdbv1.Bac
 		Status: psmdbv1.PerconaServerMongoDBBackupStatus{State: state},
 	}
 }
-
-//go:fix inline
-func stringPtr(s string) *string { return new(s) }

--- a/pkg/controller/perconaservermongodbbackup/lease_test.go
+++ b/pkg/controller/perconaservermongodbbackup/lease_test.go
@@ -222,4 +222,5 @@ func backupWithState(name, namespace, uid, clusterName string, state psmdbv1.Bac
 	}
 }
 
-func stringPtr(s string) *string { return &s }
+//go:fix inline
+func stringPtr(s string) *string { return new(s) }

--- a/pkg/controller/perconaservermongodbbackup/psmdb_backup_controller.go
+++ b/pkg/controller/perconaservermongodbbackup/psmdb_backup_controller.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	stderrors "errors"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -394,10 +395,8 @@ func (r *ReconcilePerconaServerMongoDBBackup) ensureReleaseLockFinalizer(
 	ctx context.Context,
 	cr *psmdbv1.PerconaServerMongoDBBackup,
 ) error {
-	for _, f := range cr.GetFinalizers() {
-		if f == naming.FinalizerReleaseLock {
-			return nil
-		}
+	if slices.Contains(cr.GetFinalizers(), naming.FinalizerReleaseLock) {
+		return nil
 	}
 
 	orig := cr.DeepCopy()

--- a/pkg/controller/perconaservermongodbbackup/snapshot_test.go
+++ b/pkg/controller/perconaservermongodbbackup/snapshot_test.go
@@ -18,7 +18,6 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -139,7 +138,7 @@ func TestSnapshotBackups_ReconcileSnapshot(t *testing.T) {
 			Namespace: namespace,
 		},
 		Spec: api.PerconaServerMongoDBBackupSpec{
-			VolumeSnapshotClass: ptr.To("csi-snapclass"),
+			VolumeSnapshotClass: new("csi-snapclass"),
 		},
 	}
 
@@ -149,7 +148,7 @@ func TestSnapshotBackups_ReconcileSnapshot(t *testing.T) {
 			Namespace: namespace,
 		},
 		Status: &volumesnapshotv1.VolumeSnapshotStatus{
-			ReadyToUse: ptr.To(true),
+			ReadyToUse: new(true),
 		},
 	}
 
@@ -166,7 +165,7 @@ func TestSnapshotBackups_ReconcileSnapshot(t *testing.T) {
 			check: func(t *testing.T, snapshot *volumesnapshotv1.VolumeSnapshot) {
 				assert.Equal(t, naming.VolumeSnapshotName(bcp, "rs0"), snapshot.GetName())
 				assert.Equal(t, namespace, snapshot.GetNamespace())
-				assert.Equal(t, ptr.To("csi-snapclass"), snapshot.Spec.VolumeSnapshotClassName)
+				assert.Equal(t, new("csi-snapclass"), snapshot.Spec.VolumeSnapshotClassName)
 				require.NotNil(t, snapshot.Spec.Source.PersistentVolumeClaimName)
 				assert.Equal(t, "mongod-data-pod-0", *snapshot.Spec.Source.PersistentVolumeClaimName)
 			},
@@ -178,7 +177,7 @@ func TestSnapshotBackups_ReconcileSnapshot(t *testing.T) {
 			check: func(t *testing.T, snapshot *volumesnapshotv1.VolumeSnapshot) {
 				assert.Equal(t, naming.VolumeSnapshotName(bcp, "rs0"), snapshot.GetName())
 				require.NotNil(t, snapshot.Status)
-				assert.Equal(t, ptr.To(true), snapshot.Status.ReadyToUse)
+				assert.Equal(t, new(true), snapshot.Status.ReadyToUse)
 			},
 		},
 	}
@@ -219,7 +218,7 @@ func TestSnapshotBackups_ReconcileSnapshots(t *testing.T) {
 			Namespace: namespace,
 		},
 		Spec: api.PerconaServerMongoDBBackupSpec{
-			VolumeSnapshotClass: ptr.To("csi-snapclass"),
+			VolumeSnapshotClass: new("csi-snapclass"),
 		},
 	}
 
@@ -234,7 +233,7 @@ func TestSnapshotBackups_ReconcileSnapshots(t *testing.T) {
 				Namespace: namespace,
 			},
 			Status: &volumesnapshotv1.VolumeSnapshotStatus{
-				ReadyToUse: ptr.To(true),
+				ReadyToUse: new(true),
 			},
 		}
 	}
@@ -282,7 +281,7 @@ func TestSnapshotBackups_ReconcileSnapshots(t *testing.T) {
 						Namespace: namespace,
 					},
 					Status: &volumesnapshotv1.VolumeSnapshotStatus{
-						ReadyToUse: ptr.To(false),
+						ReadyToUse: new(false),
 					},
 				},
 			},
@@ -305,7 +304,7 @@ func TestSnapshotBackups_ReconcileSnapshots(t *testing.T) {
 					},
 					Status: &volumesnapshotv1.VolumeSnapshotStatus{
 						Error: &volumesnapshotv1.VolumeSnapshotError{
-							Message: ptr.To("snapshot creation failed: insufficient storage"),
+							Message: new("snapshot creation failed: insufficient storage"),
 						},
 					},
 				},
@@ -379,7 +378,7 @@ func TestSnapshotBackups_Status(t *testing.T) {
 			},
 			Spec: api.PerconaServerMongoDBBackupSpec{
 				Type:                defs.ExternalBackup,
-				VolumeSnapshotClass: ptr.To("csi-snapclass"),
+				VolumeSnapshotClass: new("csi-snapclass"),
 			},
 			Status: api.PerconaServerMongoDBBackupStatus{
 				PBMname: pbmName,
@@ -396,7 +395,7 @@ func TestSnapshotBackups_Status(t *testing.T) {
 			Namespace: namespace,
 		},
 		Status: &volumesnapshotv1.VolumeSnapshotStatus{
-			ReadyToUse: ptr.To(true),
+			ReadyToUse: new(true),
 		},
 	}
 
@@ -406,7 +405,7 @@ func TestSnapshotBackups_Status(t *testing.T) {
 			Namespace: namespace,
 		},
 		Status: &volumesnapshotv1.VolumeSnapshotStatus{
-			ReadyToUse: ptr.To(false),
+			ReadyToUse: new(false),
 		},
 	}
 
@@ -508,7 +507,7 @@ func TestSnapshotBackups_Status(t *testing.T) {
 			cluster: &api.PerconaServerMongoDB{
 				Spec: api.PerconaServerMongoDBSpec{
 					Backup: api.BackupSpec{
-						StartingDeadlineSeconds: ptr.To(int64(10)),
+						StartingDeadlineSeconds: new(int64(10)),
 					},
 				},
 			},
@@ -618,7 +617,7 @@ func TestSnapshotBackups_Status(t *testing.T) {
 					},
 					Status: &volumesnapshotv1.VolumeSnapshotStatus{
 						Error: &volumesnapshotv1.VolumeSnapshotError{
-							Message: ptr.To("csi driver error: disk unavailable"),
+							Message: new("csi driver error: disk unavailable"),
 						},
 					},
 				},

--- a/pkg/controller/perconaservermongodbclustersync/lease_test.go
+++ b/pkg/controller/perconaservermongodbclustersync/lease_test.go
@@ -2,6 +2,7 @@ package perconaservermongodbclustersync
 
 import (
 	"context"
+	"slices"
 	"testing"
 	"time"
 
@@ -111,10 +112,10 @@ func TestReleaseClusterSyncLease(t *testing.T) {
 
 func TestAcquireClusterSyncLease(t *testing.T) {
 	tests := map[string]struct {
-		seedLease    bool
-		seedHolder   string
-		wantForeign  string
-		wantCreated  bool
+		seedLease   bool
+		seedHolder  string
+		wantForeign string
+		wantCreated bool
 	}{
 		"no lease: acquires, no foreign holder": {
 			seedLease:   false,
@@ -176,9 +177,9 @@ func TestEnsureReleaseLockFinalizer(t *testing.T) {
 		existing []string
 		wantAdd  bool
 	}{
-		"no finalizers: adds release-lock":            {existing: nil, wantAdd: true},
-		"unrelated finalizer present: appends":        {existing: []string{"other.example/x"}, wantAdd: true},
-		"already present: no patch needed, no error":  {existing: []string{naming.FinalizerReleaseLock}, wantAdd: false},
+		"no finalizers: adds release-lock":           {existing: nil, wantAdd: true},
+		"unrelated finalizer present: appends":       {existing: []string{"other.example/x"}, wantAdd: true},
+		"already present: no patch needed, no error": {existing: []string{naming.FinalizerReleaseLock}, wantAdd: false},
 	}
 
 	for name, tc := range tests {
@@ -192,13 +193,7 @@ func TestEnsureReleaseLockFinalizer(t *testing.T) {
 			got := &psmdbv1.PerconaServerMongoDBClusterSync{}
 			require.NoError(t, cl.Get(context.Background(), types.NamespacedName{Name: cr.Name, Namespace: cr.Namespace}, got))
 
-			has := false
-			for _, f := range got.Finalizers {
-				if f == naming.FinalizerReleaseLock {
-					has = true
-					break
-				}
-			}
+			has := slices.Contains(got.Finalizers, naming.FinalizerReleaseLock)
 			assert.True(t, has, "release-lock finalizer must be present")
 			if tc.wantAdd {
 				assert.Greater(t, len(got.Finalizers), len(tc.existing))

--- a/pkg/controller/perconaservermongodbclustersync/psmdb_clustersync_controller.go
+++ b/pkg/controller/perconaservermongodbclustersync/psmdb_clustersync_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	stderrors "errors"
 	"fmt"
+	"slices"
 	"time"
 
 	clustersyncclient "github.com/percona/percona-server-mongodb-operator/pkg/psmdb/clustersync/client"
@@ -212,13 +213,7 @@ func (r *ReconcilePerconaServerMongoDBClusterSync) Reconcile(ctx context.Context
 func (r *ReconcilePerconaServerMongoDBClusterSync) handleDeletion(ctx context.Context, cr *psmdbv1.PerconaServerMongoDBClusterSync) (reconcile.Result, error) {
 	log := logf.FromContext(ctx)
 
-	hasFinalizer := false
-	for _, f := range cr.GetFinalizers() {
-		if f == naming.FinalizerReleaseLock {
-			hasFinalizer = true
-			break
-		}
-	}
+	hasFinalizer := slices.Contains(cr.GetFinalizers(), naming.FinalizerReleaseLock)
 	if !hasFinalizer {
 		return reconcile.Result{}, nil
 	}
@@ -244,10 +239,8 @@ func (r *ReconcilePerconaServerMongoDBClusterSync) handleDeletion(ctx context.Co
 }
 
 func (r *ReconcilePerconaServerMongoDBClusterSync) ensureReleaseLockFinalizer(ctx context.Context, cr *psmdbv1.PerconaServerMongoDBClusterSync) error {
-	for _, f := range cr.GetFinalizers() {
-		if f == naming.FinalizerReleaseLock {
-			return nil
-		}
+	if slices.Contains(cr.GetFinalizers(), naming.FinalizerReleaseLock) {
+		return nil
 	}
 	orig := cr.DeepCopy()
 	cr.SetFinalizers(append(cr.GetFinalizers(), naming.FinalizerReleaseLock))

--- a/pkg/controller/perconaservermongodbrestore/snapshots.go
+++ b/pkg/controller/perconaservermongodbrestore/snapshots.go
@@ -18,7 +18,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -264,7 +263,7 @@ func (r *ReconcilePerconaServerMongoDBRestore) reconcileSnapshotRunning(
 	log.Info("Snapshot restore finished", "status", status.State)
 
 	status.State = psmdbv1.RestoreStateReady
-	status.CompletedAt = ptr.To(metav1.Now())
+	status.CompletedAt = new(metav1.Now())
 
 	return status, nil
 }
@@ -325,7 +324,7 @@ func (r *ReconcilePerconaServerMongoDBRestore) scaleDownStatefulSetsForSnapshotR
 				orig := sfs.DeepCopy()
 
 				// Scale down the statefulset.
-				sfs.Spec.Replicas = ptr.To(int32(0))
+				sfs.Spec.Replicas = new(int32(0))
 
 				// When the pods come up, they should start pbm with the following command:
 				sfs.Spec.Template.Spec.Containers[0].Command = []string{"/opt/percona/pbm-agent"}
@@ -525,7 +524,7 @@ func generatePVCFromSnapshot(
 	pvc.SetLabels(labels)
 	pvc.Spec = spec
 	pvc.Spec.DataSource = &corev1.TypedLocalObjectReference{
-		APIGroup: ptr.To(volumesnapshotv1.SchemeGroupVersion.Group),
+		APIGroup: new(volumesnapshotv1.SchemeGroupVersion.Group),
 		Kind:     "VolumeSnapshot",
 		Name:     snapshotName,
 	}
@@ -623,7 +622,7 @@ func (r *ReconcilePerconaServerMongoDBRestore) scaleUpStatefulSetsForSnapshotRes
 			orig := sfs.DeepCopy()
 
 			// Scale up the statefulset.
-			sfs.Spec.Replicas = ptr.To(replicas)
+			sfs.Spec.Replicas = new(replicas)
 			return r.client.Patch(ctx, &sfs, client.MergeFrom(orig))
 		}); err != nil {
 			return false, errors.Wrapf(err, "prepare statefulset %s for snapshot restore", nn.Name)
@@ -866,7 +865,7 @@ func (r *ReconcilePerconaServerMongoDBRestore) createOrUpdateDBConfigSecret(
 	log := logf.FromContext(ctx)
 
 	for _, rs := range cluster.GetAllReplsets() {
-		var securityConf interface{}
+		var securityConf any
 
 		if rs.Configuration.VaultEnabled() {
 			sec, err := rs.Configuration.GetOptions("security")
@@ -880,7 +879,7 @@ func (r *ReconcilePerconaServerMongoDBRestore) createOrUpdateDBConfigSecret(
 				// Secret volumes mount files with 0444). Update tokenFile in the security
 				// config to point to the fixed path so the local mongod started by
 				// pbm-agent restore-finish can read it.
-				if vaultConf, ok := sec["vault"].(map[interface{}]interface{}); ok {
+				if vaultConf, ok := sec["vault"].(map[any]any); ok {
 					vaultConf["tokenFile"] = "/tmp/vault-token"
 				}
 				securityConf = sec

--- a/pkg/controller/perconaservermongodbrestore/snapshots_test.go
+++ b/pkg/controller/perconaservermongodbrestore/snapshots_test.go
@@ -15,7 +15,6 @@ import (
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 
 	psmdbv1 "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
 	"github.com/percona/percona-server-mongodb-operator/pkg/naming"
@@ -41,7 +40,7 @@ func TestGeneratePVCFromSnapshot(t *testing.T) {
 	require.NotNil(t, pvc.Spec.DataSource)
 	assert.Equal(t, "my-snapshot", pvc.Spec.DataSource.Name)
 	assert.Equal(t, "VolumeSnapshot", pvc.Spec.DataSource.Kind)
-	assert.Equal(t, ptr.To(volumesnapshotv1.SchemeGroupVersion.Group), pvc.Spec.DataSource.APIGroup)
+	assert.Equal(t, new(volumesnapshotv1.SchemeGroupVersion.Group), pvc.Spec.DataSource.APIGroup)
 	assert.Equal(t, "my-restore", pvc.Annotations[naming.AnnotationRestoreName])
 	assert.Equal(t, labels, pvc.Labels)
 }
@@ -172,7 +171,7 @@ func TestScaleDownStatefulSetsForSnapshotRestore(t *testing.T) {
 				Namespace: ns,
 			},
 			Spec: appsv1.StatefulSetSpec{
-				Replicas: ptr.To(int32(3)),
+				Replicas: new(int32(3)),
 				Template: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
@@ -217,7 +216,7 @@ func TestScaleDownStatefulSetsForSnapshotRestore(t *testing.T) {
 				Namespace: ns,
 			},
 			Spec: appsv1.StatefulSetSpec{
-				Replicas: ptr.To(int32(0)),
+				Replicas: new(int32(0)),
 				Template: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{{Name: "mongod"}},
@@ -270,7 +269,7 @@ func TestScaleDownStatefulSetsForSnapshotRestore(t *testing.T) {
 					Namespace: ns,
 				},
 				Spec: appsv1.StatefulSetSpec{
-					Replicas: ptr.To(int32(0)),
+					Replicas: new(int32(0)),
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{{Name: "mongod"}},
@@ -320,7 +319,7 @@ func TestScaleDownStatefulSetsForSnapshotRestore(t *testing.T) {
 				Namespace: ns,
 			},
 			Spec: appsv1.StatefulSetSpec{
-				Replicas: ptr.To(int32(1)),
+				Replicas: new(int32(1)),
 				Template: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{{Name: "mongod"}},
@@ -396,7 +395,7 @@ func TestScaleDownStatefulSetsForSnapshotRestore(t *testing.T) {
 				Namespace: ns,
 			},
 			Spec: appsv1.StatefulSetSpec{
-				Replicas: ptr.To(int32(1)),
+				Replicas: new(int32(1)),
 				Template: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
@@ -461,7 +460,7 @@ func TestScaleDownStatefulSetsForSnapshotRestore(t *testing.T) {
 				Namespace: ns,
 			},
 			Spec: appsv1.StatefulSetSpec{
-				Replicas: ptr.To(int32(1)),
+				Replicas: new(int32(1)),
 				Template: corev1.PodTemplateSpec{
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{{Name: "mongod"}},
@@ -536,7 +535,7 @@ func TestScaleUpStatefulSetsForSnapshotRestore(t *testing.T) {
 				Namespace: ns,
 			},
 			Spec: appsv1.StatefulSetSpec{
-				Replicas: ptr.To(int32(0)),
+				Replicas: new(int32(0)),
 			},
 			Status: appsv1.StatefulSetStatus{
 				ReadyReplicas: 0,
@@ -564,7 +563,7 @@ func TestScaleUpStatefulSetsForSnapshotRestore(t *testing.T) {
 				Namespace: ns,
 			},
 			Spec: appsv1.StatefulSetSpec{
-				Replicas: ptr.To(rs.Size),
+				Replicas: new(rs.Size),
 			},
 			Status: appsv1.StatefulSetStatus{
 				ReadyReplicas: rs.Size,
@@ -1009,7 +1008,7 @@ func TestScaleDownStatefulSetsNodeAddressArg(t *testing.T) {
 			Namespace: ns,
 		},
 		Spec: appsv1.StatefulSetSpec{
-			Replicas: ptr.To(int32(1)),
+			Replicas: new(int32(1)),
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{Name: "mongod"}},

--- a/pkg/k8s/annotations.go
+++ b/pkg/k8s/annotations.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"context"
+	"maps"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -22,9 +23,7 @@ func AnnotateObject(ctx context.Context, c client.Client, obj client.Object, ann
 		a = make(map[string]string)
 	}
 
-	for k, v := range annotations {
-		a[k] = v
-	}
+	maps.Copy(a, annotations)
 	o.SetAnnotations(a)
 
 	return c.Patch(ctx, o, client.MergeFrom(orig))

--- a/pkg/k8s/lease_test.go
+++ b/pkg/k8s/lease_test.go
@@ -11,7 +11,6 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake" // nolint
 
 	"github.com/percona/percona-server-mongodb-operator/pkg/k8s"
@@ -52,7 +51,7 @@ func TestAcquireLease(t *testing.T) {
 
 		freshLease := new(coordv1.Lease)
 		require.NoError(t, cl.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, freshLease))
-		assert.Equal(t, ptr.To(holder), freshLease.Spec.HolderIdentity)
+		assert.Equal(t, new(holder), freshLease.Spec.HolderIdentity)
 	})
 
 	t.Run("replaces stale holder", func(t *testing.T) {
@@ -72,7 +71,7 @@ func TestAcquireLease(t *testing.T) {
 
 		freshLease := new(coordv1.Lease)
 		require.NoError(t, cl.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, freshLease))
-		assert.Equal(t, ptr.To(otherHolder), freshLease.Spec.HolderIdentity)
+		assert.Equal(t, new(otherHolder), freshLease.Spec.HolderIdentity)
 	})
 }
 
@@ -101,7 +100,7 @@ func lease(name, namespace, holder string) *coordv1.Lease {
 		},
 		Spec: coordv1.LeaseSpec{
 			AcquireTime:    &metav1.MicroTime{Time: time.Now()},
-			HolderIdentity: ptr.To(holder),
+			HolderIdentity: new(holder),
 		},
 	}
 }

--- a/pkg/naming/service.go
+++ b/pkg/naming/service.go
@@ -3,8 +3,6 @@ package naming
 import (
 	"strconv"
 
-	"k8s.io/utils/ptr"
-
 	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
 )
 
@@ -16,7 +14,7 @@ func AppProtocol(cr *api.PerconaServerMongoDB) *string {
 		//
 		// However, Istio expects `appProtocol: mongo`, so we use that instead.
 		// https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/#explicit-protocol-selection
-		return ptr.To("mongo")
+		return new("mongo")
 	}
 	return nil
 }

--- a/pkg/psmdb/clustersync/container.go
+++ b/pkg/psmdb/clustersync/container.go
@@ -76,10 +76,7 @@ func loopbackStatusProbe(timeoutSeconds int32) corev1.ProbeHandler {
 	if maxTime > 1 {
 		maxTime--
 	}
-	connectTimeout := int32(1)
-	if connectTimeout > maxTime {
-		connectTimeout = maxTime
-	}
+	connectTimeout := min(int32(1), maxTime)
 	return corev1.ProbeHandler{
 		Exec: &corev1.ExecAction{
 			Command: []string{

--- a/pkg/psmdb/clustersync/container_test.go
+++ b/pkg/psmdb/clustersync/container_test.go
@@ -8,7 +8,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/ptr"
 
 	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
 )
@@ -185,17 +184,17 @@ func TestContainerArgs(t *testing.T) {
 			want: []string{"--log-level=debug"},
 		},
 		"LogJSON true only": {
-			pcsm: api.ClusterSyncPCSMConfig{LogJSON: ptr.To(true)},
+			pcsm: api.ClusterSyncPCSMConfig{LogJSON: new(true)},
 			want: []string{"--log-json"},
 		},
 		"LogJSON explicitly false: no arg emitted": {
-			pcsm: api.ClusterSyncPCSMConfig{LogJSON: ptr.To(false)},
+			pcsm: api.ClusterSyncPCSMConfig{LogJSON: new(false)},
 			want: nil,
 		},
 		"both set: LogLevel precedes LogJSON for stable arg order": {
 			pcsm: api.ClusterSyncPCSMConfig{
 				LogLevel: "warn",
-				LogJSON:  ptr.To(true),
+				LogJSON:  new(true),
 			},
 			want: []string{"--log-level=warn", "--log-json"},
 		},

--- a/pkg/psmdb/clustersync/deployment.go
+++ b/pkg/psmdb/clustersync/deployment.go
@@ -1,10 +1,11 @@
 package clustersync
 
 import (
+	"maps"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 
 	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
 	"github.com/percona/percona-server-mongodb-operator/pkg/naming"
@@ -58,7 +59,7 @@ func Deployment(cr *api.PerconaServerMongoDBClusterSync) *appsv1.Deployment {
 
 func DeploymentSpec(cr *api.PerconaServerMongoDBClusterSync, template corev1.PodTemplateSpec) appsv1.DeploymentSpec {
 	return appsv1.DeploymentSpec{
-		Replicas: ptr.To(int32(1)),
+		Replicas: new(int32(1)),
 		Strategy: appsv1.DeploymentStrategy{Type: appsv1.RecreateDeploymentStrategyType},
 		Selector: &metav1.LabelSelector{MatchLabels: Labels(cr)},
 		Template: template,
@@ -103,9 +104,7 @@ func podAffinity(af *api.PodAffinity, labels map[string]string) *corev1.Affinity
 			return nil
 		}
 		labelsCopy := make(map[string]string, len(labels))
-		for k, v := range labels {
-			labelsCopy[k] = v
-		}
+		maps.Copy(labelsCopy, labels)
 		return &corev1.Affinity{
 			PodAntiAffinity: &corev1.PodAntiAffinity{
 				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{

--- a/pkg/psmdb/config/config_test.go
+++ b/pkg/psmdb/config/config_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/utils/ptr"
 )
 
 func TestVolumeProjection(t *testing.T) {
@@ -24,7 +23,7 @@ func TestVolumeProjection(t *testing.T) {
 			expected: corev1.VolumeProjection{
 				ConfigMap: &corev1.ConfigMapProjection{
 					LocalObjectReference: localObj,
-					Optional:             ptr.To(true),
+					Optional:             new(true),
 				},
 			},
 		},
@@ -34,7 +33,7 @@ func TestVolumeProjection(t *testing.T) {
 			expected: corev1.VolumeProjection{
 				Secret: &corev1.SecretProjection{
 					LocalObjectReference: localObj,
-					Optional:             ptr.To(true),
+					Optional:             new(true),
 				},
 			},
 		},

--- a/pkg/psmdb/config/const.go
+++ b/pkg/psmdb/config/const.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -108,14 +107,14 @@ func (s VolumeSourceType) VolumeProjection(name string) corev1.VolumeProjection 
 		return corev1.VolumeProjection{
 			ConfigMap: &corev1.ConfigMapProjection{
 				LocalObjectReference: localObj,
-				Optional:             ptr.To(true),
+				Optional:             new(true),
 			},
 		}
 	case VolumeSourceSecret:
 		return corev1.VolumeProjection{
 			Secret: &corev1.SecretProjection{
 				LocalObjectReference: localObj,
-				Optional:             ptr.To(true),
+				Optional:             new(true),
 			},
 		}
 	default:

--- a/pkg/psmdb/logcollector/logrotate/container.go
+++ b/pkg/psmdb/logcollector/logrotate/container.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/utils/ptr"
 
 	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
 	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb/config"
@@ -51,7 +50,7 @@ func Container(cr *api.PerconaServerMongoDB, mongoPort int32) (*corev1.Container
 					LocalObjectReference: corev1.LocalObjectReference{
 						Name: usersSecretName,
 					},
-					Optional: ptr.To(false),
+					Optional: new(false),
 				},
 			},
 		},
@@ -63,7 +62,7 @@ func Container(cr *api.PerconaServerMongoDB, mongoPort int32) (*corev1.Container
 					LocalObjectReference: corev1.LocalObjectReference{
 						Name: usersSecretName,
 					},
-					Optional: ptr.To(false),
+					Optional: new(false),
 				},
 			},
 		},

--- a/pkg/psmdb/mongo/concern_test.go
+++ b/pkg/psmdb/mongo/concern_test.go
@@ -11,15 +11,15 @@ func TestParseWriteConcernW(t *testing.T) {
 
 	tests := map[string]struct {
 		in   string
-		want interface{}
+		want any
 	}{
-		"majority stays a string":      {in: "majority", want: "majority"},
-		"custom tag stays a string":    {in: "myTag", want: "myTag"},
-		"integer 0 becomes int":        {in: "0", want: 0},
-		"integer 1 becomes int":        {in: "1", want: 1},
-		"integer 3 becomes int":        {in: "3", want: 3},
-		"negative falls back to string": {in: "-1", want: "-1"},
-		"empty stays a string":         {in: "", want: ""},
+		"majority stays a string":                         {in: "majority", want: "majority"},
+		"custom tag stays a string":                       {in: "myTag", want: "myTag"},
+		"integer 0 becomes int":                           {in: "0", want: 0},
+		"integer 1 becomes int":                           {in: "1", want: 1},
+		"integer 3 becomes int":                           {in: "3", want: 3},
+		"negative falls back to string":                   {in: "-1", want: "-1"},
+		"empty stays a string":                            {in: "", want: ""},
 		"numeric-looking tag with letters stays a string": {in: "1a", want: "1a"},
 	}
 

--- a/pkg/psmdb/mongo/fake/client.go
+++ b/pkg/psmdb/mongo/fake/client.go
@@ -23,7 +23,7 @@ func (c *fakeMongoClient) Disconnect(ctx context.Context) error {
 
 type fakeMongoClientDatabase struct{}
 
-func (c *fakeMongoClientDatabase) RunCommand(ctx context.Context, runCommand interface{}, opts ...options.Lister[options.RunCmdOptions]) *mgo.SingleResult {
+func (c *fakeMongoClientDatabase) RunCommand(ctx context.Context, runCommand any, opts ...options.Lister[options.RunCmdOptions]) *mgo.SingleResult {
 	return singleResult(mongo.OKResponse{
 		OK: 1,
 	})

--- a/pkg/psmdb/mongo/models.go
+++ b/pkg/psmdb/mongo/models.go
@@ -44,7 +44,7 @@ type RSConfig struct {
 	Members                            ConfigMembers `bson:"members" json:"members"`
 	Configsvr                          bool          `bson:"configsvr,omitempty" json:"configsvr,omitempty"`
 	ProtocolVersion                    int           `bson:"protocolVersion,omitempty" json:"protocolVersion,omitempty"`
-	Settings                           Settings      `bson:"settings,omitempty" json:"settings,omitempty"`
+	Settings                           Settings      `bson:"settings,omitempty" json:"settings"`
 	WriteConcernMajorityJournalDefault bool          `bson:"writeConcernMajorityJournalDefault" json:"writeConcernMajorityJournalDefault"`
 }
 
@@ -56,7 +56,7 @@ type Settings struct {
 	ElectionTimeoutMillis   int64                              `bson:"electionTimeoutMillis,omitempty" json:"electionTimeoutMillis,omitempty"`
 	CatchUpTimeoutMillis    int64                              `bson:"catchUpTimeoutMillis,omitempty" json:"catchUpTimeoutMillis,omitempty"`
 	GetLastErrorModes       map[string]WriteConcernReplsetTags `bson:"getLastErrorModes,omitempty" json:"getLastErrorModes,omitempty"`
-	GetLastErrorDefaults    WriteConcern                       `bson:"getLastErrorDefaults,omitempty" json:"getLastErrorDefaults,omitempty"`
+	GetLastErrorDefaults    WriteConcern                       `bson:"getLastErrorDefaults,omitempty" json:"getLastErrorDefaults"`
 	ReplicaSetID            bson.ObjectID                      `bson:"replicaSetId,omitempty" json:"replicaSetId,omitempty"`
 }
 
@@ -80,9 +80,9 @@ type OKResponse struct {
 
 // WriteConcern document: https://docs.mongodb.com/manual/reference/write-concern/
 type WriteConcern struct {
-	WriteConcern interface{} `bson:"w" json:"w"`
-	WriteTimeout int         `bson:"wtimeout" json:"wtimeout"`
-	Journal      bool        `bson:"j,omitempty" json:"j,omitempty"`
+	WriteConcern any  `bson:"w" json:"w"`
+	WriteTimeout int  `bson:"wtimeout" json:"wtimeout"`
+	Journal      bool `bson:"j,omitempty" json:"j,omitempty"`
 }
 
 type BalancerStatus struct {
@@ -157,13 +157,13 @@ type Member struct {
 	Optime            *Optime        `bson:"optime" json:"optime"`
 	OptimeDate        time.Time      `bson:"optimeDate" json:"optimeDate"`
 	ConfigVersion     int            `bson:"configVersion" json:"configVersion"`
-	ElectionTime      bson.Timestamp `bson:"electionTime,omitempty" json:"electionTime,omitempty"`
-	ElectionDate      time.Time      `bson:"electionDate,omitempty" json:"electionDate,omitempty"`
+	ElectionTime      bson.Timestamp `bson:"electionTime,omitempty" json:"electionTime"`
+	ElectionDate      time.Time      `bson:"electionDate,omitempty" json:"electionDate"`
 	InfoMessage       string         `bson:"infoMessage,omitempty" json:"infoMessage,omitempty"`
 	OptimeDurable     *Optime        `bson:"optimeDurable,omitempty" json:"optimeDurable,omitempty"`
-	OptimeDurableDate time.Time      `bson:"optimeDurableDate,omitempty" json:"optimeDurableDate,omitempty"`
-	LastHeartbeat     time.Time      `bson:"lastHeartbeat,omitempty" json:"lastHeartbeat,omitempty"`
-	LastHeartbeatRecv time.Time      `bson:"lastHeartbeatRecv,omitempty" json:"lastHeartbeatRecv,omitempty"`
+	OptimeDurableDate time.Time      `bson:"optimeDurableDate,omitempty" json:"optimeDurableDate"`
+	LastHeartbeat     time.Time      `bson:"lastHeartbeat,omitempty" json:"lastHeartbeat"`
+	LastHeartbeatRecv time.Time      `bson:"lastHeartbeatRecv,omitempty" json:"lastHeartbeatRecv"`
 	PingMs            int64          `bson:"pingMs,omitempty" json:"pingMs,omitempty"`
 	Self              bool           `bson:"self,omitempty" json:"self,omitempty"`
 	SyncingTo         string         `bson:"syncingTo,omitempty" json:"syncingTo,omitempty"`
@@ -249,8 +249,8 @@ type RoleAuthenticationRestriction struct {
 }
 
 type RolePrivilege struct {
-	Resource map[string]interface{} `bson:"resource" json:"resource"`
-	Actions  []string               `bson:"actions" json:"actions"`
+	Resource map[string]any `bson:"resource" json:"resource"`
+	Actions  []string       `bson:"actions" json:"actions"`
 }
 
 type InheritenceRole struct {

--- a/pkg/psmdb/mongo/mongo.go
+++ b/pkg/psmdb/mongo/mongo.go
@@ -207,7 +207,7 @@ func (client *mongoClient) SetDefaultRWConcern(ctx context.Context, readConcern,
 // correct BSON type. MongoDB rejects {w: "1"} as a missing custom tag, so any
 // non-negative integer string is sent as an int; everything else (including
 // "majority" and custom getLastErrorModes tags) stays a string.
-func parseWriteConcernW(w string) interface{} {
+func parseWriteConcernW(w string) any {
 	if n, err := strconv.Atoi(w); err == nil && n >= 0 {
 		return n
 	}
@@ -734,7 +734,7 @@ func (client *mongoClient) UpdateUserPass(ctx context.Context, db, name, pass st
 func (client *mongoClient) UpdateUser(ctx context.Context, currName, newName, pass string) error {
 	mu := struct {
 		Users []struct {
-			Roles interface{} `bson:"roles"`
+			Roles any `bson:"roles"`
 		} `bson:"users"`
 	}{}
 

--- a/pkg/psmdb/mongos.go
+++ b/pkg/psmdb/mongos.go
@@ -2,6 +2,7 @@ package psmdb
 
 import (
 	"fmt"
+	"maps"
 	"sort"
 	"strconv"
 	"strings"
@@ -11,7 +12,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/utils/ptr"
 
 	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
 	"github.com/percona/percona-server-mongodb-operator/pkg/naming"
@@ -68,9 +68,7 @@ func MongosTemplateSpec(cr *api.PerconaServerMongoDB, initImage string, log logr
 	ls := naming.MongosLabels(cr)
 
 	if cr.Spec.Sharding.Mongos.Labels != nil {
-		for k, v := range cr.Spec.Sharding.Mongos.Labels {
-			ls[k] = v
-		}
+		maps.Copy(ls, cr.Spec.Sharding.Mongos.Labels)
 	}
 
 	mountKeyFile := cr.KeyFileAuthEnabled() || keyfileExists
@@ -427,7 +425,7 @@ func volumes(cr *api.PerconaServerMongoDB, configSource config.VolumeSourceType,
 					LocalObjectReference: corev1.LocalObjectReference{
 						Name: name,
 					},
-					Optional: ptr.To(true),
+					Optional: new(true),
 				},
 			},
 		})
@@ -453,9 +451,7 @@ func MongosService(cr *api.PerconaServerMongoDB, name string) corev1.Service {
 
 	if cr.Spec.Sharding.Mongos != nil {
 		annotations := make(map[string]string)
-		for k, v := range cr.Spec.Sharding.Mongos.Expose.ServiceAnnotations {
-			annotations[k] = v
-		}
+		maps.Copy(annotations, cr.Spec.Sharding.Mongos.Expose.ServiceAnnotations)
 
 		if dns := cr.Spec.Sharding.Mongos.Expose.ExternalDNS; dns != nil {
 			var hostname string

--- a/pkg/psmdb/mongos_test.go
+++ b/pkg/psmdb/mongos_test.go
@@ -10,7 +10,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/yaml"
-	"k8s.io/utils/ptr"
 
 	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
 	"github.com/percona/percona-server-mongodb-operator/pkg/version"
@@ -40,7 +39,7 @@ func TestMongosService(t *testing.T) {
 						Name:        "mongos",
 						Port:        27017,
 						TargetPort:  intstr.FromInt(27017),
-						AppProtocol: ptr.To("mongo"),
+						AppProtocol: new("mongo"),
 					},
 				},
 				Selector: map[string]string{
@@ -71,7 +70,7 @@ func TestMongosService(t *testing.T) {
 						Name:        "mongos",
 						Port:        27017,
 						TargetPort:  intstr.FromInt(27017),
-						AppProtocol: ptr.To("mongo"),
+						AppProtocol: new("mongo"),
 					},
 				},
 				Selector: map[string]string{
@@ -94,7 +93,7 @@ func TestMongosService(t *testing.T) {
 					"percona.com/test": "annotation",
 				},
 				ExposeType:               corev1.ServiceTypeLoadBalancer,
-				LoadBalancerClass:        ptr.To("eks.amazonaws.com/nlb"),
+				LoadBalancerClass:        new("eks.amazonaws.com/nlb"),
 				LoadBalancerSourceRanges: []string{"10.0.0.0/16"},
 			},
 			podName: "test-cr-mongos-0",
@@ -105,7 +104,7 @@ func TestMongosService(t *testing.T) {
 						Name:        "mongos",
 						Port:        27017,
 						TargetPort:  intstr.FromInt(27017),
-						AppProtocol: ptr.To("mongo"),
+						AppProtocol: new("mongo"),
 					},
 				},
 				Selector: map[string]string{
@@ -117,7 +116,7 @@ func TestMongosService(t *testing.T) {
 				},
 				Type:                     corev1.ServiceTypeLoadBalancer,
 				ExternalTrafficPolicy:    corev1.ServiceExternalTrafficPolicyLocal,
-				LoadBalancerClass:        ptr.To("eks.amazonaws.com/nlb"),
+				LoadBalancerClass:        new("eks.amazonaws.com/nlb"),
 				LoadBalancerSourceRanges: []string{"10.0.0.0/16"},
 			},
 		},
@@ -170,7 +169,7 @@ func TestMongosContainer(t *testing.T) {
 				LocalObjectReference: corev1.LocalObjectReference{
 					Name: "test-configmap",
 				},
-				Optional: ptr.To(false),
+				Optional: new(false),
 			},
 		},
 		{
@@ -178,7 +177,7 @@ func TestMongosContainer(t *testing.T) {
 				LocalObjectReference: corev1.LocalObjectReference{
 					Name: "test-secret",
 				},
-				Optional: ptr.To(true),
+				Optional: new(true),
 			},
 		},
 	}

--- a/pkg/psmdb/secret/secret.go
+++ b/pkg/psmdb/secret/secret.go
@@ -34,7 +34,7 @@ func GeneratePassword() ([]byte, error) {
 	mrand.Seed(time.Now().UnixNano())
 	ln := mrand.Intn(passwordMaxLen-passwordMinLen) + passwordMinLen
 	b := make([]byte, ln)
-	for i := 0; i < ln; i++ {
+	for i := range ln {
 		randInt, err := rand.Int(rand.Reader, big.NewInt(int64(len(passSymbols))))
 		if err != nil {
 			return nil, err

--- a/pkg/psmdb/service.go
+++ b/pkg/psmdb/service.go
@@ -63,9 +63,7 @@ func Service(cr *api.PerconaServerMongoDB, replset *api.ReplsetSpec) *corev1.Ser
 // ExternalService returns a Service object needs to serve external connections
 func ExternalService(cr *api.PerconaServerMongoDB, replset *api.ReplsetSpec, podName string) *corev1.Service {
 	annotations := make(map[string]string)
-	for k, v := range replset.Expose.ServiceAnnotations {
-		annotations[k] = v
-	}
+	maps.Copy(annotations, replset.Expose.ServiceAnnotations)
 
 	if dns := replset.Expose.ExternalDNS; dns != nil {
 		hostname := BuildDNSHostname(dns, replset.Name, podName)

--- a/pkg/psmdb/service_test.go
+++ b/pkg/psmdb/service_test.go
@@ -10,7 +10,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -229,7 +228,7 @@ func TestExternalService(t *testing.T) {
 							Name:        "mongodb",
 							Port:        27017,
 							TargetPort:  intstr.FromInt(27017),
-							AppProtocol: ptr.To("mongo"),
+							AppProtocol: new("mongo"),
 						},
 					},
 					Selector: map[string]string{"statefulset.kubernetes.io/pod-name": "test-cr-rs0-0"},
@@ -282,7 +281,7 @@ func TestExternalService(t *testing.T) {
 							Name:        "mongodb",
 							Port:        27017,
 							TargetPort:  intstr.FromInt(27017),
-							AppProtocol: ptr.To("mongo"),
+							AppProtocol: new("mongo"),
 						},
 					},
 					Selector:              map[string]string{"statefulset.kubernetes.io/pod-name": "test-cr-rs0-0"},
@@ -304,7 +303,7 @@ func TestExternalService(t *testing.T) {
 							"percona.com/test": "annotation",
 						},
 						ExposeType:               corev1.ServiceTypeLoadBalancer,
-						LoadBalancerClass:        ptr.To("eks.amazonaws.com/nlb"),
+						LoadBalancerClass:        new("eks.amazonaws.com/nlb"),
 						LoadBalancerSourceRanges: []string{"10.0.0.0/16"},
 					},
 				},
@@ -338,13 +337,13 @@ func TestExternalService(t *testing.T) {
 							Name:        "mongodb",
 							Port:        27017,
 							TargetPort:  intstr.FromInt(27017),
-							AppProtocol: ptr.To("mongo"),
+							AppProtocol: new("mongo"),
 						},
 					},
 					Selector:                 map[string]string{"statefulset.kubernetes.io/pod-name": "test-cr-rs0-0"},
 					Type:                     corev1.ServiceTypeLoadBalancer,
 					ExternalTrafficPolicy:    corev1.ServiceExternalTrafficPolicyLocal,
-					LoadBalancerClass:        ptr.To("eks.amazonaws.com/nlb"),
+					LoadBalancerClass:        new("eks.amazonaws.com/nlb"),
 					LoadBalancerSourceRanges: []string{"10.0.0.0/16"},
 				},
 			},
@@ -398,7 +397,7 @@ func TestExternalService(t *testing.T) {
 							Name:        "mongodb",
 							Port:        27017,
 							TargetPort:  intstr.FromInt(27017),
-							AppProtocol: ptr.To("mongo"),
+							AppProtocol: new("mongo"),
 						},
 					},
 					Selector:              map[string]string{"statefulset.kubernetes.io/pod-name": "test-cr-rs0-0"},
@@ -450,7 +449,7 @@ func TestExternalService(t *testing.T) {
 							Name:        "mongodb",
 							Port:        27017,
 							TargetPort:  intstr.FromInt(27017),
-							AppProtocol: ptr.To("mongo"),
+							AppProtocol: new("mongo"),
 						},
 					},
 					Selector:              map[string]string{"statefulset.kubernetes.io/pod-name": "test-cr-rs0-2"},

--- a/pkg/psmdb/statefulset.go
+++ b/pkg/psmdb/statefulset.go
@@ -3,6 +3,7 @@ package psmdb
 import (
 	"context"
 	"fmt"
+	"maps"
 	"path"
 	"sort"
 	"strconv"
@@ -12,7 +13,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
@@ -158,9 +158,7 @@ func StatefulSpec(ctx context.Context, cr *api.PerconaServerMongoDB, replset *ap
 	}
 
 	customLabels := make(map[string]string, len(ls))
-	for k, v := range ls {
-		customLabels[k] = v
-	}
+	maps.Copy(customLabels, ls)
 
 	for k, v := range multiAZ.Labels {
 		if _, ok := customLabels[k]; !ok {
@@ -415,7 +413,7 @@ func StatefulSpec(ctx context.Context, cr *api.PerconaServerMongoDB, replset *ap
 							LocalObjectReference: corev1.LocalObjectReference{
 								Name: name,
 							},
-							Optional: ptr.To(true),
+							Optional: new(true),
 						},
 					},
 				})
@@ -448,7 +446,7 @@ func StatefulSpec(ctx context.Context, cr *api.PerconaServerMongoDB, replset *ap
 					LocalObjectReference: corev1.LocalObjectReference{
 						Name: name,
 					},
-					Optional: ptr.To(true),
+					Optional: new(true),
 				},
 			},
 		})
@@ -830,9 +828,7 @@ func PodAffinity(cr *api.PerconaServerMongoDB, af *api.PodAffinity, labels map[s
 	}
 
 	labelsCopy := make(map[string]string)
-	for k, v := range labels {
-		labelsCopy[k] = v
-	}
+	maps.Copy(labelsCopy, labels)
 
 	switch {
 	case af.Advanced != nil:

--- a/pkg/psmdb/tls/certmanager_test.go
+++ b/pkg/psmdb/tls/certmanager_test.go
@@ -12,7 +12,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake" // nolint
 
@@ -369,7 +368,7 @@ func TestWaitForCerts(t *testing.T) {
 							Kind:       cm.CertificateKind,
 							Name:       certName,
 							UID:        "cert-uid-456",
-							Controller: ptr.To(true),
+							Controller: new(true),
 						},
 					},
 				},

--- a/pkg/psmdb/vectorsearch/statefulset.go
+++ b/pkg/psmdb/vectorsearch/statefulset.go
@@ -2,6 +2,7 @@ package vectorsearch
 
 import (
 	"fmt"
+	"maps"
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -27,9 +28,7 @@ func StatefulSet(cr *api.PerconaServerMongoDB, rs *api.ReplsetSpec, initImage, c
 	spec := getSearchSpec(cr, rs)
 
 	podLabels := make(map[string]string, len(objectLabels)+len(spec.Labels))
-	for k, v := range objectLabels {
-		podLabels[k] = v
-	}
+	maps.Copy(podLabels, objectLabels)
 	for k, v := range spec.Labels {
 		if _, ok := podLabels[k]; !ok {
 			podLabels[k] = v
@@ -380,9 +379,7 @@ func podAffinity(af *api.PodAffinity, labels map[string]string) *corev1.Affinity
 			return nil
 		}
 		labelsCopy := make(map[string]string, len(labels))
-		for k, v := range labels {
-			labelsCopy[k] = v
-		}
+		maps.Copy(labelsCopy, labels)
 		return &corev1.Affinity{
 			PodAntiAffinity: &corev1.PodAntiAffinity{
 				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{

--- a/pkg/util/apply.go
+++ b/pkg/util/apply.go
@@ -42,7 +42,7 @@ func Apply(ctx context.Context, cl client.Client, obj client.Object) (ApplyStatu
 	obj.SetAnnotations(objAnnotations)
 
 	val := reflect.ValueOf(obj)
-	if val.Kind() == reflect.Ptr {
+	if val.Kind() == reflect.Pointer {
 		val = reflect.Indirect(val)
 	}
 	oldObject := reflect.New(val.Type()).Interface().(client.Object)
@@ -77,7 +77,7 @@ func Apply(ctx context.Context, cl client.Client, obj client.Object) (ApplyStatu
 }
 
 func getObjectHash(obj client.Object) (string, error) {
-	var dataToMarshall interface{}
+	var dataToMarshall any
 	switch object := obj.(type) {
 	case *appsv1.StatefulSet:
 		dataToMarshall = object.Spec

--- a/pkg/util/map.go
+++ b/pkg/util/map.go
@@ -1,5 +1,7 @@
 package util
 
+import "maps"
+
 // MapEqual compares maps for equality
 func MapEqual(a, b map[string]string) bool {
 	if len(a) != len(b) {
@@ -18,9 +20,7 @@ func MapEqual(a, b map[string]string) bool {
 // MapCopy makes (shallow) copy of src map
 func MapCopy(src map[string]string) map[string]string {
 	dst := make(map[string]string)
-	for k, v := range src {
-		dst[k] = v
-	}
+	maps.Copy(dst, src)
 
 	return dst
 }
@@ -33,9 +33,7 @@ func MapMerge(ms ...map[string]string) map[string]string {
 
 	rv := MapCopy(ms[0])
 	for _, m := range ms[1:] {
-		for k, v := range m {
-			rv[k] = v
-		}
+		maps.Copy(rv, m)
 	}
 
 	return rv

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -33,8 +33,8 @@ func TestCRDVersionLabel(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to read file: %s", err.Error())
 	}
-	yamlDocs := bytes.Split(data, []byte("\n---\n"))
-	for _, doc := range yamlDocs {
+	yamlDocs := bytes.SplitSeq(data, []byte("\n---\n"))
+	for doc := range yamlDocs {
 		if len(doc) == 0 {
 			continue
 		}


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**

Description in the Jira ticket: https://perconadev.atlassian.net/browse/K8SPSMDB-1763

The important changes are in the Makefile, everything else is autogenerated.

Additionally, the go fix was affecting the quotes on crd validations. With this PR we are also changing an existing validation to use the len() of the string for the validation instead of the quotes, which makes it more resilient against linting issues. 

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
