### PR TITLE
K8SPSMDB-1797: Catch up a missed scheduled backup after operator restart

### DIFF
--- a/pkg/controller/perconaservermongodb/backup.go
+++ b/pkg/controller/perconaservermongodb/backup.go
@@ -129,6 +129,10 @@ func (r *ReconcilePerconaServerMongoDB) createOrUpdateBackupTask(ctx context.Con
 		JobID:          jobID,
 		ClusterName:    cr.NamespacedName().String(),
 	})
+
+	if err := r.catchUpMissedScheduledBackup(ctx, cr, task); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -205,6 +209,94 @@ func (r *ReconcilePerconaServerMongoDB) createBackupTask(ctx context.Context, cr
 			log.Error(err, "failed to create backup")
 		}
 	}
+}
+
+// missedCronTick reports whether schedule should have fired after last and
+// before now. A zero last time returns false so a cluster with no prior
+// backups does not immediately create one on operator start.
+func missedCronTick(schedule string, last, now time.Time) (bool, error) {
+	if last.IsZero() {
+		return false, nil
+	}
+	sched, err := cron.ParseStandard(schedule)
+	if err != nil {
+		return false, errors.Wrap(err, "parse cron schedule")
+	}
+	next := sched.Next(last)
+	return !next.IsZero() && next.Before(now), nil
+}
+
+func backupInProgress(state api.BackupState) bool {
+	switch state {
+	case api.BackupStateNew, api.BackupStateWaiting, api.BackupStateRequested, api.BackupStateRunning:
+		return true
+	default:
+		return false
+	}
+}
+
+func (r *ReconcilePerconaServerMongoDB) latestScheduledBackup(ctx context.Context, cr *api.PerconaServerMongoDB, ancestor string) (*api.PerconaServerMongoDBBackup, error) {
+	bcpList := api.PerconaServerMongoDBBackupList{}
+	err := r.client.List(ctx,
+		&bcpList,
+		&client.ListOptions{
+			Namespace: cr.Namespace,
+			LabelSelector: labels.SelectorFromSet(map[string]string{
+				naming.LabelCluster:        cr.Name,
+				naming.LabelBackupAncestor: ancestor,
+			}),
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var latest *api.PerconaServerMongoDBBackup
+	for i := range bcpList.Items {
+		b := &bcpList.Items[i]
+		if latest == nil || latest.CreationTimestamp.Before(&b.CreationTimestamp) {
+			latest = b
+		}
+	}
+	return latest, nil
+}
+
+// catchUpMissedScheduledBackup creates one backup when the in-memory cron
+// missed a tick (operator restart or eviction). Schedules are not Kubernetes
+// CronJobs, so robfig/cron does not catch up on its own.
+func (r *ReconcilePerconaServerMongoDB) catchUpMissedScheduledBackup(ctx context.Context, cr *api.PerconaServerMongoDB, task api.BackupTaskSpec) error {
+	log := logf.FromContext(ctx)
+
+	latest, err := r.latestScheduledBackup(ctx, cr, task.Name)
+	if err != nil {
+		return errors.Wrap(err, "list scheduled backups")
+	}
+	if latest == nil {
+		return nil
+	}
+	if backupInProgress(latest.Status.State) {
+		return nil
+	}
+
+	missed, err := missedCronTick(task.Schedule, latest.CreationTimestamp.Time, time.Now())
+	if err != nil {
+		return err
+	}
+	if !missed {
+		return nil
+	}
+
+	running, err := r.isBackupRunning(ctx, cr)
+	if err != nil {
+		return errors.Wrap(err, "check if backup is running")
+	}
+	if running {
+		return nil
+	}
+
+	log.Info("catching up missed scheduled backup", "job", task.Name, "lastBackup", latest.Name, "schedule", task.Schedule)
+	r.createBackupTask(ctx, cr, task)()
+	return nil
 }
 
 func (r *ReconcilePerconaServerMongoDB) deleteBackupTask(cr *api.PerconaServerMongoDB, task api.BackupTaskSpec) {

--- a/pkg/controller/perconaservermongodb/backup_schedule_test.go
+++ b/pkg/controller/perconaservermongodb/backup_schedule_test.go
@@ -1,0 +1,134 @@
+package perconaservermongodb
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
+	"github.com/percona/percona-server-mongodb-operator/pkg/naming"
+)
+
+func TestMissedCronTick(t *testing.T) {
+	t.Parallel()
+
+	last := time.Date(2026, 7, 12, 1, 0, 0, 0, time.UTC)
+	now := time.Date(2026, 7, 13, 1, 5, 0, 0, time.UTC)
+
+	tests := []struct {
+		name     string
+		schedule string
+		last     time.Time
+		now      time.Time
+		want     bool
+	}{
+		{name: "zero last", schedule: "0 1 * * *", want: false},
+		{name: "missed daily 01:00", schedule: "0 1 * * *", last: last, now: now, want: true},
+		{name: "already ran today", schedule: "0 1 * * *", last: time.Date(2026, 7, 13, 1, 0, 2, 0, time.UTC), now: now, want: false},
+		{name: "still before next tick", schedule: "0 1 * * *", last: last, now: time.Date(2026, 7, 12, 12, 0, 0, 0, time.UTC), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := missedCronTick(tt.schedule, tt.last, tt.now)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCatchUpMissedScheduledBackup(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, api.SchemeBuilder.AddToScheme(scheme))
+
+	cr := &api.PerconaServerMongoDB{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster1", Namespace: "db"},
+		Spec: api.PerconaServerMongoDBSpec{
+			CRVersion: "1.23.0",
+			Backup: api.BackupSpec{
+				Enabled: true,
+			},
+		},
+	}
+	task := api.BackupTaskSpec{
+		Name:        "daily",
+		Enabled:     true,
+		Schedule:    "0 1 * * *",
+		StorageName: "s3-us-west",
+	}
+
+	old := &api.PerconaServerMongoDBBackup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "cron-old",
+			Namespace:         "db",
+			CreationTimestamp: metav1.NewTime(time.Now().Add(-26 * time.Hour)),
+			Labels:            naming.ScheduledBackupLabels(cr, &task),
+		},
+		Spec: api.PerconaServerMongoDBBackupSpec{
+			ClusterName: cr.Name,
+			StorageName: task.StorageName,
+		},
+		Status: api.PerconaServerMongoDBBackupStatus{State: api.BackupStateReady},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cr, old).Build()
+	r := &ReconcilePerconaServerMongoDB{
+		client: cl,
+		scheme: scheme,
+		crons:  NewCronRegistry(),
+	}
+	t.Cleanup(func() { r.crons.crons.Stop() })
+
+	require.NoError(t, r.createOrUpdateBackupTask(t.Context(), cr, task))
+
+	list := api.PerconaServerMongoDBBackupList{}
+	require.NoError(t, cl.List(t.Context(), &list, &client.ListOptions{Namespace: "db"}))
+	assert.GreaterOrEqual(t, len(list.Items), 2, "expected a catch-up PerconaServerMongoDBBackup after a missed daily tick")
+}
+
+func TestCatchUpMissedScheduledBackupSkipsFirstInstall(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, api.SchemeBuilder.AddToScheme(scheme))
+
+	cr := &api.PerconaServerMongoDB{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster1", Namespace: "db"},
+		Spec: api.PerconaServerMongoDBSpec{
+			CRVersion: "1.23.0",
+			Backup:    api.BackupSpec{Enabled: true},
+		},
+	}
+	task := api.BackupTaskSpec{
+		Name:        "daily",
+		Enabled:     true,
+		Schedule:    "0 1 * * *",
+		StorageName: "s3-us-west",
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cr).Build()
+	r := &ReconcilePerconaServerMongoDB{
+		client: cl,
+		scheme: scheme,
+		crons:  NewCronRegistry(),
+	}
+	t.Cleanup(func() { r.crons.crons.Stop() })
+
+	require.NoError(t, r.createOrUpdateBackupTask(t.Context(), cr, task))
+
+	list := api.PerconaServerMongoDBBackupList{}
+	require.NoError(t, cl.List(t.Context(), &list, &client.ListOptions{Namespace: "db"}))
+	assert.Empty(t, list.Items, "first install must not immediately create a backup")
+}


### PR DESCRIPTION
Scheduled backups are registered with robfig/cron in the leader process. They are not Kubernetes CronJobs, so a tick that was due while the process was down is never created.

After re-registering a job, if the latest backup for that task is older than the last due tick, create one catch-up `PerconaServerMongoDBBackup`. Skip when there is no prior backup (first install) and skip if a backup is already running.

Fixes https://github.com/percona/percona-server-mongodb-operator/issues/2526
