### PR TITLE
K8SPSMDB-1795: mongos pvc resize bug fix & e2e test improvement

### DIFF
--- a/e2e-tests/pvc-resize/run
+++ b/e2e-tests/pvc-resize/run
@@ -15,6 +15,10 @@ function patch_pvc_request() {
 }
 
 function get_default_storageclass() {
+	if [[ "$EKS" -eq 1 ]]; then
+		echo "gp3-resizable"
+		return 0
+	fi
 	kubectl_bin get sc -o jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")].metadata.name}'
 }
 
@@ -190,6 +194,8 @@ wait_all_pvc_resize "2Gi" 120 5 "${rs0_pvc_selector}"
 
 echo
 
+last_configured_storage="2Gi"
+
 if [[ "$EKS" -eq 1 || -n "$OPENSHIFT" ]]; then
 	# AWS rate limits PVC expansion for the same EBS volume (1 expand operation in every 6 hours),
 	# so we need to delete and recreate the cluster
@@ -206,20 +212,22 @@ if [[ "$EKS" -eq 1 || -n "$OPENSHIFT" ]]; then
 	sleep 10
 
 	wait_cluster_consistency "$cluster"
+	last_configured_storage="1Gi"
 fi
 
 desc 'create resourcequota'
 
-# rs0 holds 3x2Gi, cfg holds 3x1Gi and the mongos logs hold 2x1Gi, so 11Gi is in
-# use. We're setting the quota to 12Gi, so only one rs0 PVC can grow to 3Gi. the
-# rest fail with an exceeded quota error, which the operator handles by reverting
-# the storage request in the spec back to the configured size and keeping the
-# cluster ready
+# cfg holds 3x1Gi and the mongos logs hold 2x1Gi. rs0 holds 3x2Gi, or 3x1Gi if
+# the cluster was recreated above, so 11Gi or 8Gi is in use. We're setting the
+# quota to 12Gi, so one rs0 PVC (two after a recreate) can grow to 3Gi. the rest
+# fail with an exceeded quota error, which the operator handles by reverting the
+# storage request in the spec back to the configured size and keeping the cluster
+# ready
 
 apply_resourcequota 12Gi
 patch_pvc_request "${cluster}" "3Gi"
 
-wait_pvc_request_revert "${cluster}" "2Gi"
+wait_pvc_request_revert "${cluster}" "${last_configured_storage}"
 wait_cluster_status ${cluster} "ready"
 echo
 

--- a/e2e-tests/pvc-resize/run
+++ b/e2e-tests/pvc-resize/run
@@ -147,6 +147,28 @@ function wait_mongos_pvc_request_revert() {
 	echo "psmdb/${cluster} mongos log storage request reverted to ${expected}"
 }
 
+function wait_mongos_log_vct() {
+	local cluster=$1
+	local expected=$2
+	local retry=0
+
+	echo -n "Waiting for statefulset/${cluster}-mongos log volumeClaimTemplate to be ${expected}"
+	until [[ $(kubectl_bin get sts "${cluster}-mongos" -o jsonpath='{.spec.volumeClaimTemplates[?(@.metadata.name=="mongos-logs")].spec.resources.requests.storage}' 2>/dev/null) == "${expected}" ]]; do
+		if [[ $retry -ge 60 ]]; then
+			echo
+			echo "statefulset/${cluster}-mongos log volumeClaimTemplate was not updated to ${expected}, max retries exceeded"
+			exit 1
+		fi
+		echo -n "."
+		sleep 5
+
+		retry=$((retry + 1))
+	done
+
+	echo
+	echo "statefulset/${cluster}-mongos log volumeClaimTemplate is ${expected}"
+}
+
 set_debug
 
 if [[ "$EKS" -eq 1 ]]; then
@@ -318,9 +340,8 @@ wait_cluster_consistency "$cluster" 42
 echo
 
 wait_all_pvc_resize "2Gi" 120 5 "${mongos_pvc_selector}"
-kubectl_bin wait --for=create statefulset "${cluster}-mongos" --timeout=60s
-kubectl_bin wait --for=jsonpath='{.spec.volumeClaimTemplates[?(@.metadata.name=="mongos-logs")].spec.resources.requests.storage}'=2Gi \
-	statefulset "${cluster}-mongos" --timeout=120s
+wait_mongos_log_vct "${cluster}" "2Gi"
+wait_for_running "${cluster}-mongos" 2
 
 desc "test mongos log PVC downscale"
 

--- a/e2e-tests/pvc-resize/run
+++ b/e2e-tests/pvc-resize/run
@@ -153,7 +153,7 @@ function wait_mongos_log_vct() {
 	local retry=0
 
 	echo -n "Waiting for statefulset/${cluster}-mongos log volumeClaimTemplate to be ${expected}"
-	until [[ $(kubectl_bin get sts "${cluster}-mongos" -o jsonpath='{.spec.volumeClaimTemplates[?(@.metadata.name=="mongos-logs")].spec.resources.requests.storage}' 2>/dev/null) == "${expected}" ]]; do
+	until [[ $(kubectl_bin get sts "${cluster}-mongos" -o jsonpath='{.spec.volumeClaimTemplates[?(@.metadata.name=="mongos-logs")].spec.resources.requests.storage}' 2>/dev/null || true) == "${expected}" ]]; do
 		if [[ $retry -ge 60 ]]; then
 			echo
 			echo "statefulset/${cluster}-mongos log volumeClaimTemplate was not updated to ${expected}, max retries exceeded"

--- a/pkg/controller/perconaservermongodb/balancer.go
+++ b/pkg/controller/perconaservermongodb/balancer.go
@@ -53,7 +53,7 @@ func (r *ReconcilePerconaServerMongoDB) enableBalancerIfNeeded(ctx context.Conte
 		return errors.Wrapf(err, "get statefulset %s", msSts.Name)
 	}
 
-	if msSts.ObjectMeta.Generation != msSts.Status.ObservedGeneration {
+	if msSts.Generation != msSts.Status.ObservedGeneration {
 		log.Info("waiting for mongos statefulset to be observed",
 			"generation", msSts.Generation,
 			"observedGeneration", msSts.Status.ObservedGeneration)

--- a/pkg/controller/perconaservermongodb/balancer.go
+++ b/pkg/controller/perconaservermongodb/balancer.go
@@ -55,7 +55,7 @@ func (r *ReconcilePerconaServerMongoDB) enableBalancerIfNeeded(ctx context.Conte
 
 	if msSts.ObjectMeta.Generation != msSts.Status.ObservedGeneration {
 		log.Info("waiting for mongos statefulset to be observed",
-			"generation", msSts.ObjectMeta.Generation,
+			"generation", msSts.Generation,
 			"observedGeneration", msSts.Status.ObservedGeneration)
 		return nil
 	}

--- a/pkg/controller/perconaservermongodb/balancer.go
+++ b/pkg/controller/perconaservermongodb/balancer.go
@@ -2,7 +2,6 @@ package perconaservermongodb
 
 import (
 	"context"
-	"time"
 
 	"github.com/percona/percona-server-mongodb-operator/pkg/naming"
 	"github.com/percona/percona-server-mongodb-operator/pkg/psmdb"
@@ -48,18 +47,17 @@ func (r *ReconcilePerconaServerMongoDB) enableBalancerIfNeeded(ctx context.Conte
 	}
 
 	msSts := psmdb.MongosStatefulset(cr)
+	if err = r.client.Get(ctx, types.NamespacedName{Name: msSts.Name, Namespace: msSts.Namespace}, msSts); k8sErrors.IsNotFound(err) {
+		return nil
+	} else if err != nil {
+		return errors.Wrapf(err, "get statefulset %s", msSts.Name)
+	}
 
-	for {
-		err = r.client.Get(ctx, types.NamespacedName{Name: msSts.Name, Namespace: msSts.Namespace}, msSts)
-		if err != nil && !k8sErrors.IsNotFound(err) {
-			return errors.Wrapf(err, "get statefulset %s", msSts.Name)
-		}
-
-		if msSts.ObjectMeta.Generation == msSts.Status.ObservedGeneration {
-			break
-		}
-
-		time.Sleep(1 * time.Second)
+	if msSts.ObjectMeta.Generation != msSts.Status.ObservedGeneration {
+		log.Info("waiting for mongos statefulset to be observed",
+			"generation", msSts.ObjectMeta.Generation,
+			"observedGeneration", msSts.Status.ObservedGeneration)
+		return nil
 	}
 
 	if msSts.Status.UpdatedReplicas < msSts.Status.Replicas {


### PR DESCRIPTION
**CHANGE DESCRIPTION**
---

* `enableRebalancerIfNeeded` has a potential infinite for-loop that is triggered when the mongos statefulset is orphan deleted for PVC resize. This causes the reconcile loop to halt permanently. Sometimes this won't get triggered if the cache is stale and the client still sees an outdated (undeleted) Statefulset.
* `pvc-resize` e2e test improvements

**CHECKLIST**
---
**Jira**
- [ ] Is the Jira ticket created and referenced properly?
- [ ] Does the Jira ticket have the proper statuses for documentation (`Needs Doc`) and QA (`Needs QA`)?
- [ ] Does the Jira ticket link to the proper milestone (Fix Version field)?

**Tests**
- [ ] Is an E2E test/test case added for the new feature/change?
- [ ] Are unit tests added where appropriate?
- [ ] Are OpenShift compare files changed for E2E tests (`compare/*-oc.yml`)?

**Config/Logging/Testability**
- [ ] Are all needed new/changed options added to default YAML files?
- [ ] Are all needed new/changed options added to the [Helm Chart](https://github.com/percona/percona-helm-charts)?
- [ ] Did we add proper logging messages for operator actions?
- [ ] Did we ensure compatibility with the previous version or cluster upgrade process?
- [ ] Does the change support oldest and newest supported MongoDB version?
- [ ] Does the change support oldest and newest supported Kubernetes version?
