### PR TITLE
K8SPSMDB-1764: set authSource for healthcheck connections

### DIFF
--- a/cmd/mongodb-healthcheck/tool/config.go
+++ b/cmd/mongodb-healthcheck/tool/config.go
@@ -27,6 +27,10 @@ import (
 var (
 	defaultMongoDBHost = "localhost"
 	defaultMongoDBPort = "27017"
+	// system users used by the healthcheck live in the admin database. Without
+	// an explicit auth source the driver negotiates SASL mechanisms against an
+	// empty database and mongod logs a ProtocolError on every probe.
+	defaultAuthSource = "admin"
 )
 
 func NewConfig(app *kingpin.Application, envUser string, envPassword string) (*db.Config, error) {
@@ -94,6 +98,7 @@ func NewConfig(app *kingpin.Application, envUser string, envPassword string) (*d
 
 	conf.SSL = ssl
 	conf.Direct = true
+	conf.AuthSource = defaultAuthSource
 
 	return conf, nil
 }

--- a/cmd/mongodb-healthcheck/tool/config.go
+++ b/cmd/mongodb-healthcheck/tool/config.go
@@ -27,10 +27,7 @@ import (
 var (
 	defaultMongoDBHost = "localhost"
 	defaultMongoDBPort = "27017"
-	// system users used by the healthcheck live in the admin database. Without
-	// an explicit auth source the driver negotiates SASL mechanisms against an
-	// empty database and mongod logs a ProtocolError on every probe.
-	defaultAuthSource = "admin"
+	defaultAuthSource  = "admin"
 )
 
 func NewConfig(app *kingpin.Application, envUser string, envPassword string) (*db.Config, error) {

--- a/cmd/mongodb-healthcheck/tool/config_test.go
+++ b/cmd/mongodb-healthcheck/tool/config_test.go
@@ -1,0 +1,19 @@
+package tool
+
+import (
+	"testing"
+
+	"github.com/alecthomas/kingpin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewConfigAuthSource(t *testing.T) {
+	app := kingpin.New("test", "")
+
+	conf, err := NewConfig(app, EnvMongoDBClusterMonitorUser, EnvMongoDBClusterMonitorPassword)
+	require.NoError(t, err)
+
+	assert.Equal(t, "admin", conf.AuthSource)
+	assert.True(t, conf.Direct)
+}

--- a/pkg/psmdb/mongo/mongo_test.go
+++ b/pkg/psmdb/mongo/mongo_test.go
@@ -1,6 +1,7 @@
 package mongo_test
 
 import (
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -1326,6 +1327,56 @@ func TestVoting(t *testing.T) {
 			if votes != 0 && !c.unsafePSA {
 				assert.Falsef(t, votes%2 == 0, "total votes (%d) should be an odd number", votes)
 			}
+		})
+	}
+}
+
+func TestConfigAuthSource(t *testing.T) {
+	cases := []struct {
+		name       string
+		conf       mongo.Config
+		authSource string
+	}{
+		{
+			name: "auth source set",
+			conf: mongo.Config{
+				Hosts:      []string{"localhost:27017"},
+				Username:   "clusterMonitor",
+				Password:   "pass",
+				AuthSource: "admin",
+			},
+			authSource: "admin",
+		},
+		{
+			name: "custom auth source",
+			conf: mongo.Config{
+				Hosts:      []string{"localhost:27017"},
+				Username:   "app",
+				Password:   "pass",
+				AuthSource: "application",
+			},
+			authSource: "application",
+		},
+		{
+			name: "auth source unset",
+			conf: mongo.Config{
+				Hosts:    []string{"localhost:27017"},
+				Username: "clusterMonitor",
+				Password: "pass",
+			},
+			authSource: "",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			opts := c.conf.Options()
+			require.NotNil(t, opts.Auth)
+			assert.Equal(t, c.authSource, opts.Auth.AuthSource)
+
+			uri, err := url.Parse(c.conf.URI())
+			require.NoError(t, err)
+			assert.Equal(t, c.authSource, uri.Query().Get("authSource"))
 		})
 	}
 }


### PR DESCRIPTION
## What

Set `AuthSource` to `admin` explicitly in `mongodb-healthcheck`'s `NewConfig`, plus regression tests for the healthcheck config and for `mongo.Config` propagating `AuthSource` into the driver credential and the connection URI.

## Why

Fixes #2468 (K8SPSMDB-1764). The healthcheck never set `AuthSource`, and the Go driver resolves the empty value inconsistently — in the pinned `go.mongodb.org/mongo-driver/v2 v2.8.0`:

- Handshake: `x/mongo/driver/topology/topology_options.go:301` builds `handshakeOpts.DBUser = opts.Auth.AuthSource + "." + opts.Auth.Username`, so `saslSupportedMechs` is sent with an empty database.
- SCRAM auth: `x/mongo/driver/auth/scram.go:40,58` falls back to `admin` when the source is empty.

The two paths disagree, so mongod logs a `ProtocolError` ("Attempt to switch database target during SASL authentication from clusterMonitor@ to @admin") on every readiness probe — every 3s by default — while authentication itself succeeds. This only makes the handshake agree with the source the driver was already authenticating against; no change to auth behavior.

The healthcheck is the only `mongo.Dial` caller that left the field empty — `pkg/psmdb/client.go` already passes it through from `Credentials{AuthSource: "admin"}`.

## Verification

`go build ./...`, `go vet` and `go test ./cmd/mongodb-healthcheck/... ./pkg/psmdb/mongo/...` pass. The new healthcheck test was confirmed to fail without the fix.

The unit tests only guard the config value — they do not prove the log noise is gone. The cluster-level check (no `id:5286202` entries in the mongod log while `id:5286306 Successfully authenticated` still appears) has not been run on my side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)