### PR TITLE
CLOUD-929 Fix e2e-tests in pytest on Rancher and Minikube

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -367,6 +367,7 @@ void runTest(Integer TEST_ID) {
                 export SKIP_DELETE=0
                 export COLUMNS=200
                 export KUBECONFIG=/tmp/${CLUSTER_NAME}-${clusterSuffix}
+                export PYTEST_NAMESPACE_FILE=/tmp/pytest_current_namespace-${testName}-${clusterSuffix}
                 export GCP_PROJECT=\$GCP_PROJECT
                 export GCS_WI_SERVICE_ACCOUNT=percona-psmdb-operator-wi@\$GCP_PROJECT.iam.gserviceaccount.com
                 export PATH="\$HOME/.local/bin:\$PATH"

--- a/e2e-tests/conftest.py
+++ b/e2e-tests/conftest.py
@@ -217,7 +217,8 @@ def setup_env_vars() -> None:
     }
 
     for key, value in defaults.items():
-        os.environ.setdefault(key, value)
+        if not os.environ.get(key):
+            os.environ[key] = value
 
     registry = os.environ["REGISTRY_NAME"].rstrip("/") + "/"
     image_vars = [key for key in defaults if key.startswith("IMAGE")]
@@ -444,6 +445,9 @@ def _cert_manager_url() -> str:
 
 def _delete_cert_manager() -> None:
     """Best-effort removal of cert-manager; safe to call when it isn't installed."""
+    if env_bool("RANCHER"):
+        logger.info("Rancher cluster detected, skipping cert-manager destroy")
+        return
     logger.info("Deleting cert-manager")
     kubectl_bin("delete", "-f", _cert_manager_url(), "--ignore-not-found", check=False)
 
@@ -459,6 +463,9 @@ def deploy_cert_manager() -> Generator[Callable[..., None]]:
     """Deploy Cert Manager and clean up after tests."""
 
     def _deploy(*extra_args: str) -> None:
+        if env_bool("RANCHER"):
+            logger.info("Rancher cluster detected, skipping cert-manager deployment")
+            return
         logger.info("Deploying cert-manager")
         try:
             kubectl_bin("create", "namespace", "cert-manager")

--- a/e2e-tests/conftest.py
+++ b/e2e-tests/conftest.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import subprocess
+import time
 import uuid
 from collections.abc import Callable, Generator
 from concurrent.futures import ThreadPoolExecutor
@@ -87,10 +88,35 @@ def pytest_collection_modifyitems(
             )
 
 
+_NODES_READY_TIMEOUT = 300
+_NODES_READY_INTERVAL = 10
+
+
+def _wait_for_nodes_ready() -> None:
+    """Wait until K8s nodes are ready, failing the test if they aren't in time."""
+    from lib import report_generator
+
+    deadline = time.monotonic() + _NODES_READY_TIMEOUT
+    while True:
+        status = report_generator.check_nodes_ready()
+        if status["ok"]:
+            return
+        if time.monotonic() >= deadline:
+            pytest.fail(
+                f"K8s nodes not ready: {status['ready']}/{status['total']} "
+                f"(need >= {report_generator.MIN_READY_NODES}) "
+                f"after {_NODES_READY_TIMEOUT}s",
+                pytrace=False,
+            )
+        logger.warning(f"Waiting for nodes ready: {status['ready']}/{status['total']}")
+        time.sleep(_NODES_READY_INTERVAL)
+
+
 @pytest.hookimpl(tryfirst=True)
 def pytest_runtest_setup(item: pytest.Item) -> None:
-    """Print newline after pytest's verbose test name output."""
+    """Print newline after pytest's verbose test name output and gate on node readiness."""
     print()
+    _wait_for_nodes_ready()
 
 
 @pytest.hookimpl(tryfirst=True)
@@ -220,7 +246,7 @@ def setup_env_vars() -> None:
         if not os.environ.get(key):
             os.environ[key] = value
 
-    registry = os.environ["REGISTRY_NAME"].rstrip("/") + "/"
+    registry = os.environ.get("REGISTRY_NAME", "").rstrip("/") + "/"
     image_vars = [key for key in defaults if key.startswith("IMAGE")]
     image_vars.append("IMAGE_OPERATOR")
     for var in image_vars:
@@ -323,6 +349,23 @@ def _cleanup_crd(src_dir: str) -> None:
         _kubectl_quietly("wait", "--for=delete", "crd", name, "--timeout=60s")
 
 
+def _clear_namespace_finalizers(ns: str) -> None:
+    """Strip finalizers on operator resources so the namespace does not hang in
+    Terminating when the operator is already gone (or gke-mcs stops clearing them)."""
+    for kind in ("psmdb", "psmdb-backup", "psmdb-restore", "serviceexport", "serviceimport"):
+        names = kubectl_bin("get", kind, "-n", ns, "-o", "name", "--ignore-not-found", check=False)
+        for name in (names or "").split():
+            _kubectl_quietly(
+                "patch",
+                name,
+                "-n",
+                ns,
+                "--type=merge",
+                "-p",
+                '{"metadata":{"finalizers":[]}}',
+            )
+
+
 def _cleanup_infra(test_paths: Paths, namespaces: list[str]) -> None:
     """Best-effort teardown of everything created by the create_infra fixture."""
     logger.info("Cleaning up test environment")
@@ -345,7 +388,13 @@ def _cleanup_infra(test_paths: Paths, namespaces: list[str]) -> None:
         pool.submit(_cleanup_crd, src_dir)
 
     # Namespaces go last so finalizer-bearing resources (e.g. psmdb-backup) are removed first.
+    # Strip finalizers up front so the namespace does not hang in Terminating waiting
+    # for a controller that may already be torn down.
     if namespaces:
+        with ThreadPoolExecutor(max_workers=len(namespaces)) as pool:
+            for ns in namespaces:
+                pool.submit(_clear_namespace_finalizers, ns)
+
         with ThreadPoolExecutor(max_workers=len(namespaces)) as pool:
             for ns in namespaces:
                 pool.submit(
@@ -418,7 +467,7 @@ def deploy_chaos_mesh() -> Generator[Callable[[str], None]]:
             "--namespace",
             namespace,
             "--version",
-            os.environ["CHAOS_MESH_VER"],
+            os.environ.get("CHAOS_MESH_VER", ""),
             "--set",
             "dashboard.create=false",
             "--set",
@@ -535,7 +584,7 @@ def deploy_minio() -> Generator[None]:
     helm_bin("repo", "add", "minio", "https://charts.min.io/")
 
     endpoint = f"http://{service_name}:9000"
-    minio_ver = os.environ.get("MINIO_VER") or ""
+    minio_ver = os.environ.get("MINIO_VER", "")
     settings = {
         "replicas": "1",
         "mode": "standalone",
@@ -616,3 +665,20 @@ def psmdb_client(test_paths: Paths) -> MongoManager:
     pod_name = result.strip()
     wait_pod(pod_name)
     return MongoManager(pod_name)
+
+
+@pytest.fixture
+def bash_test_cleanup(test_paths: Paths) -> Generator[None]:
+    """Tear down a bash-wrapped test's namespace after diagnostics are collected."""
+    yield
+
+    if env_bool("SKIP_DELETE"):
+        logger.info("SKIP_DELETE is set. Skipping bash test cleanup")
+        return
+
+    ns = _get_current_namespace()
+    namespaces = [ns] if ns else []
+    operator_ns = os.environ.get("OPERATOR_NS")
+    if operator_ns:
+        namespaces.append(operator_ns)
+    _cleanup_infra(test_paths, namespaces)

--- a/e2e-tests/conftest.py
+++ b/e2e-tests/conftest.py
@@ -371,8 +371,10 @@ def _cleanup_infra(test_paths: Paths, namespaces: list[str]) -> None:
     logger.info("Cleaning up test environment")
     src_dir = test_paths["src_dir"]
     rbac = f"{src_dir}/deploy/{'cw-' if os.environ.get('OPERATOR_NS') else ''}rbac.yaml"
+
+    _kubectl_quietly("delete", "psmdb-backup", "--all", "--ignore-not-found", "--timeout=120s")
+
     deletes = [
-        ["delete", "psmdb-backup", "--all", "--ignore-not-found"],
         [
             "delete",
             "-f",
@@ -387,9 +389,6 @@ def _cleanup_infra(test_paths: Paths, namespaces: list[str]) -> None:
             pool.submit(_kubectl_quietly, *args)
         pool.submit(_cleanup_crd, src_dir)
 
-    # Namespaces go last so finalizer-bearing resources (e.g. psmdb-backup) are removed first.
-    # Strip finalizers up front so the namespace does not hang in Terminating waiting
-    # for a controller that may already be torn down.
     if namespaces:
         with ThreadPoolExecutor(max_workers=len(namespaces)) as pool:
             for ns in namespaces:
@@ -400,11 +399,10 @@ def _cleanup_infra(test_paths: Paths, namespaces: list[str]) -> None:
                 pool.submit(
                     _kubectl_quietly,
                     "delete",
-                    "--grace-period=0",
-                    "--force",
                     "namespace",
                     ns,
                     "--ignore-not-found",
+                    "--wait=false",
                 )
 
 

--- a/e2e-tests/conftest.py
+++ b/e2e-tests/conftest.py
@@ -62,9 +62,9 @@ logger = logging.getLogger(__name__)
 
 _current_namespace: str | None = None
 
-# Path shared with the bash harness (see e2e-tests/functions), which writes the
-# active namespace here so failure reports can be generated for bash-wrapped tests.
-_NAMESPACE_FILE = "/tmp/pytest_current_namespace"
+# Shared with the bash harness (e2e-tests/functions). Override via
+# PYTEST_NAMESPACE_FILE so parallel Jenkins clusters don't race on one path.
+_NAMESPACE_FILE = os.environ.get("PYTEST_NAMESPACE_FILE", "/tmp/pytest_current_namespace")
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
@@ -329,7 +329,7 @@ def _kubectl_quietly(*args: str) -> None:
 
 
 def _cleanup_crd(src_dir: str) -> None:
-    """Delete the operator CRDs, clearing finalizers so the deletion can finish."""
+    """Best-effort CRD delete: never wait on controllers."""
     crd_file = Path(src_dir) / "deploy" / "crd.yaml"
     _kubectl_quietly("delete", "-f", str(crd_file), "--ignore-not-found", "--wait=false")
 
@@ -346,7 +346,6 @@ def _cleanup_crd(src_dir: str) -> None:
         _kubectl_quietly(
             "patch", "crd", name, "--type=merge", "-p", '{"metadata":{"finalizers":[]}}'
         )
-        _kubectl_quietly("wait", "--for=delete", "crd", name, "--timeout=60s")
 
 
 def _clear_namespace_finalizers(ns: str) -> None:
@@ -366,13 +365,26 @@ def _clear_namespace_finalizers(ns: str) -> None:
             )
 
 
+def _delete_namespace_crs(ns: str) -> None:
+    """Issue non-blocking deletes for operator CRs after finalizers are cleared."""
+    for kind in ("psmdb-backup", "psmdb-restore", "psmdb"):
+        _kubectl_quietly("delete", kind, "--all", "-n", ns, "--ignore-not-found", "--wait=false")
+
+
 def _cleanup_infra(test_paths: Paths, namespaces: list[str]) -> None:
-    """Best-effort teardown of everything created by the create_infra fixture."""
+    """Best-effort teardown: strip finalizers, fire-and-forget deletes, never hang."""
     logger.info("Cleaning up test environment")
     src_dir = test_paths["src_dir"]
     rbac = f"{src_dir}/deploy/{'cw-' if os.environ.get('OPERATOR_NS') else ''}rbac.yaml"
 
-    _kubectl_quietly("delete", "psmdb-backup", "--all", "--ignore-not-found", "--timeout=120s")
+    # Finalizers first, while CRD APIs still exist. Do not wait on operator/storage.
+    if namespaces:
+        with ThreadPoolExecutor(max_workers=len(namespaces)) as pool:
+            for ns in namespaces:
+                pool.submit(_clear_namespace_finalizers, ns)
+        with ThreadPoolExecutor(max_workers=len(namespaces)) as pool:
+            for ns in namespaces:
+                pool.submit(_delete_namespace_crs, ns)
 
     deletes = [
         [
@@ -380,8 +392,9 @@ def _cleanup_infra(test_paths: Paths, namespaces: list[str]) -> None:
             "-f",
             f"{test_paths['test_dir']}/../conf/container-rc.yaml",
             "--ignore-not-found",
+            "--wait=false",
         ],
-        ["delete", "-f", rbac, "--ignore-not-found"],
+        ["delete", "-f", rbac, "--ignore-not-found", "--wait=false"],
     ]
 
     with ThreadPoolExecutor(max_workers=len(deletes) + 1) as pool:
@@ -390,10 +403,6 @@ def _cleanup_infra(test_paths: Paths, namespaces: list[str]) -> None:
         pool.submit(_cleanup_crd, src_dir)
 
     if namespaces:
-        with ThreadPoolExecutor(max_workers=len(namespaces)) as pool:
-            for ns in namespaces:
-                pool.submit(_clear_namespace_finalizers, ns)
-
         with ThreadPoolExecutor(max_workers=len(namespaces)) as pool:
             for ns in namespaces:
                 pool.submit(
@@ -436,11 +445,13 @@ def create_infra(
         # Track created namespace for cleanup and failure collection
         created_namespaces.append(namespace)
         _current_namespace = namespace
+        Path(_NAMESPACE_FILE).write_text(namespace)
         return namespace
 
     yield _create_infra
 
     _current_namespace = None
+    Path(_NAMESPACE_FILE).unlink(missing_ok=True)
 
     if env_bool("SKIP_DELETE"):
         logger.info("SKIP_DELETE is set. Skipping test environment cleanup")

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -1687,7 +1687,7 @@ delete_crd() {
 			| grep -v 'NAMESPACE' \
 			| xargs -L 1 sh -xc 'kubectl patch '${crd_name}' -n $0 $1 --type=merge -p "{\"metadata\":{\"finalizers\":[]}}"' \
 			|| :
-		kubectl_bin wait --for=delete crd ${crd_name} || :
+		kubectl_bin patch crd "${crd_name}" --type=merge -p '{"metadata":{"finalizers":[]}}' --ignore-not-found || :
 	done
 
 	local rbac_yaml='rbac.yaml'
@@ -1695,15 +1695,16 @@ delete_crd() {
 		rbac_yaml='cw-rbac.yaml'
 	fi
 
-	kubectl_bin delete -f "${src_dir}/deploy/$rbac_yaml" --ignore-not-found || true
+	kubectl_bin delete -f "${src_dir}/deploy/$rbac_yaml" --ignore-not-found --wait=false || true
 }
 
 delete_backups() {
-	desc 'Delete psmdb-backup'
-	if [ $(kubectl_bin get psmdb-backup --no-headers | wc -l) != 0 ]; then
-		kubectl_bin get psmdb-backup
-		kubectl_bin delete psmdb-backup --all
-	fi
+	desc 'Delete psmdb-backup (non-blocking)'
+	local name
+	for name in $(kubectl_bin get psmdb-backup -o name --ignore-not-found 2>/dev/null); do
+		kubectl_bin patch "${name}" --type=merge -p '{"metadata":{"finalizers":[]}}' || :
+	done
+	kubectl_bin delete psmdb-backup --all --ignore-not-found --wait=false || :
 }
 
 destroy() {
@@ -2421,7 +2422,8 @@ setup_azure_credentials() {
 create_infra() {
 	local ns="$1"
 
-	echo "$ns" >/tmp/pytest_current_namespace
+	# PYTEST_NAMESPACE_FILE isolates parallel Jenkins/local jobs sharing /tmp.
+	echo "$ns" >"${PYTEST_NAMESPACE_FILE:-/tmp/pytest_current_namespace}"
 
 	if [[ ${DELETE_CRD_ON_START} == 1 ]]; then
 		delete_crd

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -299,8 +299,12 @@ create_namespace() {
 	if [[ ${CLEAN_NAMESPACE} == 1 ]] && [[ -z ${skip_clean_namespace} ]]; then
 		destroy_chaos_mesh
 		desc 'cleaned up all old namespaces'
+		local ns_filter="^kube-|^default|Terminating|psmdb-operator|openshift|^gke-|^gmp-|^NAME"
+		if [[ -n "$RANCHER" ]]; then
+			ns_filter="${ns_filter}|^cattle-|^fleet-|^cluster-fleet-|^local|^longhorn-|^metallb-|^cert-manager|^p-"
+		fi
 		kubectl_bin get ns \
-			| grep -E -v "^kube-|^default|Terminating|psmdb-operator|openshift|^gke-|^gmp-|^NAME" \
+			| grep -E -v "${ns_filter}" \
 			| awk '{print$1}' \
 			| xargs kubectl delete ns &
 	fi

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -1710,6 +1710,9 @@ destroy() {
 	local namespace="$1"
 	local ignore_logs="${2:-true}"
 
+	# NOTE: the pytest bash wrapper (lib/bash_wrapper.py) always forces SKIP_DELETE=1
+	# for bash-wrapped runs, so this early return is always taken there and the actual
+	# teardown is owned by the bash_test_cleanup fixture in conftest.py instead.
 	if [[ ${SKIP_DELETE} == 1 ]]; then
 		echo "SKIP_DELETE=1, not destroying ${namespace}"
 		return

--- a/e2e-tests/functions
+++ b/e2e-tests/functions
@@ -1652,7 +1652,7 @@ run_pumba() {
 }
 
 deploy_cert_manager() {
-	if [[ $PLATFORM == "rancher" ]]; then
+	if [[ -n "$RANCHER" ]]; then
 		log "Rancher cluster detected, skipping cert manager deployment"
 		return
 	fi
@@ -1747,7 +1747,7 @@ destroy() {
 }
 
 destroy_cert_manager() {
-	if [[ $PLATFORM == "rancher" ]]; then
+	if [[ -n "$RANCHER" ]]; then
 		log "Rancher cluster detected, skipping cert manager destroy"
 		return
 	fi

--- a/e2e-tests/lib/bash_wrapper.py
+++ b/e2e-tests/lib/bash_wrapper.py
@@ -17,7 +17,10 @@ def run_bash_test(test_name: str) -> None:
 
     try:
         os.chdir(script_dir)
-        result = subprocess.run(["bash", "run"], check=False)
+        # Keep the namespace alive so pytest can collect diagnostics on failure;
+        # pytest handles teardown afterward (see bash_test_cleanup fixture).
+        env = {**os.environ, "SKIP_DELETE": "1"}
+        result = subprocess.run(["bash", "run"], check=False, env=env)
 
         if result.returncode != 0:
             pytest.fail(f"Test {test_name} failed with exit code {result.returncode}")

--- a/e2e-tests/lib/kubectl.py
+++ b/e2e-tests/lib/kubectl.py
@@ -201,17 +201,19 @@ def clean_all_namespaces() -> None:
             "fleet-",
             "cluster-fleet-",
             "local",
+            "longhorn-",
+            "metallb-",
+            "p-",
         ]
-        # cert-manager is not destroyed on Rancher, so keep it around there.
+
         if os.environ.get("RANCHER") == "1":
             excluded.append("cert-manager")
-
         namespaces = [
             parts[0]
             for line in result.strip().splitlines()
             if (parts := line.split())
             and len(parts) == 2
-            and not any(ex in parts[0] for ex in excluded)
+            and not any(parts[0].startswith(ex) for ex in excluded)
             and parts[1] != "Terminating"
         ]
 
@@ -243,6 +245,7 @@ def detect_platform() -> str:
         ("eksctl.io", "eks"),
         ("cloud.google.com/gke", "gke"),
         ("kubernetes.azure.com", "aks"),
+        ("minikube.k8s.io", "minikube"),
     ):
         if needle in labels:
             return name
@@ -250,7 +253,7 @@ def detect_platform() -> str:
     provider_id = kubectl_bin(
         "get", "nodes", "-o", "jsonpath={.items[0].spec.providerID}", check=False
     ).lower()
-    for needle, name in (("kind://", "kind"), ("minikube", "minikube"), ("rke2", "rancher")):
+    for needle, name in (("kind://", "kind"), ("rke2", "rancher")):
         if needle in provider_id:
             return name
 

--- a/e2e-tests/lib/kubectl.py
+++ b/e2e-tests/lib/kubectl.py
@@ -190,7 +190,21 @@ def clean_all_namespaces() -> None:
             "-o",
             "jsonpath={range .items[*]}{.metadata.name} {.status.phase}{'\\n'}{end}",
         )
-        excluded = ("kube-", "default", "psmdb-operator", "openshift", "gke-", "gmp-")
+        excluded = [
+            "kube-",
+            "default",
+            "psmdb-operator",
+            "openshift",
+            "gke-",
+            "gmp-",
+            "cattle-",
+            "fleet-",
+            "cluster-fleet-",
+            "local",
+        ]
+        # cert-manager is not destroyed on Rancher, so keep it around there.
+        if os.environ.get("RANCHER") == "1":
+            excluded.append("cert-manager")
 
         namespaces = [
             parts[0]
@@ -202,7 +216,7 @@ def clean_all_namespaces() -> None:
         ]
 
         if namespaces:
-            kubectl_bin("delete", "ns", *namespaces)
+            kubectl_bin("delete", "ns", "--wait=false", *namespaces)
     except subprocess.CalledProcessError:
         logger.error("Failed to clean namespaces")
 

--- a/e2e-tests/test_pytest_wrapper.py
+++ b/e2e-tests/test_pytest_wrapper.py
@@ -2,7 +2,7 @@ import pytest
 from lib.bash_wrapper import run_bash_test
 
 
-def test_bash_wrapper(request: pytest.FixtureRequest) -> None:
+def test_bash_wrapper(request: pytest.FixtureRequest, bash_test_cleanup: None) -> None:
     """Run a bash test script via pytest wrapper."""
     test_name = request.config.getoption("--test-name")
     if not test_name:


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
- Rancher pipeline and Minikube were failing when running e2e-tests with pytest:
  - namespace cleaning on Rancher was not considering rancher's namespaces, leading to problems when they were deleted.
  - cert-manager does not need to be installed on a Rancher cluster by the tests, cause it comes with it.
  - Minikube was not being detected correctly.
- Tests that run with pytest wrapper can't have its resources collected at the end cause their namespace was destroyed before the collection.
- Test can begin even if the k8s nodes are not ready, leading to flakiness.


**Solution:**
- List the correct namespaces to not be deleted.
- When Rancher is detected, don't install cert-manager. 
- Use different method of detection for Minikube.
- Make the cleanup after the test be responsibility of pytest, so SKIP_DELETE=1 is forced on tests that run with wrapper.
- Wait for 5 minutes for the k8s nodes to be ready before starting the test, if not, fail the test.

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
