### PR TITLE
K8SPSMDB-1798: Ignore NotFound when deleting secrets and config maps during cleanup

### DIFF
--- a/pkg/controller/perconaservermongodb/finalizers.go
+++ b/pkg/controller/perconaservermongodb/finalizers.go
@@ -326,7 +326,7 @@ func (r *ReconcilePerconaServerMongoDB) deleteSecrets(ctx context.Context, cr *a
 
 		logf.FromContext(ctx).Info("deleting secret", "name", secret.Name)
 		err = r.client.Delete(ctx, secret)
-		if err != nil {
+		if err != nil && !k8serrors.IsNotFound(err) {
 			return errors.Wrapf(err, "delete secret %s", secretName)
 		}
 	}

--- a/pkg/controller/perconaservermongodb/finalizers_test.go
+++ b/pkg/controller/perconaservermongodb/finalizers_test.go
@@ -2,10 +2,16 @@ package perconaservermongodb
 
 import (
 	"context"
+	"errors"
 	"slices"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
 	"github.com/percona/percona-server-mongodb-operator/pkg/naming"
@@ -111,4 +117,46 @@ func TestCheckFinalizers(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDeleteSecretsIgnoresNotFoundOnDelete(t *testing.T) {
+	newCR := func() *api.PerconaServerMongoDB {
+		cr := newTestCR()
+		cr.Spec.Secrets.Users = cr.Name + "-users"
+		return cr
+	}
+	objsFor := func(cr *api.PerconaServerMongoDB) []client.Object {
+		objs := []client.Object{cr}
+		for _, name := range []string{
+			cr.Spec.Secrets.Users,
+			"internal-" + cr.Name,
+			"internal-" + cr.Name + "-users",
+			cr.Name + "-mongodb-encryption-key",
+		} {
+			objs = append(objs, &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: cr.Namespace},
+			})
+		}
+		return objs
+	}
+
+	t.Run("delete returns NotFound", func(t *testing.T) {
+		cr := newCR()
+		r := buildFakeClient(objsFor(cr)...)
+		r.client = interceptorClient(r.client, func(_ context.Context, _ client.WithWatch, obj client.Object, _ ...client.DeleteOption) error {
+			return k8serrors.NewNotFound(corev1.Resource("secrets"), obj.GetName())
+		})
+
+		require.NoError(t, r.deleteSecrets(t.Context(), cr))
+	})
+
+	t.Run("delete fails for another reason", func(t *testing.T) {
+		cr := newCR()
+		r := buildFakeClient(objsFor(cr)...)
+		r.client = interceptorClient(r.client, func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.DeleteOption) error {
+			return errors.New("boom")
+		})
+
+		require.Error(t, r.deleteSecrets(t.Context(), cr))
+	})
 }

--- a/pkg/controller/perconaservermongodb/psmdb_controller.go
+++ b/pkg/controller/perconaservermongodb/psmdb_controller.go
@@ -1414,7 +1414,11 @@ func deleteConfigMapIfExists(ctx context.Context, cl client.Client, cr *api.Perc
 		return nil
 	}
 
-	return cl.Delete(ctx, configMap)
+	if err := cl.Delete(ctx, configMap); err != nil && !k8serrors.IsNotFound(err) {
+		return err
+	}
+
+	return nil
 }
 
 func (r *ReconcilePerconaServerMongoDB) createOrUpdateConfigMap(ctx context.Context, cr *api.PerconaServerMongoDB, configMap *corev1.ConfigMap) error {

--- a/pkg/controller/perconaservermongodb/psmdb_controller_test.go
+++ b/pkg/controller/perconaservermongodb/psmdb_controller_test.go
@@ -2,6 +2,7 @@ package perconaservermongodb
 
 import (
 	"context"
+	"errors"
 	"os"
 	"testing"
 	"time"
@@ -15,6 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -449,3 +451,45 @@ var _ = Describe("PerconaServerMongoDB CRD Validation", Ordered, func() {
 		})
 	})
 })
+
+func TestDeleteConfigMapIfExistsIgnoresNotFoundOnDelete(t *testing.T) {
+	const cmName = "test-cluster-cfg"
+
+	build := func() (*psmdbv1.PerconaServerMongoDB, *ReconcilePerconaServerMongoDB) {
+		cr := newTestCR()
+		cr.UID = "test-uid"
+		isController := true
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      cmName,
+				Namespace: cr.Namespace,
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: "psmdb.percona.com/v1",
+					Kind:       "PerconaServerMongoDB",
+					Name:       cr.Name,
+					UID:        cr.UID,
+					Controller: &isController,
+				}},
+			},
+		}
+		return cr, buildFakeClient(cr, cm)
+	}
+
+	t.Run("delete returns NotFound", func(t *testing.T) {
+		cr, r := build()
+		cl := interceptorClient(r.client, func(_ context.Context, _ client.WithWatch, obj client.Object, _ ...client.DeleteOption) error {
+			return k8serrors.NewNotFound(corev1.Resource("configmaps"), obj.GetName())
+		})
+
+		require.NoError(t, deleteConfigMapIfExists(t.Context(), cl, cr, cmName))
+	})
+
+	t.Run("delete fails for another reason", func(t *testing.T) {
+		cr, r := build()
+		cl := interceptorClient(r.client, func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.DeleteOption) error {
+			return errors.New("boom")
+		})
+
+		require.Error(t, deleteConfigMapIfExists(t.Context(), cl, cr, cmName))
+	})
+}

--- a/pkg/controller/perconaservermongodb/ssl.go
+++ b/pkg/controller/perconaservermongodb/ssl.go
@@ -251,7 +251,9 @@ func (r *ReconcilePerconaServerMongoDB) createSSLByCertManager(ctx context.Conte
 				}
 
 				log.Info("CA is not up to date. Recreating secret", "secret", secret.Name)
-				if err := r.client.Delete(ctx, secret); err != nil {
+				// The cache can be behind the API server, so a secret that is
+				// already gone is the state this path wants.
+				if err := r.client.Delete(ctx, secret); err != nil && !k8serrors.IsNotFound(err) {
 					return err
 				}
 			}
@@ -384,7 +386,8 @@ func (r *ReconcilePerconaServerMongoDB) mergeNewCA(ctx context.Context, cr *api.
 
 		// If secret was already updated, we should delete the old one
 		if bytes.Equal(mergedCA, secret.Data["ca.crt"]) {
-			if err := r.client.Delete(ctx, oldSecret); err != nil {
+			// As above, an old secret that is already gone is not a failure.
+			if err := r.client.Delete(ctx, oldSecret); err != nil && !k8serrors.IsNotFound(err) {
 				return err
 			}
 			log.Info("new ca is already in secret, deleting old secret")

--- a/pkg/controller/perconaservermongodb/ssl_test.go
+++ b/pkg/controller/perconaservermongodb/ssl_test.go
@@ -1,6 +1,9 @@
 package perconaservermongodb
 
 import (
+	"context"
+	"encoding/pem"
+	"errors"
 	"testing"
 
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
@@ -8,8 +11,10 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	api "github.com/percona/percona-server-mongodb-operator/pkg/apis/psmdb/v1"
 	"github.com/percona/percona-server-mongodb-operator/pkg/naming"
@@ -283,4 +288,57 @@ func TestApplyCertManagerCertificatesExternalIssuer(t *testing.T) {
 		assert.Zero(t, cm.ApplyCertificateCalls)
 		assert.Zero(t, cm.WaitForCertsCalls)
 	})
+}
+
+// mergeNewCA deletes the "-old" secret once the merged CA is already in the
+// live one. The client cache can be behind the API server there, so a secret
+// that is already gone is the state the cleanup wants, not a failure.
+func TestMergeNewCADeletesAnAlreadyDeletedOldSecret(t *testing.T) {
+	pemBlock := func(body string) []byte {
+		return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: []byte(body)})
+	}
+	oldCA := pemBlock("old-ca")
+	newCA := pemBlock("new-ca")
+	mergedCA := append(append([]byte{}, oldCA...), newCA...)
+
+	secretsFor := func(cr *api.PerconaServerMongoDB) []client.Object {
+		objs := []client.Object{cr}
+		for _, name := range []string{api.SSLInternalSecretName(cr), api.SSLSecretName(cr)} {
+			objs = append(objs,
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: cr.Namespace},
+					Data:       map[string][]byte{"ca.crt": mergedCA},
+				},
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: name + "-old", Namespace: cr.Namespace},
+					Data:       map[string][]byte{"ca.crt": oldCA},
+				},
+			)
+		}
+		return objs
+	}
+
+	t.Run("delete returns NotFound", func(t *testing.T) {
+		cr := newTestCR()
+		r := buildFakeClient(secretsFor(cr)...)
+		r.client = interceptorClient(r.client, func(_ context.Context, _ client.WithWatch, obj client.Object, _ ...client.DeleteOption) error {
+			return k8serrors.NewNotFound(corev1.Resource("secrets"), obj.GetName())
+		})
+
+		require.NoError(t, r.mergeNewCA(t.Context(), cr))
+	})
+
+	t.Run("delete fails for another reason", func(t *testing.T) {
+		cr := newTestCR()
+		r := buildFakeClient(secretsFor(cr)...)
+		r.client = interceptorClient(r.client, func(_ context.Context, _ client.WithWatch, _ client.Object, _ ...client.DeleteOption) error {
+			return errors.New("boom")
+		})
+
+		require.Error(t, r.mergeNewCA(t.Context(), cr))
+	})
+}
+
+func interceptorClient(c client.Client, del func(context.Context, client.WithWatch, client.Object, ...client.DeleteOption) error) client.Client {
+	return interceptor.NewClient(c.(client.WithWatch), interceptor.Funcs{Delete: del})
 }


### PR DESCRIPTION
`K8SPSMDB-1798`

The controller cache can lag the API server, so an object the reconciler still sees may already be gone by the time it issues the `Delete`. The cleanup paths treated that `NotFound` as a real failure and aborted, even though it is the outcome they were asking for.

Three call sites, all in cleanup:

- `ssl.go`, in `createSSLByCertManager` and `mergeNewCA`, deleting the TLS secrets during CA rotation.
- `finalizers.go`, in `deleteSecrets`. The `Get` above it already skips a missing secret, so the `Delete` below it now agrees.
- `psmdb_controller.go`, in `deleteConfigMapIfExists`, which ended in a bare `return cl.Delete(...)`. Five callers, all cleanup.

Each gets a test with both outcomes: `NotFound` has to come back as success, and any other error still has to reach the caller. Both halves were checked to fail before the change rather than assumed, and the "fails for another reason" halves pass either way so they are not vacuous.

The last two sites were added on 6 September, after the first round of review; the original PR only covered `ssl.go`, which is why the old title named only the TLS path.
