### PR TITLE
K8SPSMDB-1601 additional test fixes for EKS and Openshift

### DIFF
--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -1425,6 +1425,18 @@ get_service_ip() {
 	kubectl_bin get service/$service -o 'jsonpath={.status.loadBalancer.ingress[].hostname}'
 }
 
+compare_mongo_output() {
+	local command="$1"
+	local postfix="$2"
+
+	if [[ ${UPDATE_COMPARE_FILES} -ne 0 ]]; then
+		cp $tmp_dir/${command}${postfix} ${test_dir}/compare/${command}${postfix}.json
+		return
+	fi
+
+	diff -u ${test_dir}/compare/${command}${postfix}.json $tmp_dir/${command}${postfix}
+}
+
 compare_mongo_cmd() {
 	local command="$1"
 	local uri="$2"
@@ -1435,6 +1447,8 @@ compare_mongo_cmd() {
 	local sort="$7"
 	local tls="${8:-false}"
 	local replicaset="$9"
+	local retries="${10:-3}"
+	local retry_delay="${11:-10}"
 
 	local full_command="db.${collection}.${command}()"
 	if [[ -n ${sort} ]]; then
@@ -1449,16 +1463,21 @@ compare_mongo_cmd() {
 		mongo_command=run_mongo
 	fi
 
-	$mongo_command "use ${database}\n ${full_command}" "$uri" "mongodb" "$suffix" "" ${replicaset} \
-		| grep -E -v 'I NETWORK|W NETWORK|F NETWORK|"c":"NETWORK"|Error saving history file|Percona Server for MongoDB|connecting to:|Unable to reach primary for set|Implicit session:|versions do not match|Error saving history file:|Started a new thread for the timer service' \
-		| $sed -re 's/ObjectId\("[0-9a-f]+"\)//; s/-[0-9]+.svc/-xxx.svc/' \
-			>$tmp_dir/${command}${postfix}
+	for attempt in $(seq 1 "$retries"); do
+		if $mongo_command "use ${database}\n ${full_command}" "$uri" "mongodb" "$suffix" "" "${replicaset}" \
+			| grep -E -v 'I NETWORK|W NETWORK|F NETWORK|"c":"NETWORK"|Error saving history file|Percona Server for MongoDB|connecting to:|Unable to reach primary for set|Implicit session:|versions do not match|Error saving history file:|Started a new thread for the timer service' \
+			| $sed -re 's/ObjectId\("[0-9a-f]+"\)//; s/-[0-9]+.svc/-xxx.svc/' \
+				>$tmp_dir/${command}${postfix}
+		then
+			if compare_mongo_output "$command" "$postfix"; then
+				return
+			fi
+		fi
 
-	if [[ ${UPDATE_COMPARE_FILES} -eq 0 ]]; then
-		diff -u ${test_dir}/compare/${command}${postfix}.json $tmp_dir/${command}${postfix}
-	else
-		cp $tmp_dir/${command}${postfix} ${test_dir}/compare/${command}${postfix}.json
-	fi
+		[[ $attempt -lt $retries ]] && sleep "$retry_delay"
+	done
+
+	return 1
 }
 
 compare_mongosh_cmd() {
@@ -1471,6 +1490,8 @@ compare_mongosh_cmd() {
 	local sort="$7"
 	local tls="${8:-false}"
 	local replicaset="$9"
+	local retries="${10:-3}"
+	local retry_delay="${11:-10}"
 
 	local full_command="db.${collection}.${command}()"
 	if [[ -n ${sort} ]]; then
@@ -1485,16 +1506,21 @@ compare_mongosh_cmd() {
 		mongo_command=run_mongosh
 	fi
 
-	$mongo_command "use ${database}\n ${full_command}" "$uri" "mongodb" "$suffix" "" ${replicaset} \
-		| grep -E -v 'I NETWORK|W NETWORK|F NETWORK|"c":"NETWORK"|Error saving history file|Percona Server for MongoDB|connecting to:|Unable to reach primary for set|Implicit session:|versions do not match|Error saving history file:|Started a new thread for the timer service' \
-		| $sed -re 's/ObjectId\("[0-9a-f]+"\)//; s/-[0-9]+.svc/-xxx.svc/' \
-			>$tmp_dir/${command}${postfix}
+	for attempt in $(seq 1 "$retries"); do
+		if $mongo_command "use ${database}\n ${full_command}" "$uri" "mongodb" "$suffix" "" "${replicaset}" \
+			| grep -E -v 'I NETWORK|W NETWORK|F NETWORK|"c":"NETWORK"|Error saving history file|Percona Server for MongoDB|connecting to:|Unable to reach primary for set|Implicit session:|versions do not match|Error saving history file:|Started a new thread for the timer service' \
+			| $sed -re 's/ObjectId\("[0-9a-f]+"\)//; s/-[0-9]+.svc/-xxx.svc/' \
+				>$tmp_dir/${command}${postfix}
+		then
+			if compare_mongo_output "$command" "$postfix"; then
+				return
+			fi
+		fi
 
-	if [[ ${UPDATE_COMPARE_FILES} -eq 0 ]]; then
-		diff -u ${test_dir}/compare/${command}${postfix}.json $tmp_dir/${command}${postfix}
-	else
-		cp $tmp_dir/${command}${postfix} ${test_dir}/compare/${command}${postfix}.json
-	fi
+		[[ $attempt -lt $retries ]] && sleep "$retry_delay"
+	done
+
+	return 1
 }
 
 compare_mongos_cmd() {
@@ -1506,6 +1532,8 @@ compare_mongos_cmd() {
 	local collection="${6:-test}"
 	local port="${7:-27017}"
 	local tls="${8:-false}"
+	local retries="${9:-3}"
+	local retry_delay="${10:-10}"
 
 	if [[ $tls == "true" ]]; then
 		mongos_command=run_mongos_tls
@@ -1515,16 +1543,21 @@ compare_mongos_cmd() {
 
 	log "running db.${collection}.command() in ${database}"
 
-	$mongos_command "use ${database}\n db.${collection}.${command}()" "$uri" "mongodb" "$suffix" "" "$port" \
-		| grep -E -v 'I NETWORK|W NETWORK|Error saving history file|Percona Server for MongoDB|connecting to:|Unable to reach primary for set|Implicit session:|versions do not match|Error saving history file:|Started a new thread for the timer service' \
-		| $sed -re 's/ObjectId\("[0-9a-f]+"\)//; s/-[0-9]+.svc/-xxx.svc/' \
-			>$tmp_dir/${command}${postfix}
+	for attempt in $(seq 1 "$retries"); do
+		if $mongos_command "use ${database}\n db.${collection}.${command}()" "$uri" "mongodb" "$suffix" "" "$port" \
+			| grep -E -v 'I NETWORK|W NETWORK|Error saving history file|Percona Server for MongoDB|connecting to:|Unable to reach primary for set|Implicit session:|versions do not match|Error saving history file:|Started a new thread for the timer service' \
+			| $sed -re 's/ObjectId\("[0-9a-f]+"\)//; s/-[0-9]+.svc/-xxx.svc/' \
+				>$tmp_dir/${command}${postfix}
+		then
+			if compare_mongo_output "$command" "$postfix"; then
+				return
+			fi
+		fi
 
-	if [[ ${UPDATE_COMPARE_FILES} -eq 0 ]]; then
-		diff ${test_dir}/compare/${command}${postfix}.json $tmp_dir/${command}${postfix}
-	else
-		cp $tmp_dir/${command}${postfix} ${test_dir}/compare/${command}${postfix}.json
-	fi
+		[[ $attempt -lt $retries ]] && sleep "$retry_delay"
+	done
+
+	return 1
 }
 
 get_mongo_primary_endpoint() {

--- a/e2e-tests/ldap-tls/conf/openldap.yaml
+++ b/e2e-tests/ldap-tls/conf/openldap.yaml
@@ -42,6 +42,7 @@ spec:
       labels:
         app.kubernetes.io/name: openldap
     spec:
+      serviceAccountName: openldap
       containers:
         - name: ldap-setup
           image: docker.io/osixia/openldap:latest

--- a/e2e-tests/ldap-tls/run
+++ b/e2e-tests/ldap-tls/run
@@ -7,15 +7,15 @@ test_dir=$(realpath "$(dirname "$0")")
 set_debug
 
 deploy_openldap() {
+	kubectl_bin create serviceaccount openldap
+
 	if [[ -n "$OPENSHIFT" ]]; then
-		yq 'select(.kind=="Deployment").spec.template.spec.containers[0].securityContext.capabilities.drop[0]="ALL" |
-			select(.kind=="Deployment").spec.template.spec.containers[0].securityContext.capabilities.add[0]="NET_BIND_SERVICE" |
-			select(.metadata.name == "ldap-ca").spec.dnsNames[0]="openldap.'$namespace'.svc.cluster.local"' "$test_dir/conf/openldap.yaml" \
-			| kubectl_bin apply -f -
-	else
-		yq 'select(.metadata.name == "ldap-ca").spec.dnsNames[0]="openldap.'$namespace'.svc.cluster.local"' "$test_dir/conf/openldap.yaml" \
-			| kubectl_bin apply -f -
+		oc adm policy add-scc-to-user anyuid -z openldap -n "$namespace"
+		sleep 5
 	fi
+
+	yq 'select(.metadata.name == "ldap-ca").spec.dnsNames[0]="openldap.'$namespace'.svc.cluster.local"' "$test_dir/conf/openldap.yaml" \
+		| kubectl_bin apply -f -
 
 	kubectl rollout status deployment/openldap --timeout=220s
 }

--- a/e2e-tests/ldap/conf/openldap.yaml
+++ b/e2e-tests/ldap/conf/openldap.yaml
@@ -22,6 +22,7 @@ spec:
       labels:
         app.kubernetes.io/name: openldap
     spec:
+      serviceAccountName: openldap
       containers:
         - name: ldap-setup
           image: docker.io/osixia/openldap:latest

--- a/e2e-tests/ldap/run
+++ b/e2e-tests/ldap/run
@@ -7,13 +7,14 @@ test_dir=$(realpath "$(dirname "$0")")
 set_debug
 
 deploy_openldap() {
+	kubectl_bin create serviceaccount openldap
+
 	if [[ -n "$OPENSHIFT" ]]; then
-		yq 'select(.kind=="Deployment").spec.template.spec.containers[0].securityContext.capabilities.drop[0]="ALL" |
-			select(.kind=="Deployment").spec.template.spec.containers[0].securityContext.capabilities.add[0]="NET_BIND_SERVICE"' "$test_dir/conf/openldap.yaml" \
-			| kubectl_bin apply -f -
-	else
-		kubectl_bin apply -f "$test_dir/conf/openldap.yaml"
+		oc adm policy add-scc-to-user anyuid -z openldap -n "$namespace"
+		sleep 5
 	fi
+
+	kubectl_bin apply -f "$test_dir/conf/openldap.yaml"
 
 	kubectl rollout status deployment/openldap --timeout=220s
 }

--- a/e2e-tests/pvc-resize/conf/eks-storageclass.yml
+++ b/e2e-tests/pvc-resize/conf/eks-storageclass.yml
@@ -1,10 +1,10 @@
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: gp2-resizable
+  name: gp3-resizable
 parameters:
   fsType: ext4
-  type: gp2
+  type: gp3
 provisioner: kubernetes.io/aws-ebs
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer

--- a/e2e-tests/pvc-resize/conf/some-name-eks.yml
+++ b/e2e-tests/pvc-resize/conf/some-name-eks.yml
@@ -49,10 +49,10 @@ spec:
             prefixCompression: true
     volumeSpec:
       persistentVolumeClaim:
-        storageClassName: gp2-resizable
+        storageClassName: gp3-resizable
         resources:
           requests:
-            storage: 1G
+            storage: 1Gi
     size: 3
   secrets:
     users: some-users


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Description:**
- Add permissions required by Openshift to openldap deployment.
- Add retries to compare functions in order to avoid intermittence with exposed loadbalancer availability (mostly hapenning on Openshift and EKS). In this case service-per-pod test is failing sue to this issue.
- Use gp3 as a lower cost storage for volume expansion (EKS), also fix G to Gi on EKS cluster setup.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
