### PR TITLE
K8SPSMDB-1794 add missing / before query string in ClusterSync URIs

### DIFF
--- a/pkg/controller/perconaservermongodbclustersync/uri.go
+++ b/pkg/controller/perconaservermongodbclustersync/uri.go
@@ -30,6 +30,9 @@ func buildSourceURI(ctx context.Context, cl client.Client, cr *psmdbv1.PerconaSe
 		return "", errors.Wrapf(err, "parse source uri %q", cr.Spec.Source.URI)
 	}
 	u.User = url.UserPassword(username, password)
+	if u.Path == "" {
+		u.Path = "/"
+	}
 	return u.String(), nil
 }
 
@@ -60,6 +63,7 @@ func buildTargetURI(target *psmdbv1.PerconaServerMongoDB, username, password str
 		Scheme: "mongodb",
 		User:   url.UserPassword(username, password),
 		Host:   host,
+		Path:   "/",
 	}
 	if rsName != "" {
 		q := u.Query()

--- a/pkg/controller/perconaservermongodbclustersync/uri_test.go
+++ b/pkg/controller/perconaservermongodbclustersync/uri_test.go
@@ -1,0 +1,175 @@
+package perconaservermongodbclustersync
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	psmdbv1 "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
+)
+
+func TestBuildTargetURI(t *testing.T) {
+	tests := map[string]struct {
+		target   *psmdbv1.PerconaServerMongoDB
+		username string
+		password string
+		want     string
+		wantErr  string
+	}{
+		"replicaset target": {
+			target: &psmdbv1.PerconaServerMongoDB{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster1", Namespace: "ns"},
+				Spec: psmdbv1.PerconaServerMongoDBSpec{
+					Replsets: []*psmdbv1.ReplsetSpec{{Name: "rs0"}},
+				},
+			},
+			username: "sync",
+			password: "syncpass",
+			want:     "mongodb://sync:syncpass@cluster1-rs0.ns.svc.cluster.local:27017/?replicaSet=rs0",
+		},
+		"replicaset target with custom dns suffix": {
+			target: &psmdbv1.PerconaServerMongoDB{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster1", Namespace: "ns"},
+				Spec: psmdbv1.PerconaServerMongoDBSpec{
+					ClusterServiceDNSSuffix: psmdbv1.MultiClusterDefaultDNSSuffix,
+					Replsets:                []*psmdbv1.ReplsetSpec{{Name: "rs0"}},
+				},
+			},
+			username: "sync",
+			password: "syncpass",
+			want:     "mongodb://sync:syncpass@cluster1-rs0.ns.svc.clusterset.local:27017/?replicaSet=rs0",
+		},
+		"sharded target points at mongos without replicaSet": {
+			target: &psmdbv1.PerconaServerMongoDB{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster1", Namespace: "ns"},
+				Spec: psmdbv1.PerconaServerMongoDBSpec{
+					Replsets: []*psmdbv1.ReplsetSpec{{Name: "rs0"}},
+					Sharding: psmdbv1.Sharding{
+						Enabled: true,
+						Mongos:  &psmdbv1.MongosSpec{Port: 27019},
+					},
+				},
+			},
+			username: "sync",
+			password: "syncpass",
+			want:     "mongodb://sync:syncpass@cluster1-mongos.ns.svc.cluster.local:27019/",
+		},
+		"credentials are percent-encoded": {
+			target: &psmdbv1.PerconaServerMongoDB{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster1", Namespace: "ns"},
+				Spec: psmdbv1.PerconaServerMongoDBSpec{
+					Replsets: []*psmdbv1.ReplsetSpec{{Name: "rs0"}},
+				},
+			},
+			username: "sync",
+			password: "p@ss/word",
+			want:     "mongodb://sync:p%40ss%2Fword@cluster1-rs0.ns.svc.cluster.local:27017/?replicaSet=rs0",
+		},
+		"empty credentials": {
+			target:  &psmdbv1.PerconaServerMongoDB{},
+			wantErr: "syncTargetUser credentials are empty",
+		},
+		"no replsets": {
+			target: &psmdbv1.PerconaServerMongoDB{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster1", Namespace: "ns"},
+			},
+			username: "sync",
+			password: "syncpass",
+			wantErr:  "has no replsets",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := buildTargetURI(tc.target, tc.username, tc.password)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+			require.NoError(t, options.Client().ApplyURI(got).Validate())
+		})
+	}
+}
+
+func TestBuildSourceURI(t *testing.T) {
+	tests := map[string]struct {
+		uri     string
+		secret  *corev1.Secret
+		want    string
+		wantErr string
+	}{
+		"credentials are injected": {
+			uri:    "mongodb://source-rs0.ns.svc.cluster.local:27017/?replicaSet=rs0",
+			secret: sourceSecret("src", "srcpass"),
+			want:   "mongodb://src:srcpass@source-rs0.ns.svc.cluster.local:27017/?replicaSet=rs0",
+		},
+		"missing slash before query is normalized": {
+			uri:    "mongodb://source-rs0.ns.svc.cluster.local:27017?replicaSet=rs0",
+			secret: sourceSecret("src", "srcpass"),
+			want:   "mongodb://src:srcpass@source-rs0.ns.svc.cluster.local:27017/?replicaSet=rs0",
+		},
+		"credentials are percent-encoded": {
+			uri:    "mongodb://source-rs0.ns.svc.cluster.local:27017/",
+			secret: sourceSecret("src", "p@ss/word"),
+			want:   "mongodb://src:p%40ss%2Fword@source-rs0.ns.svc.cluster.local:27017/",
+		},
+		"missing password": {
+			uri:     "mongodb://source-rs0.ns.svc.cluster.local:27017/",
+			secret:  sourceSecret("src", ""),
+			wantErr: "missing username/password keys",
+		},
+		"missing secret": {
+			uri:     "mongodb://source-rs0.ns.svc.cluster.local:27017/",
+			wantErr: "get source credentials secret",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			s := runtime.NewScheme()
+			require.NoError(t, corev1.AddToScheme(s))
+			require.NoError(t, psmdbv1.SchemeBuilder.AddToScheme(s))
+
+			b := fake.NewClientBuilder().WithScheme(s)
+			if tc.secret != nil {
+				b = b.WithObjects(tc.secret)
+			}
+
+			cr := &psmdbv1.PerconaServerMongoDBClusterSync{
+				ObjectMeta: metav1.ObjectMeta{Name: "sync", Namespace: "ns"},
+				Spec: psmdbv1.PerconaServerMongoDBClusterSyncSpec{
+					Source: psmdbv1.ClusterSyncSource{URI: tc.uri, CredentialsSecret: "source-creds"},
+				},
+			}
+
+			got, err := buildSourceURI(t.Context(), b.Build(), cr)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+			require.NoError(t, options.Client().ApplyURI(got).Validate())
+		})
+	}
+}
+
+func sourceSecret(username, password string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "source-creds", Namespace: "ns"},
+		Data: map[string][]byte{
+			"username": []byte(username),
+			"password": []byte(password),
+		},
+	}
+}


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**

Jira: https://perconadev.atlassian.net/browse/K8SPSMDB-1794

The ClusterSync target URI was built with `net/url.URL` without setting `Path`, so Go emitted something like `mongodb://user:pass@host:27017?replicaSet=rs0`, with no slash before the query. The MongoDB driver rejects that with `must have a / before the query ?`, and the PCSM pod crashlooped before it could connect. 

e.g.

<img width="1121" height="98" alt="Screenshot 2026-08-21 at 12 30 03 PM" src="https://github.com/user-attachments/assets/244bf72c-458d-45a3-bdeb-a3c95add7207" />


Note that only non-sharded targets were affected.

**Cause:**
*Short explanation of the root cause of the issue if applicable.*

**Solution:**
*Short explanation of the solution we are providing with this PR.*

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
