### PR TITLE
set CLOUDSDK_CONFIG in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,6 +11,7 @@ void createCluster(String CLUSTER_SUFFIX) {
     withCredentials([string(credentialsId: 'GCP_PROJECT_ID', variable: 'GCP_PROJECT'), file(credentialsId: 'gcloud-key-file', variable: 'CLIENT_SECRET_FILE')]) {
         sh """
             export KUBECONFIG=/tmp/${CLUSTER_NAME}-${CLUSTER_SUFFIX}
+            export CLOUDSDK_CONFIG=/tmp/gcloud-$CLUSTER_NAME-${CLUSTER_SUFFIX}
             gcloud auth activate-service-account --key-file "\$CLIENT_SECRET_FILE"
             gcloud config set project "\$GCP_PROJECT"
             GKE_VERSION=\$(gcloud container get-server-config --zone ${zone} --flatten='channels[].validVersions[]' --filter='channels.channel=STABLE' --format='value(channels.validVersions)' | sort -V | head -n1)
@@ -57,6 +58,7 @@ void shutdownCluster(String CLUSTER_SUFFIX) {
     withCredentials([string(credentialsId: 'GCP_PROJECT_ID', variable: 'GCP_PROJECT'), file(credentialsId: 'gcloud-key-file', variable: 'CLIENT_SECRET_FILE')]) {
         sh """
             export KUBECONFIG=/tmp/${CLUSTER_NAME}-${CLUSTER_SUFFIX}
+            export CLOUDSDK_CONFIG=/tmp/gcloud-$CLUSTER_NAME-${CLUSTER_SUFFIX}
             gcloud auth activate-service-account --key-file "\$CLIENT_SECRET_FILE"
             gcloud config set project "\$GCP_PROJECT"
             for namespace in \$(kubectl get namespaces --no-headers | awk '{print \$1}' | grep -vE "^kube-|^openshift" | sed '/-operator/ s/^/1-/' | sort | sed 's/^1-//'); do


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---
**Problem:**
Jenkins can sometimes fail with:

```
10:23:31    File "/usr/lib64/google-cloud-sdk/platform/bundledpythonunix/lib/python3.14/configparser.py", line 1172, in _handle_option
10:23:31      raise DuplicateOptionError(st.sectname, st.optname,
10:23:31                              fpname, st.lineno)
10:23:31  configparser.DuplicateOptionError: While reading from '/root/.config/gcloud/configurations/config_default' [line  5]: option 'project' in section 'core' already exists
10:23:31  ERROR: gcloud failed to load. This usually indicates corruption in your gcloud installation or problems with your Python interpreter.
10:23:31
10:23:31  Please verify that the following is the path to a working Python 3.10-3.14 executable:
10:23:31      /usr/lib64/google-cloud-sdk/platform/bundledpythonunix/bin/python3
10:23:31
10:23:31  If it is not, please set the CLOUDSDK_PYTHON environment variable to point to a working Python executable.
```

**Cause:**

`createCluster()` runs 15 parallel branches on one agent and each one runs gcloud auth activate-service-account and gcloud config set project. They all write the same `/root/.config/gcloud`, so when two branches collide the config gets a duplicate project line (build 22) or a branch sees no active account (build 21). Build 25 got past it, so it depends on timing.

**Solution:**

The pxc-operator Jenkinsfile fixed the same race with a per-branch export CLOUDSDK_CONFIG=/tmp/gcloud-${CLUSTER_SUFFIX} before the gcloud calls, we apply the same fix here

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
