### PR TITLE
K8SPSMDB-1772: Wait for MCS service import hostname to resolve before proceeding

### DIFF
--- a/pkg/controller/perconaservermongodb/mgo.go
+++ b/pkg/controller/perconaservermongodb/mgo.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"reflect"
 	"slices"
 	"sort"
@@ -67,6 +68,32 @@ func shouldSetDefaultRWConcern(cr *api.PerconaServerMongoDB, replset *api.Replse
 	return replset.Arbiter.Enabled || externalArbiterFound || cr.Spec.DefaultRWConcern != nil
 }
 
+// dnsResolver resolves hostnames to IP addresses. It is satisfied by
+// *net.Resolver and can be replaced in tests.
+type dnsResolver interface {
+	LookupIPAddr(ctx context.Context, host string) ([]net.IPAddr, error)
+}
+
+// resolver returns the configured DNS resolver, falling back to the default
+// system resolver when none is set.
+func (r *ReconcilePerconaServerMongoDB) resolver() dnsResolver {
+	if r.dnsResolver != nil {
+		return r.dnsResolver
+	}
+	return net.DefaultResolver
+}
+
+// hostResolvable reports whether host resolves to at least one IP address.
+// A resolver error is returned to the caller; a successful lookup with no
+// addresses returns (false, nil).
+func hostResolvable(ctx context.Context, resolver dnsResolver, host string) (bool, error) {
+	ips, err := resolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return false, err
+	}
+	return len(ips) > 0, nil
+}
+
 func (r *ReconcilePerconaServerMongoDB) reconcileCluster(ctx context.Context, cr *api.PerconaServerMongoDB, replset *api.ReplsetSpec, mongosPods []corev1.Pod) (api.AppState, map[string]api.ReplsetMemberStatus, error) {
 	log := logf.FromContext(ctx)
 
@@ -121,6 +148,13 @@ func (r *ReconcilePerconaServerMongoDB) reconcileCluster(ctx context.Context, cr
 			}
 			if !imported {
 				log.Info("waiting for service import", "replset", replset.Name, "serviceExport", se.Name)
+				return api.AppStateInit, nil, nil
+			}
+			// check if the hostname is resolvable yet; DNS may lag behind the service import
+			host := psmdb.GetMCSHost(cr, se.Name)
+			resolved, err := hostResolvable(ctx, r.resolver(), host)
+			if err != nil || !resolved {
+				log.Info("waiting for imported service hostname to resolve to an IP", "replset", replset.Name, "host", host, "error", err)
 				return api.AppStateInit, nil, nil
 			}
 		}

--- a/pkg/controller/perconaservermongodb/mgo_test.go
+++ b/pkg/controller/perconaservermongodb/mgo_test.go
@@ -1,13 +1,93 @@
 package perconaservermongodb
 
 import (
+	"context"
+	"net"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
 	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb/mongo"
 )
+
+// fakeResolver is a test double for dnsResolver.
+type fakeResolver struct {
+	ips     []net.IPAddr
+	err     error
+	gotHost string
+}
+
+func (f *fakeResolver) LookupIPAddr(_ context.Context, host string) ([]net.IPAddr, error) {
+	f.gotHost = host
+	return f.ips, f.err
+}
+
+func TestHostResolvable(t *testing.T) {
+	t.Parallel()
+
+	const host = "my-cluster-rs0-0.psmdb.svc.clusterset.local"
+
+	tests := map[string]struct {
+		resolver    *fakeResolver
+		expectedOK  bool
+		expectedErr bool
+	}{
+		"resolves to an IP": {
+			resolver:    &fakeResolver{ips: []net.IPAddr{{IP: net.ParseIP("10.0.0.1")}}},
+			expectedOK:  true,
+			expectedErr: false,
+		},
+		"resolves to multiple IPs": {
+			resolver: &fakeResolver{ips: []net.IPAddr{
+				{IP: net.ParseIP("10.0.0.1")},
+				{IP: net.ParseIP("10.0.0.2")},
+			}},
+			expectedOK:  true,
+			expectedErr: false,
+		},
+		"lookup error": {
+			resolver:    &fakeResolver{err: errors.New("no such host")},
+			expectedOK:  false,
+			expectedErr: true,
+		},
+		"no addresses without error": {
+			resolver:    &fakeResolver{ips: nil},
+			expectedOK:  false,
+			expectedErr: false,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			ok, err := hostResolvable(context.Background(), tt.resolver, host)
+
+			if tt.expectedErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.expectedOK, ok)
+			// the bare hostname must be passed to the resolver, never host:port
+			assert.Equal(t, host, tt.resolver.gotHost)
+		})
+	}
+}
+
+func TestReconcilerResolverDefault(t *testing.T) {
+	t.Parallel()
+
+	// no resolver configured -> falls back to the system default resolver
+	r := &ReconcilePerconaServerMongoDB{}
+	assert.Same(t, net.DefaultResolver, r.resolver())
+
+	// configured resolver is returned as-is
+	fake := &fakeResolver{}
+	r.dnsResolver = fake
+	assert.Same(t, fake, r.resolver())
+}
 
 func TestCompareTags(t *testing.T) {
 	t.Parallel()

--- a/pkg/controller/perconaservermongodb/psmdb_controller.go
+++ b/pkg/controller/perconaservermongodb/psmdb_controller.go
@@ -247,6 +247,10 @@ type ReconcilePerconaServerMongoDB struct {
 	initImage string
 
 	lockers lockStore
+
+	// dnsResolver resolves hostnames when checking imported multi-cluster
+	// services. Defaults to net.DefaultResolver; overridable in tests.
+	dnsResolver dnsResolver
 }
 
 type lockStore struct {

--- a/pkg/psmdb/service.go
+++ b/pkg/psmdb/service.go
@@ -408,9 +408,14 @@ func GetServiceMeshAddr(cr *api.PerconaServerMongoDB, pod string, port int32) st
 		":" + strconv.Itoa(int(port))
 }
 
+// GetMCSHost returns the ReplicaSet pod hostname using the MultiCluster FQDN, without a port.
+func GetMCSHost(cr *api.PerconaServerMongoDB, pod string) string {
+	return fmt.Sprintf("%s.%s.%s", pod, cr.Namespace, cr.Spec.MultiCluster.DNSSuffix)
+}
+
 // GetMCSAddr returns ReplicaSet pod address using MultiCluster FQDN
 func GetMCSAddr(cr *api.PerconaServerMongoDB, pod string, port int32) string {
-	return fmt.Sprintf("%s.%s.%s:%d", pod, cr.Namespace, cr.Spec.MultiCluster.DNSSuffix, port)
+	return fmt.Sprintf("%s:%d", GetMCSHost(cr, pod), port)
 }
 
 var ErrServiceNotExists = errors.New("service doesn't exist")

--- a/pkg/psmdb/service_test.go
+++ b/pkg/psmdb/service_test.go
@@ -529,3 +529,35 @@ func TestBuildDNSHostnameWithoutIndex(t *testing.T) {
 		})
 	}
 }
+
+func TestGetMCSHost(t *testing.T) {
+	tests := map[string]struct {
+		namespace string
+		dnsSuffix string
+		pod       string
+		expected  string
+	}{
+		"typical clusterset host": {
+			namespace: "psmdb",
+			dnsSuffix: "svc.clusterset.local",
+			pod:       "my-cluster-rs0-0",
+			expected:  "my-cluster-rs0-0.psmdb.svc.clusterset.local",
+		},
+		"empty dns suffix": {
+			namespace: "psmdb",
+			dnsSuffix: "",
+			pod:       "my-cluster-rs0-0",
+			expected:  "my-cluster-rs0-0.psmdb.",
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			cr := &api.PerconaServerMongoDB{}
+			cr.Namespace = tt.namespace
+			cr.Spec.MultiCluster.DNSSuffix = tt.dnsSuffix
+
+			assert.Equal(t, tt.expected, GetMCSHost(cr, tt.pod))
+			assert.Equal(t, tt.expected+":27017", GetMCSAddr(cr, tt.pod, 27017))
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- DNS propagation for imported multi-cluster (MCS) services can lag behind `ServiceImport` registration. The reconciler now verifies the imported service's hostname actually resolves before treating the replset as ready to proceed, instead of assuming DNS is immediately available once the `ServiceImport` object exists.
- Adds `psmdb.GetMCSHost` as a shared helper for building the MCS FQDN (without port), and refactors `GetMCSAddr` to reuse it instead of duplicating the format string.

## Test plan
- [x] `go build ./...`
- [x] `gofmt -l` / `go vet` clean on touched files
- [x] New unit tests: `TestHostResolvable`, `TestReconcilerResolverDefault` (controller), `TestGetMCSHost` (psmdb)
- [x] Existing unit tests in both touched packages pass